### PR TITLE
New docs + refactorings in JobGenerator

### DIFF
--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -875,11 +875,20 @@ class GenericOutput(OrderedDict):
 
 class JobGenerator(object):
     """
-    JobGenerator - this class implements the functions to generate the parameter list, modify the individual jobs
-    according to the parameter list and generate the new job names according to the parameter list.
+    Implements the functions to generate the parameter list, modify the individual jobs according to the parameter list
+    and generate the new job names according to the parameter list.
+
+    Subclasses have to override :method:`.parameter_list()` to provide a list of (arbitrary) parameter objects and
+    :method:`.modify_job()` and may override :method:`.job_name()` to provide custom job names.
+
+    The generated jobs are created as child job from the given template job.
     """
 
     def __init__(self, job):
+        """
+        Args:
+            job (:class:`.GenericJob`): template job from which children are created
+        """
         self._job = job
         self._childcounter = 0
         self._parameter_lst_cached = []
@@ -910,7 +919,7 @@ class JobGenerator(object):
             job (:class:`.GenericJob`):
                 new job instance
             parameter (type):
-                current parameter object drawn from :attr:`.parameter_list`.
+                current parameter object drawn from :attribute:`.parameter_list`.
 
         Returns:
             :class:`.GenericJob`: must be the given job
@@ -920,13 +929,13 @@ class JobGenerator(object):
     @staticmethod
     def job_name(parameter):
         """
-        Return new job name from paramter object.  The next child job created
+        Return new job name from parameter object.  The next child job created
         will have this name.  Subclasses may override this to give custom job
         names.
 
         Args:
             parameter (type):
-                current parameter object drawn from :attr:`.parameter_list`.
+                current parameter object drawn from :attribute:`.parameter_list`.
 
         Returns:
             str: job name for the next child job

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -881,15 +881,16 @@ class JobGenerator(object):
     Subclasses have to override :method:`.parameter_list()` to provide a list of (arbitrary) parameter objects and
     :method:`.modify_job()` and may override :method:`.job_name()` to provide custom job names.
 
-    The generated jobs are created as child job from the given template job.
+    The generated jobs are created as child job from the given master.
     """
 
-    def __init__(self, job):
+    def __init__(self, master):
         """
         Args:
-            job (:class:`.GenericJob`): template job from which children are created
+            master (:class:`.ParallelMaster`): master job from which child jobs are created with
+            :method:`.ParallelMaster.create_child_job()`.
         """
-        self._job = job
+        self._master = master
         self._childcounter = 0
         self._parameter_lst_cached = []
 
@@ -939,7 +940,7 @@ class JobGenerator(object):
         Returns:
             str: job name for the next child job
         """
-        return self._job.ref_job.job_name + "_" + str(self._childcounter)
+        return self._master.ref_job.job_name + "_" + str(self._childcounter)
 
     def __iter__(self):
         return self
@@ -959,7 +960,7 @@ class JobGenerator(object):
         """
         if len(self.parameter_list_cached) > self._childcounter:
             current_paramenter = self.parameter_list_cached[self._childcounter]
-            job = self._job.create_child_job(
+            job = self._master.create_child_job(
                 self.job_name(parameter=current_paramenter)
             )
             if job is not None:
@@ -969,5 +970,5 @@ class JobGenerator(object):
             else:
                 raise StopIteration()
         else:
-            self._job.refresh_job_status()
+            self._master.refresh_job_status()
             raise StopIteration()

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -926,8 +926,7 @@ class JobGenerator(object):
         """
         raise NotImplementedError("Implement in derived class")
 
-    @staticmethod
-    def job_name(parameter):
+    def job_name(self, parameter):
         """
         Return new job name from parameter object.  The next child job created
         will have this name.  Subclasses may override this to give custom job

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -895,10 +895,29 @@ class JobGenerator(object):
 
     @property
     def parameter_list(self):
+        """
+        list:
+            parameter objects passed to :method:`.modify_job()` when the next
+            job is requested.
+        """
         raise NotImplementedError("Implement in derived class")
 
     @staticmethod
     def modify_job(job, parameter):
+        """
+        Modify next job with the parameter object.  job is already the newly
+        created job object cloned from the template job, so this function has
+        to return the same instance, but may (and should) modify it.
+
+        Args:
+            job (:class:`.GenericJob`):
+                new job instance
+            parameter (type):
+                current parameter object drawn from :attr:`.parameter_list`.
+
+        Returns:
+            :class:`.GenericJob`: must be the given job
+        """
         raise NotImplementedError("Implement in derived class")
 
     def __iter__(self):

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -920,6 +920,22 @@ class JobGenerator(object):
         """
         raise NotImplementedError("Implement in derived class")
 
+    @staticmethod
+    def job_name(parameter):
+        """
+        Return new job name from paramter object.  The next child job created
+        will have this name.  Subclasses may override this to give custom job
+        names.
+
+        Args:
+            parameter (type):
+                current parameter object drawn from :attr:`.parameter_list`.
+
+        Returns:
+            str: job name for the next child job
+        """
+        return self._job.ref_job.job_name + "_" + str(self._childcounter)
+
     def __iter__(self):
         return self
 
@@ -938,14 +954,9 @@ class JobGenerator(object):
         """
         if len(self.parameter_list_cached) > self._childcounter:
             current_paramenter = self.parameter_list_cached[self._childcounter]
-            if hasattr(self, "job_name"):
-                job = self._job.create_child_job(
-                    self.job_name(parameter=current_paramenter)
-                )
-            else:
-                job = self._job.create_child_job(
-                    self._job.ref_job.job_name + "_" + str(self._childcounter)
-                )
+            job = self._job.create_child_job(
+                self.job_name(parameter=current_paramenter)
+            )
             if job is not None:
                 self._childcounter += 1
                 job = self.modify_job(job=job, parameter=current_paramenter)

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -879,12 +879,9 @@ class JobGenerator(object):
     according to the parameter list and generate the new job names according to the parameter list.
     """
 
-    def __init__(self, job, no_job_checks=False):
+    def __init__(self, job):
         self._job = job
-        if no_job_checks:
-            self._childcounter = len(self._job.child_ids)
-        else:
-            self._childcounter = 0
+        self._childcounter = 0
         self._parameter_lst_cached = []
 
     @property

--- a/tests/master/test_parallelmaster.py
+++ b/tests/master/test_parallelmaster.py
@@ -38,11 +38,14 @@ class TestGenericJob(unittest.TestCase):
         cls.master.ref_job = cls.project.create_job(cls.project.job_type.ScriptJob, "ref")
 
     def test_jobgenerator_name(self):
-        """Generated jobs have to be in order, the correct name and correct parameters."""
+        """Generated jobs have to be unique instances, in order, the correct name and correct parameters."""
         self.assertEqual(len(self.master._job_generator), TestGenerator.test_length,
                          "Incorrect length.")
+        job_set = set()
         for i, j in zip(self.master._job_generator.parameter_list,
                         self.master._job_generator):
+            self.assertTrue(j not in job_set,
+                            "Returned job instance is not a copy.")
             self.assertEqual(j.name, "test_{}".format(i),
                              "Incorrect job name.")
             self.assertEqual(j.input['parameter'], i,

--- a/tests/master/test_parallelmaster.py
+++ b/tests/master/test_parallelmaster.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+import os
+from pyiron_base.project.generic import Project
+from pyiron_base import JobGenerator, ParallelMaster
+
+class TestGenerator(JobGenerator):
+
+    test_length = 10
+
+    @property
+    def parameter_list(self):
+        return list(range(self.test_length))
+
+    def job_name(self, parameter):
+        return "test_{}".format(parameter)
+
+    @staticmethod
+    def modify_job(job, parameter):
+        job.input['parameter'] = parameter
+        return job
+
+class TestMaster(ParallelMaster):
+
+    def __init__(self, job_name, project):
+        super().__init__(job_name, project)
+        self._job_generator = TestGenerator(self)
+
+class TestGenericJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
+        cls.project = Project(os.path.join(cls.file_location, "jobs_testing"))
+        cls.master = cls.project.create_job(TestMaster, "master")
+        cls.master.ref_job = cls.project.create_job(cls.project.job_type.ScriptJob, "ref")
+
+    def test_jobgenerator_name(self):
+        """Generated jobs have to be in order, the correct name and correct parameters."""
+        self.assertEqual(len(self.master._job_generator), TestGenerator.test_length,
+                         "Incorrect length.")
+        for i, j in zip(self.master._job_generator.parameter_list,
+                        self.master._job_generator):
+            self.assertEqual(j.name, "test_{}".format(i),
+                             "Incorrect job name.")
+            self.assertEqual(j.input['parameter'], i,
+                             "Incorrect parameter set on job.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Nothing changes about the interface, but `job_name` is a predefined method now instead of special case.