### PR TITLE
Change queue_delete to call _queue_delete internally

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -443,7 +443,7 @@ class JobCore(PyironObject):
                 and str(self.status) in ["submitted", "running", "collect"]
                 and server_hdf_dict["qid"] is not None
             ):
-                self.project._queue_delete_job(server_hdf_dict["qid"])
+                self.project.queue_delete_job(server_hdf_dict["qid"])
         with self.project_hdf5.open("..") as hdf_parent:
             try:
                 del hdf_parent[self.job_name]

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1146,10 +1146,7 @@ class Project(ProjectPath):
         Returns:
             str: Output from the queuing system as string - optimized for the Sun grid engine
         """
-        if isinstance(item, int):
-            self.remove_job(job_specifier=item)
-        else:
-            item.remove()
+        self._queue_delete_job(item)
 
     @staticmethod
     def create_hdf(path, job_name):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1146,7 +1146,10 @@ class Project(ProjectPath):
         Returns:
             str: Output from the queuing system as string - optimized for the Sun grid engine
         """
-        self._queue_delete_job(item)
+        if not self.view_mode:
+            return queue_delete_job(item)
+        else:
+            raise EnvironmentError("copy_to: is not available in Viewermode !")
 
     @staticmethod
     def create_hdf(path, job_name):
@@ -1436,21 +1439,6 @@ class Project(ProjectPath):
             for f in glob.glob(pattern):
                 s.logger.info("remove file {}".format(posixpath.basename(f)))
                 os.remove(f)
-        else:
-            raise EnvironmentError("copy_to: is not available in Viewermode !")
-
-    def _queue_delete_job(self, item):
-        """
-        Delete a job from the queuing system
-
-        Args:
-            item (int, GenericJob): Provide either the job_ID or the full hamiltonian
-
-        Returns:
-            str: Output from the queuing system as string - optimized for the Sun grid engine
-        """
-        if not self.view_mode:
-            return queue_delete_job(item)
         else:
             raise EnvironmentError("copy_to: is not available in Viewermode !")
 


### PR DESCRIPTION
Changed the queue_delete method from calling job.remove internally to prevent people from accidentally deleting jobs permanently. Instead they are only deleted from the queuing system