### PR TITLE
Allow to pass track_order when creating groups

### DIFF
--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -329,13 +329,15 @@ class FileHDFio(object):
                             del f_target["/tmp"]
         return destination
 
-    def create_group(self, name):
+    def create_group(self, name, track_order=False):
         """
         Create an HDF5 group - similar to a folder in the filesystem - the HDF5 groups allow the users to structure
         their data.
 
         Args:
             name (str): name of the HDF5 group
+            track_order (bool): if False this groups tracks its elements in
+                alphanumeric order, if True in insertion order
 
         Returns:
             FileHDFio: FileHDFio object pointing to the new group
@@ -343,7 +345,7 @@ class FileHDFio(object):
         full_name = posixpath.join(self.h5_path, name)
         with h5py.File(self.file_name, mode="a", libver="latest", swmr=True) as h:
             try:
-                h.create_group(full_name)
+                h.create_group(full_name, track_order=track_order)
             except ValueError:
                 pass
         h_new = self[name].copy()


### PR DESCRIPTION
This causes hdf groups to be returned in insertion order.

This will be necessary to keep track of the element order when saving InputLists to groups.  Since elements in an InputList have a guaranteed order even when they have keys associated with them, this order needs to be mapped also in the HDF5 file.  However since we want users to be able to reach directly into the HDF5 paths, I'd rather not mangle the group names to keep track of the order (e.g. "{group_name}_{index_in_list}" would be clunky).  HDF5 allows to track the insertion order by passing `track_order=True` when creating new groups.  This PR simply allows to pass that option to our existing `create_group`.