### PR TITLE
Include master name in generated job name

### DIFF
--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -940,7 +940,7 @@ class JobGenerator(object):
         Returns:
             str: job name for the next child job
         """
-        return self._master.ref_job.job_name + "_" + str(self._childcounter)
+        return '_'.join([self._master.job_name, self._master.ref_job.job_name, str(self._childcounter)])
 
     def __iter__(self):
         return self


### PR DESCRIPTION
When multiple parallel masters use the same reference job, everything runs because the project hdf5 is the parallel master's hdf5, but at the parent project level you can't load the children because their names are not unique. This fixes that, at the cost of longer child names.