### PR TITLE
Allow deprecating single keyword arguments

### DIFF
--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -123,12 +123,12 @@ class Deprecator:
         self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
     def __call__(self, message=None, version=None, arguments={}):
-        self.arguments = arguments
         if isinstance(message, types.FunctionType):
-            return self.wrap(message)
+            return self.__deprecate_function(message)
         else:
             self.message = message
             self.version = version
+            self.arguments = arguments
             return self.wrap
 
     def _build_message(self):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -133,9 +133,9 @@ class Deprecator:
 
     def _build_message(self):
         if self.category == PendingDeprecationWarning:
-            message_format =  "{} is deprecated"
-        else:
             message_format =  "{} will be deprecated"
+        else:
+            message_format =  "{} is deprecated"
 
         if self.message is not None:
             message_format += ": {}.".format(self.message)

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -122,7 +122,7 @@ class Deprecator:
         self.version = version
         self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
-    def __call__(self, message, version = None):
+    def __call__(self, message, version=None):
         if isinstance(message, types.FunctionType):
             return self.wrap(message)
         else:
@@ -130,17 +130,7 @@ class Deprecator:
             self.version = version
             return self.wrap
 
-    def wrap(self, function):
-        """
-        Wrap the given function to emit a DeprecationWarning at call time.  The warning message is constructed from the
-        given message and version.
-
-        Args:
-            function (function): function to mark as deprecated
-
-        Return:
-            function: raises DeprecationWarning when given function is called
-        """
+    def _build_message(self, function):
         if self.category == PendingDeprecationWarning:
             message_format =  "{}.{} is deprecated"
         else:
@@ -154,6 +144,21 @@ class Deprecator:
 
         if self.version is not None:
             message += " It is not guaranteed to be in service in vers. {}".format(self.version)
+
+        return message
+
+    def wrap(self, function):
+        """
+        Wrap the given function to emit a DeprecationWarning at call time.  The warning message is constructed from the
+        given message and version.
+
+        Args:
+            function (function): function to mark as deprecated
+
+        Return:
+            function: raises DeprecationWarning when given function is called
+        """
+        message = self._build_message(function)
 
         @functools.wraps(function)
         def decorated(*args, **kwargs):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -106,6 +106,18 @@ class Deprecator:
     >>> foo(1, 2)
     DeprecationWarning: __main__.foo is deprecated: pyiron says no!  It is not
     guaranteed to be in service in vers. 0.5.0
+
+    Alternatively the decorator can also be called with `arguments` set to a dictionary mapping names of keyword
+    arguments to deprecation messages.  In this case the warning will only be emitted when the decorated function is
+    called with arguments in that dictionary.
+
+    >>> deprecate = Deprecator()
+    >>> @deprecate(arguments={"bar": "use baz instead."})
+    ... def foo(bar=None, baz=None):
+    ...     pass
+    >>> foo(baz=True)
+    >>> foo(bar=True)
+    DeprecationWarning: bar is deprecated: use baz instead.
     """
 
     def __init__(self, message=None, version=None, pending=False):
@@ -180,7 +192,8 @@ class Deprecator:
     def wrap(self, function):
         """
         Wrap the given function to emit a DeprecationWarning at call time.  The warning message is constructed from the
-        given message and version.
+        given message and version.  If :attr:`.arguments` is set then the warning is only emitted, when the decorated
+        function is called with keyword arguments found in that dictionary.
 
         Args:
             function (function): function to mark as deprecated

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -134,13 +134,14 @@ class Deprecator:
         self.version = version
         self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
-    def __call__(self, message=None, version=None, arguments={}):
+    def __call__(self, message=None, version=None, arguments={}, **kwargs):
         if isinstance(message, types.FunctionType):
             return self.__deprecate_function(message)
         else:
             self.message = message
             self.version = version
             self.arguments = arguments
+            self.arguments.update(kwargs)
             return self.wrap
 
     def _build_message(self):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -117,7 +117,7 @@ class Deprecator:
     ...     pass
     >>> foo(baz=True)
     >>> foo(bar=True)
-    DeprecationWarning: bar is deprecated: use baz instead.
+    DeprecationWarning: __main__.foo(bar=True) is deprecated: use baz instead.
 
     As a short cut, it is also possible to pass the values in the arguments dict directly as keyword arguments to the
     decorator.
@@ -127,7 +127,7 @@ class Deprecator:
     ...     pass
     >>> foo(baz=True)
     >>> foo(bar=True)
-    DeprecationWarning: bar is deprecated: use baz instead.
+    DeprecationWarning: __main__.foo(bar=True)  is deprecated: use baz instead.
     """
 
     def __init__(self, message=None, version=None, pending=False):
@@ -193,7 +193,13 @@ class Deprecator:
             for kw in kwargs:
                 if kw in self.arguments:
                     warnings.warn(
-                        message_format.format("Argument '{}'".format(kw)),
+                        message_format.format(
+                            "{}.{}({}={})".format(
+                                function.__module__,
+                                function.__name__,
+                                kw,
+                                kwargs[kw])
+                        ),
                         category=self.category,
                         stacklevel=2
                     )

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -130,22 +130,21 @@ class Deprecator:
             self.version = version
             return self.wrap
 
-    def _build_message(self, function):
+    def _build_message(self):
         if self.category == PendingDeprecationWarning:
-            message_format =  "{}.{} is deprecated"
+            message_format =  "{} is deprecated"
         else:
-            message_format =  "{}.{} will be deprecated"
-        message = message_format.format(function.__module__, function.__name__)
+            message_format =  "{} will be deprecated"
 
         if self.message is not None:
-            message += ": {}.".format(self.message)
+            message_format += ": {}.".format(self.message)
         else:
-            message += "."
+            message_format += "."
 
         if self.version is not None:
-            message += " It is not guaranteed to be in service in vers. {}".format(self.version)
+            message_format += " It is not guaranteed to be in service in vers. {}".format(self.version)
 
-        return message
+        return message_format
 
     def wrap(self, function):
         """
@@ -158,7 +157,9 @@ class Deprecator:
         Return:
             function: raises DeprecationWarning when given function is called
         """
-        message = self._build_message(function)
+        message = self._build_message().format(
+                "{}.{}".format(function.__module__, function.__name__)
+        )
 
         @functools.wraps(function)
         def decorated(*args, **kwargs):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -118,6 +118,16 @@ class Deprecator:
     >>> foo(baz=True)
     >>> foo(bar=True)
     DeprecationWarning: bar is deprecated: use baz instead.
+
+    As a short cut, it is also possible to pass the values in the arguments dict directly as keyword arguments to the
+    decorator.
+
+    >>> @deprecate(bar="use baz instead.")
+    ... def foo(bar=None, baz=None):
+    ...     pass
+    >>> foo(baz=True)
+    >>> foo(bar=True)
+    DeprecationWarning: bar is deprecated: use baz instead.
     """
 
     def __init__(self, message=None, version=None, pending=False):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -144,13 +144,13 @@ class Deprecator:
         self.version = version
         self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
-    def __call__(self, message=None, version=None, arguments={}, **kwargs):
+    def __call__(self, message=None, version=None, arguments=None, **kwargs):
         if isinstance(message, types.FunctionType):
             return self.__deprecate_function(message)
         else:
             self.message = message
             self.version = version
-            self.arguments = arguments
+            self.arguments = arguments if arguments is not None else {}
             self.arguments.update(kwargs)
             return self.wrap
 

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -64,5 +64,23 @@ class TestJobType(unittest.TestCase):
         self.assertEqual(w[0].category, PendingDeprecationWarning,
                         "Raised warning is not a PendingDeprecationWarning")
 
+    def test_deprecate_args(self):
+        """DeprecationWarning should only be raised when the given arguments occur."""
+        @deprecate(arguments={"bar": "use foo instead"})
+        def foo(a, foo=None, bar=None):
+            return 2*a
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(foo(1, bar=True), 2,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertTrue(len(w) > 0, "No warning raised!")
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(foo(1, foo=True), 2,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertEqual(len(w), 0, "Warning raised, but deprecated argument was not given.")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -82,5 +82,23 @@ class TestJobType(unittest.TestCase):
                              "return value")
         self.assertEqual(len(w), 0, "Warning raised, but deprecated argument was not given.")
 
+    def test_deprecate_kwargs(self):
+        """DeprecationWarning should only be raised when the given arguments occur, also when given via kwargs."""
+        @deprecate(bar="use baz instead")
+        def foo(a, bar=None, baz=None):
+            return 2*a
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(foo(1, bar=True), 2,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertTrue(len(w) > 0, "No warning raised!")
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(foo(1, baz=True), 2,
+                             "Decorated function does not return original "
+                             "return value")
+        self.assertEqual(len(w), 0, "Warning raised, but deprecated argument was not given.")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds the missing feature to replace most existing deprecation warnings in pyrion.  The code is a bit messier now, but I hope the interface is still clear enough (I added more examples to the docstring).  Am open to refactorings, though.

There was also a bug in the previous PR, where the messages between `pending=False` & `pending=True` were swapped.  This is fixed now.