### PR TITLE
Add tests for external script jobs

### DIFF
--- a/pyiron_base/job/external.py
+++ b/pyiron_base/job/external.py
@@ -38,8 +38,8 @@ class Notebook(object):
         hdf_file = project_folder / folder
         hdf_file = str(hdf_file) + ".h5"
         if Path(hdf_file).exists():
-            hdf = FileHDFio(hdf_file)
-            custom_dict = hdf[folder + '/input/custom_dict/data']
+            hdf = FileHDFio(hdf_file)._create_project_from_hdf5()
+            custom_dict = hdf[folder + '/input/custom_dict'].to_object()
             custom_dict["project_dir"] = str(project_folder)
             return custom_dict
         elif Path("input.json").exists():

--- a/tests/job/test_external.py
+++ b/tests/job/test_external.py
@@ -12,9 +12,7 @@ print(coeff_tot['value'])
 class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
-            "\\", "/"
-        )
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
         cls.job_location = os.path.join(cls.file_location, "job.py")
         cls.project = Project(os.path.join(cls.file_location, "test_notebook"))
         cls.job = cls.project.create_job(cls.project.job_type.ScriptJob,

--- a/tests/job/test_external.py
+++ b/tests/job/test_external.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from pyiron_base import Project
+
+job_py_source = """
+from pyiron_base import Notebook as nb
+coeff_tot = nb.get_custom_dict()
+print(coeff_tot['value'])
+"""
+
+class TestScriptJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
+            "\\", "/"
+        )
+        cls.job_location = os.path.join(cls.file_location, "job.py")
+        cls.project = Project(os.path.join(cls.file_location, "test_notebook"))
+        cls.job = cls.project.create_job(cls.project.job_type.ScriptJob,
+                                               "test")
+        with open(cls.job_location, 'w') as f:
+            f.write(job_py_source)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.job_location)
+        cls.project.remove(enable=True)
+
+
+    def test_notebook_input(self):
+        """
+        Test that input is readable from external scripts.
+        """
+        self.job.input['value'] = 300
+        self.job.script_path = self.job_location
+        try:
+            self.job.run()
+        except Exception as e:
+            self.fail("Running script job failed with {}".format(e))

--- a/tests/job/test_scriptjob.py
+++ b/tests/job/test_scriptjob.py
@@ -25,7 +25,6 @@ class TestScriptJob(unittest.TestCase):
         Notebook jobs c.f. `Notebook.get_custom_dict()`.
         """
         self.job.input['value'] = 300
-        self.job.script_path = 'job.ipynb'
         self.job.save()
         self.assertTrue("custom_dict" in self.job["input"].list_groups(),
                         "Input not saved in the 'custom_dict' group in HDF")

--- a/tests/job/test_scriptjob.py
+++ b/tests/job/test_scriptjob.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+
+from pyiron_base import Project
+
+class TestScriptJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
+            "\\", "/"
+        )
+        cls.project = Project(os.path.join(cls.file_location, "test_scriptjob"))
+        cls.job = cls.project.create_job(cls.project.job_type.ScriptJob,
+                                               "test")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.remove(enable=True)
+
+
+    def test_notebook_input(self):
+        """
+        Makes sure that the ScriptJob saves its input class in
+        hdf["input/custom_group"] as this is needed when running external
+        Notebook jobs c.f. `Notebook.get_custom_dict()`.
+        """
+        self.job.input['value'] = 300
+        self.job.script_path = 'job.ipynb'
+        self.job.save()
+        self.assertTrue("custom_dict" in self.job["input"].list_groups(),
+                        "Input not saved in the 'custom_dict' group in HDF")


### PR DESCRIPTION
This also uses the generic ProjectHDFio.to_object() machinery to load
the input dictionary from the ScriptJob hdf without depending on the
internals.

This should make sure #44 doesn't happen again.