### PR TITLE
Fixes problem with non pyiron jobs in queue

### DIFF
--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -236,6 +236,7 @@ def update_from_remote(project, recursive=True):
         df_combined = df_project[df_project.status.isin(["running", "submitted"])]
         df_queue = s.queue_adapter.get_status_of_my_jobs()
         if len(df_queue) > 0 and len(df_queue[df_queue.jobname.str.startswith("pi_")]) > 0:
+            df_queue = df_queue[df_queue.jobname.str.startswith("pi_")]
             df_queue["pyiron_id"] = df_queue.apply(
                 lambda x: int(x["jobname"].split("pi_")[1]),
                 axis=1


### PR DESCRIPTION
Seems like I actually had no other jobs in the queue when I tried the last time. Applyin the lambda function still lead to a non existent list element for non pyiron jobs.