### PR TITLE
Remove python2 compatibility code

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -3,31 +3,15 @@ import os
 import pandas
 import datetime
 import h5io
-from six import with_metaclass
 from pyfileindex import PyFileIndex
-
-
-class Singleton(type):
-    """
-    Implemented with suggestions from
-
-    http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
-
-    """
-
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+from pyiron_base.generic.util import Singleton
 
 
 def filter_function(file_name):
     return '.h5' in file_name
 
 
-class FileTable(with_metaclass(Singleton)):
+class FileTable(metaclass=Singleton):
     def __init__(self, project):
         self._fileindex = None
         self._job_table = None

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 
 import h5py
 import os

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -18,6 +18,22 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+class Singleton(type):
+    """
+    Implemented with suggestions from
+
+    http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
+
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
 def static_isinstance(obj, obj_type):
     """
     A static implementation of isinstance() - instead of comparing an object and a class, the object is compared to a

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import copy
 import os
 import posixpath

--- a/pyiron_base/job/external.py
+++ b/pyiron_base/job/external.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import json
 from pathlib2 import Path
 import warnings

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 
 # import copy
 import signal

--- a/pyiron_base/job/jobstatus.py
+++ b/pyiron_base/job/jobstatus.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import six
 from pyiron_base.database.generic import DatabaseAccess
 from pyiron_base.database.filetable import FileTable
 
@@ -171,7 +170,7 @@ class JobStatus(object):
                           refresh, busy, finished, warning]
         """
         self._reset()
-        if isinstance(status, six.string_types) and status in self._status_dict.keys():
+        if isinstance(status, str) and status in self._status_dict.keys():
             self._status_dict[status] = True
             self._status_write()
         else:

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -2,11 +2,10 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import importlib
 import inspect
 import os
-from six import with_metaclass
+from pyiron_base.generic.util import Singleton
 from pyiron_base.job.jobstatus import job_status_finished_lst
 
 """
@@ -32,23 +31,7 @@ JOB_CLASS_DICT = {
 }
 
 
-class Singleton(type):
-    """
-    Implemented with suggestions from
-
-    http://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
-
-    """
-
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
-
-
-class JobTypeChoice(with_metaclass(Singleton)):
+class JobTypeChoice(metaclass=Singleton):
     """
     Helper class to choose the job type directly from the project, autocompletion is enabled by overwriting the
     __dir__() function.

--- a/pyiron_base/job/script.py
+++ b/pyiron_base/job/script.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import os
 import shutil
 from pyiron_base.job.generic import GenericJob

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.core import JobCore
 from pyiron_base.job.generic import GenericJob

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import division, print_function
 from collections import OrderedDict
 from datetime import datetime
 import numpy as np

--- a/pyiron_base/master/serial.py
+++ b/pyiron_base/master/serial.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 from collections import OrderedDict
 import inspect
 import time

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import os
 import posixpath
 import shutil

--- a/pyiron_base/project/path.py
+++ b/pyiron_base/project/path.py
@@ -2,13 +2,11 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 
 from copy import copy
 import os
 import posixpath
 from pyiron_base.settings.generic import Settings
-from six import string_types
 
 """
 Classes for representing the file system path in pyiron
@@ -364,7 +362,7 @@ class ProjectPath(GenericPath):
         """
         if isinstance(path, GenericPath):
             return path
-        elif isinstance(path, string_types):
+        elif isinstance(path, str):
             path = os.path.normpath(path)
             if not os.path.isabs(path):
                 path_local = self._windows_path_to_unix_path(

--- a/pyiron_base/project/store.py
+++ b/pyiron_base/project/store.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 from datetime import datetime
 from pyiron_base.job.generic import GenericJob
 

--- a/pyiron_base/pyio/parser.py
+++ b/pyiron_base/pyio/parser.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 import ast
 import numpy as np
 

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -5,7 +5,6 @@
 from builtins import input
 import os
 import importlib
-from six import with_metaclass
 import sys
 from configparser import ConfigParser
 from pathlib2 import Path
@@ -51,7 +50,7 @@ class Singleton(type):
         return cls._instances[cls]
 
 
-class Settings(with_metaclass(Singleton)):
+class Settings(metaclass=Singleton):
     """
     The settings object can either search for an configuration file and use the default configuration only when no
     other configuration file is found, or it can be forced to use the default configuration file.

--- a/pyiron_base/settings/update.py
+++ b/pyiron_base/settings/update.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from __future__ import print_function
 from pyiron_base.settings.generic import Settings
 
 """

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'psutil>=5.7.0',
         'pyfileindex>=0.0.4',
         'pysqa>=0.0.11',
-        'six>=1.14.0',
         'sqlalchemy>=1.3.14',
         'tables>=3.6.1'
     ],


### PR DESCRIPTION
Following #46 remove all code that existed only for python2.   I also unified two of the three Singleton metaclasses in `pyiron_base.generic.util`.  The third one is for the `Settings` object and does something specific for that, so I left it.