### PR TITLE
Import all classes available to the outside in __init__.py

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -8,18 +8,18 @@ from pyiron_base.generic.jedi import fix_ipython_autocomplete
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
 from pyiron_base.job.executable import Executable
+from pyiron_base.job.external import Notebook
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.interactive import InteractiveBase
-from pyiron_base.job.jobstatus import JobStatus, job_status_successful_lst
+from pyiron_base.job.jobstatus import JobStatus, job_status_successful_lst, job_status_finished_lst, job_status_lst
 from pyiron_base.job.jobtype import JOB_CLASS_DICT, JobType, JobTypeChoice
-from pyiron_base.job.external import Notebook
 from pyiron_base.master.generic import GenericMaster, get_function_from_string
 from pyiron_base.master.parallel import ParallelMaster, JobGenerator
 from pyiron_base.master.serial import SerialMasterBase
 from pyiron_base.project.generic import Project
 from pyiron_base.project.gui import ProjectGUI
 from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
-from pyiron_base.server.queuestatus import _validate_que_request
+from pyiron_base.server.queuestatus import validate_que_request
 from pyiron_base.settings.generic import Settings
 from pyiron_base.settings.install import install_dialog
 from ._version import get_versions

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -1,1 +1,33 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
+from pyiron_base.generic.inputlist import InputList
+from pyiron_base.generic.jedi import fix_ipython_autocomplete
+from pyiron_base.generic.parameters import GenericParameters
+from pyiron_base.generic.template import PyironObject
+from pyiron_base.job.executable import Executable
+from pyiron_base.job.generic import GenericJob
+from pyiron_base.job.interactive import InteractiveBase
+from pyiron_base.job.jobstatus import JobStatus, job_status_successful_lst
+from pyiron_base.job.jobtype import JOB_CLASS_DICT, JobType, JobTypeChoice
+from pyiron_base.job.external import Notebook
+from pyiron_base.master.generic import GenericMaster, get_function_from_string
+from pyiron_base.master.parallel import ParallelMaster, JobGenerator
+from pyiron_base.master.serial import SerialMasterBase
 from pyiron_base.project.generic import Project
+from pyiron_base.project.gui import ProjectGUI
+from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
+from pyiron_base.server.queuestatus import _validate_que_request
+from pyiron_base.settings.generic import Settings
+from pyiron_base.settings.install import install_dialog
+
+
+from ._version import get_versions
+
+__version__ = get_versions()["version"]
+del get_versions
+
+# jedi fix
+fix_ipython_autocomplete()

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -17,11 +17,16 @@ from pyiron_base.master.generic import GenericMaster, get_function_from_string
 from pyiron_base.master.parallel import ParallelMaster, JobGenerator
 from pyiron_base.master.serial import SerialMasterBase
 from pyiron_base.project.generic import Project
-from pyiron_base.project.gui import ProjectGUI
 from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
 from pyiron_base.server.queuestatus import validate_que_request
 from pyiron_base.settings.generic import Settings
 from pyiron_base.settings.install import install_dialog
+
+try:
+    from pyiron_base import ProjectGUI
+except (ImportError, TypeError, AttributeError):
+    pass
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -78,7 +78,7 @@ def queue_check_job_is_waiting_or_running(item):
     Returns:
         bool: [True/False]
     """
-    que_id = _validate_que_request(item)
+    que_id = validate_que_request(item)
     if s.queue_adapter is not None:
         return s.queue_adapter.get_status_of_job(process_id=que_id) in [
             "pending",
@@ -128,7 +128,7 @@ def queue_delete_job(item):
     Returns:
         str: Output from the queuing system as string - optimized for the Sun grid engine
     """
-    que_id = _validate_que_request(item)
+    que_id = validate_que_request(item)
     if s.queue_adapter is not None:
         return s.queue_adapter.delete_job(process_id=que_id)
     else:
@@ -145,7 +145,7 @@ def queue_enable_reservation(item):
     Returns:
         str: Output from the queuing system as string - optimized for the Sun grid engine
     """
-    que_id = _validate_que_request(item)
+    que_id = validate_que_request(item)
     if s.queue_adapter is not None:
         if isinstance(que_id, list):
             return [s.queue_adapter.enable_reservation(process_id=q) for q in que_id]
@@ -264,7 +264,7 @@ def update_from_remote(project, recursive=True):
                     job_object.transfer_from_remote()
 
 
-def _validate_que_request(item):
+def validate_que_request(item):
     """
     Internal function to convert the job_ID or hamiltonian to the queuing system ID.
 


### PR DESCRIPTION
This allows us to change the internal structure of pyiron_base without the need to change derived packages.