### PR TITLE
Fix copy to

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -514,7 +514,7 @@ class GenericJob(JobCore):
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
         if len(job_table) > 0 and new_job_name in job_table.job.values:
-                return project[new_job_name]
+                return project.load(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -519,7 +519,6 @@ class GenericJob(JobCore):
             if not delete_existing_job:
                 return project.load(new_job_name)
             else:
-                print("checkpoint 2")
                 project.remove_job(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -513,8 +513,7 @@ class GenericJob(JobCore):
         project = project or self.project
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
-        if len(job_table) > 0:
-            if new_job_name in job_table.job.tolist():
+        if len(job_table) > 0 and new_job_name in job_table.job.values:
                 return project[new_job_name]
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -516,7 +516,6 @@ class GenericJob(JobCore):
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
         if len(job_table) > 0 and new_job_name in job_table.job.values:
-            print("checkpoint 1", delete_existing_job)
             if not delete_existing_job:
                 return project.load(new_job_name)
             else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -512,6 +512,8 @@ class GenericJob(JobCore):
         # Get new hdf location
         project = project or self.project
         new_job_name = new_job_name or self.job_name
+        if new_job_name in project.job_table(recursive=False).job.tolist():
+            return project[new_job_name]
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -514,7 +514,7 @@ class GenericJob(JobCore):
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
         if len(job_table) > 0 and new_job_name in job_table.job.values:
-                return project.load(new_job_name)
+            return project.load(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -512,8 +512,10 @@ class GenericJob(JobCore):
         # Get new hdf location
         project = project or self.project
         new_job_name = new_job_name or self.job_name
-        if new_job_name in project.job_table(recursive=False).job.tolist():
-            return project[new_job_name]
+        job_table = project.job_table(recursive=False)
+        if len(job_table) > 0:
+            if new_job_name in job_table.job.tolist():
+                return project[new_job_name]
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -478,7 +478,8 @@ class GenericJob(JobCore):
         copied_self._job_id = None
         return copied_self
 
-    def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True, delete_existing_job=False):
+    def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True,
+                delete_existing_job=False):
         """
         Copy the content of the job including the HDF5 file to a new location.
 
@@ -515,9 +516,11 @@ class GenericJob(JobCore):
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
         if len(job_table) > 0 and new_job_name in job_table.job.values:
+            print("checkpoint 1", delete_existing_job)
             if not delete_existing_job:
                 return project.load(new_job_name)
             else:
+                print("checkpoint 2")
                 project.remove_job(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -478,7 +478,7 @@ class GenericJob(JobCore):
         copied_self._job_id = None
         return copied_self
 
-    def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True):
+    def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True, delete_existing_job=False):
         """
         Copy the content of the job including the HDF5 file to a new location.
 
@@ -489,6 +489,7 @@ class GenericJob(JobCore):
             input_only (bool): [True/False] Whether to copy only the input. (Default is False.)
             new_database_entry (bool): [True/False] Whether to create a new database entry. If input_only is True then
                 new_database_entry is False. (Default is True.)
+            delete_existing_job (bool): [True/False] Delete existing job in case it exists already (Default is False.)
 
         Returns:
             GenericJob: GenericJob object pointing to the new location.
@@ -514,7 +515,10 @@ class GenericJob(JobCore):
         new_job_name = new_job_name or self.job_name
         job_table = project.job_table(recursive=False)
         if len(job_table) > 0 and new_job_name in job_table.job.values:
-            return project.load(new_job_name)
+            if not delete_existing_job:
+                return project.load(new_job_name)
+            else: 
+                project.remove_job(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -517,7 +517,7 @@ class GenericJob(JobCore):
         if len(job_table) > 0 and new_job_name in job_table.job.values:
             if not delete_existing_job:
                 return project.load(new_job_name)
-            else: 
+            else:
                 project.remove_job(new_job_name)
         if in_same_project and len(self.project_hdf5.h5_path.split("/")) > 2:
             new_location = self.project_hdf5.open("../" + new_job_name)

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -126,6 +126,10 @@ class TestGenericJob(unittest.TestCase):
         _ = job.copy_to(new_job_name="template_last", input_only=False, new_database_entry=True)
         df = self.project.job_table()
         self.assertEqual(len(df[df.job == "template"]), 2)
+        _ = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False,
+                        delete_existing_job=True)
+        df = self.project.job_table()
+        self.assertTrue("template_copy" not in df.job.values)
 
     # def test_sub_job_name(self):
     #     pass

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -106,6 +106,27 @@ class TestGenericJob(unittest.TestCase):
         pr_a.remove(enable=True)
         pr_b.remove(enable=True)
 
+    def test_copy_to(self):
+        job = self.project.create_job("ScriptJob", "template")
+        job.save()
+        job_copy = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False)
+        job_copy.save()
+        job_copy.status.finished = True
+        df = self.project.job_table()
+        self.assertEqual("template", sorted(df.job.values)[0])
+        self.assertEqual("template_copy", sorted(df.job.values)[1])
+        # Load job if copied with same name
+        job_copy_again = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False)
+        self.assertEqual(job_copy["input/generic_dict"], job_copy_again["input/generic_dict"])
+        self.assertTrue(job_copy_again.status.finished)
+        # Completely new job name
+        job_new = job.copy_to(new_job_name="template_new", input_only=False, new_database_entry=False)
+        self.assertTrue(job_new.status.initialized)
+        # Check if new database entry implemented
+        _ = job.copy_to(new_job_name="template_last", input_only=False, new_database_entry=True)
+        df = self.project.job_table()
+        self.assertEqual(len(df[df.job == "template"]), 2)
+
     # def test_sub_job_name(self):
     #     pass
 


### PR DESCRIPTION
Debugging the `copy_to` function to load the already existing job with the same name. This is necessary for many workflows (including the ones in the recent phase diagrams workshop) to work seamlessly.