### PR TITLE
Add new deprecate decorator

### DIFF
--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -112,8 +112,7 @@ class Deprecator:
         """
         Initialize default values for deprecation message and version.
 
-        Args
-        ----
+        Args:
             message (str): default deprecation message
             version (str): default version after which the function might be removed
             pending (bool): only warn about future deprecation, warning category will be PendingDeprecationWarning
@@ -136,11 +135,10 @@ class Deprecator:
         Wrap the given function to emit a DeprecationWarning at call time.  The warning message is constructed from the
         given message and version.
 
-        Args
-        ----
+        Args:
             function (function): function to mark as deprecated
-        Return
-        ------
+
+        Return:
             function: raises DeprecationWarning when given function is called
         """
         if self.category == PendingDeprecationWarning:

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -115,7 +115,7 @@ class Deprecator:
         Args
         ----
             message (str): default deprecation message
-            version (str): default version after which the function will be removed
+            version (str): default version after which the function might be removed
             pending (bool): only warn about future deprecation, warning category will be PendingDeprecationWarning
                 instead of DeprecationWarning
         """

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -114,18 +114,14 @@ class Deprecator:
 
         Args
         ----
-            message (str):
-                default deprecation message
-            version (str):
-                default version after which the function will be removed
-            pending (bool):
-                only warn about future deprecation, warning category will be
-                PendingDeprecationWarning instead of DeprecationWarning
+            message (str): default deprecation message
+            version (str): default version after which the function will be removed
+            pending (bool): only warn about future deprecation, warning category will be PendingDeprecationWarning
+                instead of DeprecationWarning
         """
         self.message = message
         self.version = version
-        self.category = PendingDeprecationWarning \
-                            if pending else DeprecationWarning
+        self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
     def __call__(self, message, version = None):
         if isinstance(message, types.FunctionType):
@@ -137,13 +133,12 @@ class Deprecator:
 
     def wrap(self, function):
         """
-        Wrap the given function to emit a DeprecationWarning at call time.  The
-        warning message is constructed from the given message and version.
+        Wrap the given function to emit a DeprecationWarning at call time.  The warning message is constructed from the
+        given message and version.
 
         Args
         ----
-            function (function):
-                function to mark as deprecated
+            function (function): function to mark as deprecated
         Return
         ------
             function: raises DeprecationWarning when given function is called
@@ -154,16 +149,13 @@ class Deprecator:
             message_format =  "{}.{} will be deprecated"
         message = message_format.format(function.__module__, function.__name__)
 
-        if self.message:
+        if self.message is not None:
             message += ": {}.".format(self.message)
         else:
             message += "."
 
-        if self.version:
-            message += \
-                " It is not guaranteed to be in service in vers. {}".format(
-                        self.version
-                )
+        if self.version is not None:
+            message += " It is not guaranteed to be in service in vers. {}".format(self.version)
 
         @functools.wraps(function)
         def decorated(*args, **kwargs):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -6,6 +6,10 @@
 Utility functions used in pyiron.
 """
 
+import functools
+import types
+import warnings
+
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
     "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
@@ -57,3 +61,94 @@ def static_isinstance(obj, obj_type):
         return obj_type in obj_class_lst
     else:
         raise TypeError()
+
+
+class Deprecator:
+    """
+    Decorator class to mark functions and methods as deprecated with a uniform
+    warning message at the time the function is called.  The message has the
+    form
+
+        {function_name} is deprecated: {message}. It is not guaranteed to be in
+        service after {version}.
+
+    If message and version are not initialized or given during the decorating
+    call the respective parts are left out from the message.
+
+    >>> deprecate = Deprecator()
+    >>> @deprecate
+    ... def foo(a, b):
+    ...     pass
+    >>> foo(1, 2)
+    DeprecationWarning: __main__.foo is deprecated
+
+    >>> @deprecate("use bar() instead")
+    ... def foo(a, b):
+    ...     pass
+    >>> foo(1, 2)
+    DeprecationWarning: __main__.foo is deprecated: use bar instead
+
+    >>> @deprecate("use bar() instead", version="0.4.0")
+    ... def foo(a, b):
+    ...     pass
+    >>> foo(1, 2)
+    DeprecationWarning: __main__.foo is deprecated: use bar instead.  It is not
+    guaranteed to be in service in vers. 0.4.0
+
+    >>> deprecate = Deprecator(message="pyiron says no!", version="0.5.0")
+    >>> @deprecate
+    ... def foo(a, b):
+    ...     pass
+    >>> foo(1, 2)
+    DeprecationWarning: __main__.foo is deprecated: pyiron says no!  It is not
+    guaranteed to be in service in vers. 0.5.0
+    """
+
+    def __init__(self, message = None, version = None):
+        """
+        Initialize default values for deprecation message and version.
+        """
+        self.message = message
+        self.version = version
+
+    def __call__(self, message, version = None):
+        if isinstance(message, types.FunctionType):
+            return self.wrap(message)
+        else:
+            self.message = message
+            self.version = version
+            return lambda f: self.wrap(f)
+
+    def wrap(self, function):
+        """
+        Wrap the given function to emit a DeprecationWarning at call time.  The
+        warning message is constructed from the given message and version.
+
+        Args
+        ----
+            function (function):
+                function to mark as deprecated
+        Return
+        ------
+            function: raises DeprecationWarning when given function is called
+        """
+        message = "{}.{} is deprecated".format(
+                    function.__module__, function.__name__)
+        if self.message:
+            message += ": {}.".format(self.message)
+        if self.version:
+            message += \
+                " It is not guaranteed to be in service in vers. {}".format(
+                        self.version
+                )
+        @functools.wraps(function)
+        def decorated(*args, **kwargs):
+            warnings.warn(
+                message,
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+            return function(*args, **kwargs)
+        return decorated
+
+deprecate = Deprecator()

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -133,7 +133,7 @@ class Deprecator:
         else:
             self.message = message
             self.version = version
-            return lambda f: self.wrap(f)
+            return self.wrap
 
     def wrap(self, function):
         """

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -19,7 +19,7 @@ from pyiron_base.settings.generic import Settings
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.jobstatus import JobStatus
 from pyiron_base.job.core import JobCore
-from pyiron_base.generic.util import static_isinstance
+from pyiron_base.generic.util import static_isinstance, deprecate
 from pyiron_base.server.generic import Server
 from pyiron_base.database.filetable import FileTable
 import subprocess
@@ -1671,6 +1671,7 @@ class GenericJob(JobCore):
                 self._before_successor_calc(child)
                 child.run()
 
+    @deprecate("Use job.save()")
     def _create_job_structure(self, debug=False):
         """
         Internal helper function to create the input directories, save the job in the database and write the wrapper.
@@ -1678,7 +1679,6 @@ class GenericJob(JobCore):
         Args:
             debug (bool): Debug Mode
         """
-        warnings.warn("Use job.save() instead of job._create_job_structure().", self.s.DeprecationWarning)
         self.save()
 
     def _check_if_input_should_be_written(self):

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -26,9 +26,7 @@ class TestJobType(unittest.TestCase):
         self.assertRaises(TypeError, static_isinstance, list(), 1)
 
     def test_deprecate(self):
-        """
-        Function decorated with `deprecate` should raise a warning.
-        """
+        """ Function decorated with `deprecate` should raise a warning.  """
         @deprecate
         def foo(a):
             return 2*a

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -26,7 +26,7 @@ class TestJobType(unittest.TestCase):
         self.assertRaises(TypeError, static_isinstance, list(), 1)
 
     def test_deprecate(self):
-        """ Function decorated with `deprecate` should raise a warning.  """
+        """Function decorated with `deprecate` should raise a warning."""
         @deprecate
         def foo(a):
             return 2*a

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -5,7 +5,7 @@
 import unittest
 import warnings
 from pyiron_base.generic.util import static_isinstance
-from pyiron_base.generic.util import Deprecator, deprecate
+from pyiron_base.generic.util import deprecate, deprecate_soon
 
 
 class TestJobType(unittest.TestCase):
@@ -54,6 +54,17 @@ class TestJobType(unittest.TestCase):
                            "service in vers. 0.2.0"
         self.assertTrue( w[0].message.args[0].endswith(expected_message),
                         "Warning message does not reflect decorator arguments.")
+
+        @deprecate_soon
+        def baz(a):
+            return 3*a
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(baz(1), 3,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertEqual(w[0].category, PendingDeprecationWarning,
+                        "Raised warning is not a PendingDeprecationWarning")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -3,7 +3,9 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
+import warnings
 from pyiron_base.generic.util import static_isinstance
+from pyiron_base.generic.util import Deprecator, deprecate
 
 
 class TestJobType(unittest.TestCase):
@@ -23,6 +25,35 @@ class TestJobType(unittest.TestCase):
         )
         self.assertRaises(TypeError, static_isinstance, list(), 1)
 
+    def test_deprecate(self):
+        """
+        Function decorated with `deprecate` should raise a warning.
+        """
+        @deprecate
+        def foo(a):
+            return 2*a
+
+        @deprecate("use baz instead", version="0.2.0")
+        def bar(a):
+            return 4*a
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(foo(1), 2,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertTrue(len(w) > 0, "No warning raised!")
+        self.assertEqual(w[0].category, DeprecationWarning,
+                        "Raised warning is not a DeprecationWarning")
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(bar(1), 4,
+                             "Decorated function does not return original "
+                             "return value")
+
+        expected_message = "use baz instead. It is not guaranteed to be in " \
+                           "service in vers. 0.2.0"
+        self.assertTrue( w[0].message.args[0].endswith(expected_message),
+                        "Warning message does not reflect decorator arguments.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As we discussed in the pyiron meeting today, I made a minimal decorator.  You can pass a message and a version after which the function is expected to disappear.   I thought about making it raise an exception automatically when the given version is lower than the package version, but it is surprisingly difficult to come up with a solution that works for pyiron_base & pyiron.