### PR TITLE
inhibit ragged list warning

### DIFF
--- a/pyiron_base/generic/parameters.py
+++ b/pyiron_base/generic/parameters.py
@@ -857,7 +857,7 @@ class GenericParameters(PyironObject):
                     continue
 
             for col in self._dataset:
-                self._dataset[col] = np.array(self._dataset[col]).tolist()
+                self._dataset[col] = np.array(self._dataset[col], dtype=object).tolist()
 
             comment = ""
             if isinstance(val, tuple):


### PR DESCRIPTION
Every now and then when a job is created/loaded, I saw the warning:

*VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray*

Since apparently the line causing the warning `self._dataset[col] = np.array(self._dataset[col]).tolist()` only wants to convert the object to `list`, I did what the warning wanted me to do.