### PR TITLE
Add friendly error message when setting queue w/o adapter

### DIFF
--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -197,7 +197,8 @@ class Server(
                 self._active_queue = new_scheduler
                 self.run_mode = "queue"
             else:
-                raise TypeError("No queue adapter defined.")
+                raise TypeError("No queue adapter defined. Have you "
+                                "configured in $PYIRONRESOURCES_PATHS/queues?")
 
     @property
     def queue_id(self):


### PR DESCRIPTION
The error was already thrown in the correct place, but I added a small sentence to hint where to fix it.