### PR TITLE
Allow to reset job.queue to None

### DIFF
--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -162,6 +162,10 @@ class Server(
         Args:
             new_scheduler (str): scheduler name
         """
+        if new_scheduler == None:
+            self._active_queue = None
+            self._run_mode.mode = "modal"
+            return
         if s.queue_adapter is not None:
             cores, run_time_max, memory_max = s.queue_adapter.check_queue_parameters(
                 queue=new_scheduler,

--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -169,7 +169,7 @@ class Server(
             self.run_mode.modal = True
             self.cores = 1
             self.threads = 1
-            self.run_time = None
+            self._run_time = None
             self.memory_limit = None
         else:
             if s.queue_adapter is not None:

--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -157,41 +157,47 @@ class Server(
     @queue.setter
     def queue(self, new_scheduler):
         """
-        Set a que for the current simulation, by choosing one of the available que_names
+        Set a queue for the current simulation, by choosing one of the options
+        listed in :attribute:`~.queue_list`.
 
         Args:
-            new_scheduler (str): scheduler name
+            new_scheduler (str/None): scheduler name, None resets to default
+                                      run_mode modal
         """
-        if new_scheduler == None:
+        if new_scheduler is None:
             self._active_queue = None
-            self._run_mode.mode = "modal"
-            return
-        if s.queue_adapter is not None:
-            cores, run_time_max, memory_max = s.queue_adapter.check_queue_parameters(
-                queue=new_scheduler,
-                cores=self.cores,
-                run_time_max=self.run_time,
-                memory_max=self.memory_limit,
-            )
-            if cores != self.cores:
-                self._cores = cores
-                s.logger.debug(
-                    "Updated the number of cores to: {}".format(cores)
-                )
-            if run_time_max != self.run_time:
-                self._run_time = run_time_max
-                s.logger.debug(
-                    "Updated the run time limit to: {}".format(run_time_max)
-                )
-            if memory_max != self.memory_limit:
-                self._memory_limit = memory_max
-                s.logger.debug(
-                    "Updated the memory limit to: {}".format(memory_max)
-                )
-            self._active_queue = new_scheduler
-            self.run_mode = "queue"
+            self.run_mode.modal = True
+            self.cores = 1
+            self.threads = 1
+            self.run_time = None
+            self.memory_limit = None
         else:
-            raise TypeError("No queue adapter defined.")
+            if s.queue_adapter is not None:
+                cores, run_time_max, memory_max = s.queue_adapter.check_queue_parameters(
+                    queue=new_scheduler,
+                    cores=self.cores,
+                    run_time_max=self.run_time,
+                    memory_max=self.memory_limit,
+                )
+                if cores != self.cores:
+                    self._cores = cores
+                    s.logger.debug(
+                        "Updated the number of cores to: {}".format(cores)
+                    )
+                if run_time_max != self.run_time:
+                    self._run_time = run_time_max
+                    s.logger.debug(
+                        "Updated the run time limit to: {}".format(run_time_max)
+                    )
+                if memory_max != self.memory_limit:
+                    self._memory_limit = memory_max
+                    s.logger.debug(
+                        "Updated the memory limit to: {}".format(memory_max)
+                    )
+                self._active_queue = new_scheduler
+                self.run_mode = "queue"
+            else:
+                raise TypeError("No queue adapter defined.")
 
     @property
     def queue_id(self):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+from pyiron_base.server.generic import Server
+
+
+class TestRunmode(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server()
+
+    def test_queue_set_None(self):
+        try:
+            self.server.queue = None
+        except:
+            self.fail("queue should accept None")
+
+        self.assertEqual(self.server._active_queue, None,
+                "active queue not set to None")
+        self.assertTrue(self.server.run_mode.modal,
+                "run_mode default not restored after reseting queue")
+        self.assertEqual(self.server.cores, 1,
+                "cores default not restored after reseting queue")
+        self.assertEqual(self.server.threads, 1,
+                "threads default not restored after reseting queue")
+        self.assertEqual(self.server.run_time, None,
+                "run_time default not restored after reseting queue")
+        self.assertEqual(self.server.memory_limit, None,
+                "memory_limit default not restored after reseting queue")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This sets the run_mode to modal, not sure if that's the best default.
I also haven't tested this yet on the cluster, but it seems straightforward enough.