### PR TITLE
Run static

### DIFF
--- a/pyiron_base/objects/job/generic.py
+++ b/pyiron_base/objects/job/generic.py
@@ -529,6 +529,12 @@ class GenericJob(JobCore):
         The run if modal function is called by run to execute the simulation, while waiting for the output. For this we
         use subprocess.check_output()
         """
+        self.run_static()
+        
+    def run_static(self):
+        """
+        The run static function is called by run to execute the simulation.
+        """
         self._logger.info('{}, status: {}, run job (modal)'.format(self.job_info_str, self.status))
         if self.executable.executable_path == '':
             self.status.aborted = True

--- a/pyiron_base/objects/job/list.py
+++ b/pyiron_base/objects/job/list.py
@@ -214,9 +214,9 @@ class ListMaster(GenericMaster):
             else:
                 return False
 
-    def run_if_modal(self):
+    def run_static(self):
         """
-        The run if modal function is called by run to execute the simulation, while waiting for the output. For the
+        The run static function is called by run to execute the simulation. For the
         ListMaster this means executing all the childs appened in parallel.
         """
         self._input['num_points'] = len(self)

--- a/pyiron_base/objects/job/parallel.py
+++ b/pyiron_base/objects/job/parallel.py
@@ -355,9 +355,9 @@ class ParallelMaster(GenericMaster):
             return set([self.project.db.get_item_by_id(child_id)['status'] for child_id in self.child_ids])\
                    <{'finished', 'busy', 'refresh'}
 
-    def run_if_modal(self):
+    def run_static(self):
         """
-        The run if modal function is called by run to execute the simulation, while waiting for the output. For the
+        The run static function is called by run to execute the simulation, while waiting for the output. For the
         ParallelMaster this means executing all the childs appened in parallel.
         """
         self._logger.info('{} run parallel master (modal)'.format(self.job_info_str))

--- a/pyiron_base/objects/job/serial.py
+++ b/pyiron_base/objects/job/serial.py
@@ -305,7 +305,7 @@ class SerialMasterBase(GenericMaster):
         for job_id in self.child_ids:
             yield self.project.load(job_id, convert_to_object=convert_to_object)
 
-    def run_if_modal(self, **qwargs):
+    def run_static(self, **qwargs):
         """
         The run if modal function is called by run to execute the simulation, while waiting for the output. For the
         SerialMaster this means executing the child job check whether is fulfills the convergence goal and create a
@@ -448,7 +448,7 @@ class SerialMasterBase(GenericMaster):
             if ham is not True:
                 self.append(ham)
                 self.to_hdf()
-                self.run_if_modal()
+                self.run_static()
             else:
                 self.status.collect = True
                 self.run()

--- a/pyiron_base/objects/job/wrapper.py
+++ b/pyiron_base/objects/job/wrapper.py
@@ -62,4 +62,4 @@ class JobWrapper(object):
         """
         The job wrapper run command, sets the job status to 'running' and executes run_if_modal().
         """
-        self.job.run_if_modal()
+        self.job.run_static()


### PR DESCRIPTION
Clarify the naming use `run_static()` rather than `run_if_modal()`, to reduce the confusion when using `run_interactive()`. Now the developers can choose between `run_static()` and `run_interactive()`. 