### PR TITLE
Allow default in when access HDF5

### DIFF
--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -445,7 +445,7 @@ class FileHDFio(object):
             df = pandas.DataFrame(val)
             return df
 
-    def get(self, key):
+    def get(self, key, default = None):
         """
         Internal wrapper function for __getitem__() - self[name]
 
@@ -455,7 +455,13 @@ class FileHDFio(object):
         Returns:
             dict, list, float, int: data or data object
         """
-        return self.__getitem__(key)
+        try:
+            return self.__getitem__(key)
+        except ValueError:
+            if default is not None:
+                return default
+            else:
+                raise
 
     def put(self, key, value):
         """

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -451,6 +451,7 @@ class FileHDFio(object):
 
         Args:
             key (str, slice): path to the data or key of the data object
+            default (object): default value to return if key doesn't exist
 
         Returns:
             dict, list, float, int: data or data object

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -66,6 +66,12 @@ class TestFileHDFio(unittest.TestCase):
                 )
             )
         )
+        self.assertEqual(self.full_hdf5.get("doesnotexist", default=42), 42,
+                         "default value not returned when value doesn't exist.")
+        self.assertTrue(np.array_equal(
+                            self.full_hdf5.get("content/array", default=42),
+                            np.array([1, 2, 3, 4, 5, 6])
+                        ), "default value returned when value doesn't exist.")
 
     def test_file_name(self):
         self.assertEqual(


### PR DESCRIPTION
Just a small quality of life fix to avoid patterns like
```python
if k in hdf.list_nodes():
  return hdf[k]
else
  return 'default'
...
```