### PR TITLE
assert

### DIFF
--- a/pyiron_base/objects/generic/parameters.py
+++ b/pyiron_base/objects/generic/parameters.py
@@ -461,7 +461,8 @@ class GenericParameters(PyironObject):
         Args:
             block_dict (dict): dictionary to define the block
         """
-        assert isinstance(block_dict, OrderedDict)
+        if not isinstance(block_dict, OrderedDict):
+            raise AssertionError()
         self._block_dict = block_dict
 
     def to_hdf(self, hdf, group_name=None):

--- a/pyiron_base/objects/job/generic.py
+++ b/pyiron_base/objects/job/generic.py
@@ -275,11 +275,9 @@ class GenericJob(JobCore):
             filenames (list):
         """
         for f in filenames:
-            try:
-                assert(os.path.isfile(f))
-                self.restart_file_list.append(f)
-            except AssertionError:
+            if not (os.path.isfile(f)):
                 raise IOError("File: {} does not exist".format(f))
+            self.restart_file_list.append(f)
 
     @property
     def restart_file_dict(self):
@@ -878,9 +876,7 @@ class GenericJob(JobCore):
         """
         Internal helper function to copy the files required for the restart job.
         """
-        try:
-            assert (os.path.isdir(self.working_directory))
-        except AssertionError:
+        if not (os.path.isdir(self.working_directory)):
             raise ValueError("The working directory is not yet available to copy restart files")
         for i, actual_name in enumerate([os.path.basename(f) for f in self._restart_file_list]):
             if actual_name in self.restart_file_dict.keys():

--- a/pyiron_base/objects/volumetric/generic.py
+++ b/pyiron_base/objects/volumetric/generic.py
@@ -38,19 +38,14 @@ class VolumetricData(object):
 
     @total_data.setter
     def total_data(self, val):
-        try:
-            assert(isinstance(val, (np.ndarray, list)))
-            try:
-                val = np.array(val)
-                shape = np.array(np.shape(val))
-                assert(len(shape) == 3)
-                self._total_data = val
-            except AssertionError:
-                raise ValueError("Attribute total_data should be a 3D array")
-
-        except AssertionError:
+        if not (isinstance(val, (np.ndarray, list))):
             raise TypeError("Attribute total_data should be a numpy.ndarray instance or a list and "
                             "not {}".format(type(val)))
+        val = np.array(val)
+        shape = np.array(np.shape(val))
+        if not (len(shape) == 3):
+            raise ValueError("Attribute total_data should be a 3D array")
+        self._total_data = val
 
     def get_average_along_axis(self, ind=2):
         """


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.