### PR TITLE
Check length of job name

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -918,6 +918,11 @@ class JobCore(PyironObject):
                 raise ValueError(
                     'Invalid name for a PyIron object (no "." or "#") allowed'
                 )
+            if len(job_name) > 50:
+                raise ValueError(
+                    'Invalid name for a PyIron object: must be less then or '
+                    'equal to 50 characters'
+                )
         except AttributeError:
             pass  # no name check in Python 2.7
 


### PR DESCRIPTION
catch here instead of causing an error in database code

As far as I am aware the length restriction is a detail of our deployment, but I think it's much nicer to get an error early rather than some deep from the database.