### PR TITLE
Update external.py

### DIFF
--- a/pyiron_base/job/external.py
+++ b/pyiron_base/job/external.py
@@ -38,7 +38,7 @@ class Notebook(object):
         hdf_file = str(hdf_file) + ".h5"
         if Path(hdf_file).exists():
             hdf = FileHDFio(hdf_file)
-            custom_dict = hdf[folder + '/input/custom_dict/data']
+            custom_dict = hdf[folder + '/input/custom_dict/data_dict']
             custom_dict["project_dir"] = str(project_folder)
             return custom_dict
         elif Path("input.json").exists():


### PR DESCRIPTION
`'input/custom_dict/data'` does not exist and gives an `"Unknown item: data"` error for script jobs. I found the input data to be stored in `'/input/custom_dict/data_dict'`