### PR TITLE
Fix bug that ignores group_name GenericJob.to_hdf

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1144,7 +1144,7 @@ class GenericJob(JobCore):
         if hdf is not None:
             self._hdf5 = hdf
         if group_name is not None:
-            self._hdf5.open(group_name)
+            self._hdf5 = self._hdf5.open(group_name)
         self._executable_activate_mpi()
         self._type_to_hdf()
         self._hdf5["status"] = self.status.string


### PR DESCRIPTION
Previously GenericJob always serialize themselves in the `hdf` argument given to `to_hdf` independent of the given `group_name`.  This is because `ProjectHDFio.open` returns a copy of the newly opened file/group, but does not update its internal path.