### PR TITLE
Add list_nodes/list_groups to InputList

### DIFF
--- a/pyiron_base/generic/inputlist.py
+++ b/pyiron_base/generic/inputlist.py
@@ -571,7 +571,7 @@ class InputList(MutableMapping):
         Iterator over keys to terminal nodes.
 
         Returns:
-            :class:`list`: list of all keys to nested lists.
+            :class:`list`: list of keys to normal values.
         """
         for k, v in self.items():
             if not isinstance(v, InputList):
@@ -582,7 +582,7 @@ class InputList(MutableMapping):
         Return a list of keys to terminal nodes.
 
         Returns:
-            :class:`list`: list of all keys to nested lists.
+            :class:`list`: list of keys to normal values.
         """
         return list(self.nodes())
 

--- a/pyiron_base/generic/inputlist.py
+++ b/pyiron_base/generic/inputlist.py
@@ -565,3 +565,43 @@ class InputList(MutableMapping):
 
         self.clear()
         self.update(data, wrap = True)
+
+    def nodes(self):
+        """
+        Iterator over keys to terminal nodes.
+
+        Returns:
+            :class:`list`: list of all keys to nested lists.
+        """
+        for k, v in self.items():
+            if not isinstance(v, InputList):
+                yield k
+
+    def list_nodes(self):
+        """
+        Return a list of keys to terminal nodes.
+
+        Returns:
+            :class:`list`: list of all keys to nested lists.
+        """
+        return list(self.nodes())
+
+    def groups(self):
+        """
+        Return a list of keys to nested lists.
+
+        Returns:
+            :class:`list`: list of all keys to elements of :class:`InputList`.
+        """
+        for k, v in self.items():
+            if isinstance(v, InputList):
+                yield k
+
+    def list_groups(self):
+        """
+        Return a list of keys to nested lists.
+
+        Returns:
+            :class:`list`: list of all keys to elements of :class:`InputList`.
+        """
+        return list(self.groups())

--- a/tests/generic/test_inputlist.py
+++ b/tests/generic/test_inputlist.py
@@ -3,6 +3,7 @@
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.project.generic import Project
+from collections import Iterator
 import copy
 import os
 import unittest
@@ -341,6 +342,29 @@ class TestInputList(unittest.TestCase):
         l.from_hdf(hdf=self.hdf, group_name = "test_group")
         self.assertEqual(self.pl, l)
 
+    def test_groups_nodes(self):
+        self.assertTrue(isinstance(self.pl.nodes(), Iterator),
+                        "nodes does not return an Iterator")
+        self.assertTrue(isinstance(self.pl.groups(), Iterator),
+                        "groups does not return an Iterator")
+        self.assertTrue(isinstance(self.pl.list_nodes(), list),
+                        "nodes does not return an list")
+        self.assertTrue(isinstance(self.pl.list_groups(), list),
+                        "groups does not return an list")
+
+        for v1, v2 in zip(self.pl.list_groups(), self.pl.groups()):
+            self.assertEqual(v1, v2, "list and iterator over groups not the same")
+
+        for v1, v2 in zip(self.pl.list_nodes(), self.pl.nodes()):
+            self.assertEqual(v1, v2, "list and iterator over nodes not the same")
+
+        for g in self.pl.groups():
+            self.assertTrue(isinstance(self.pl[g], InputList),
+                            "groups returns a node")
+
+        for n in self.pl.nodes():
+            self.assertFalse(isinstance(self.pl[n], InputList),
+                            "nodes returns a group")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds generic methods to distinguish groups and nodes in the list as we just discussed in the meeting.  I defined groups as nested `InputList`s only not other containers otherwise it might get confusing.