### PR TITLE
Refactor project handling for children in master jobs

### DIFF
--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -153,6 +153,17 @@ class GenericMaster(GenericJob):
             return super(GenericMaster, self).child_ids
 
     @property
+    def child_project(self):
+        """
+            :class:`.Project`: project which holds the created child jobs
+        """
+        if not self.server.new_hdf:
+            return self.project
+        else:
+            return self.project.open(self.job_name + "_hdf5")
+
+
+    @property
     def job_object_dict(self):
         """
         internal cache of currently loaded jobs

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -162,6 +162,24 @@ class GenericMaster(GenericJob):
         else:
             return self.project.open(self.job_name + "_hdf5")
 
+    def child_hdf(self, job_name):
+        """
+        Find correct HDF for new children.  Depending on `self.server.new_hdf` this creates a new hdf file or creates
+        the group in the file of this job.
+
+        Args:
+            job_name (str): name of the new job
+
+        Returns:
+            :class:`.ProjectHDFio`: HDF file for new child job, can be assigned to its
+            :attribute:`~.Generic.project_hdf5`
+        """
+        if self.server.new_hdf:
+            return self.project_hdf5.create_hdf(
+                path=self.child_project.path, job_name=job_name
+            )
+        else:
+            return self.project_hdf5.open(job_name)
 
     @property
     def job_object_dict(self):

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -774,17 +774,6 @@ class ParallelMaster(GenericMaster):
         self.status.collect = True
         self.run()
 
-    @property
-    def child_project(self):
-        """
-            :class:`.Project`: project which holds the created child jobs
-        """
-        if not self.server.new_hdf:
-            return self.project
-        else:
-            return self.project.open(self.job_name + "_hdf5")
-
-
     def create_child_job(self, job_name):
         """
         Internal helper function to create the next child job from the reference job template - usually this is called

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -774,25 +774,6 @@ class ParallelMaster(GenericMaster):
         self.status.collect = True
         self.run()
 
-    def child_hdf(self, job_name):
-        """
-        Find correct HDF for new children.  Depending on `self.server.new_hdf` this creates a new hdf file or creates
-        the group in the file of this job.
-
-        Args:
-            job_name (str): name of the new job
-
-        Returns:
-            :class:`.ProjectHDFio`: HDF file for new child job, can be assigned to its
-            :attribute:`~.Generic.project_hdf5`
-        """
-        if self.server.new_hdf:
-            return self.project_hdf5.create_hdf(
-                path=self.child_project.path, job_name=job_name
-            )
-        else:
-            return self.project_hdf5.open(job_name)
-
     def create_child_job(self, job_name):
         """
         Internal helper function to create the next child job from the reference job template - usually this is called

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -774,6 +774,17 @@ class ParallelMaster(GenericMaster):
         self.status.collect = True
         self.run()
 
+    @property
+    def child_project(self):
+        """
+            :class:`.Project`: project which holds the created child jobs
+        """
+        if not self.server.new_hdf:
+            return self.project
+        else:
+            return self.project.open(self.job_name + "_hdf5")
+
+
     def create_child_job(self, job_name):
         """
         Internal helper function to create the next child job from the reference job template - usually this is called
@@ -785,8 +796,8 @@ class ParallelMaster(GenericMaster):
         Returns:
             GenericJob: next job
         """
+        project = self.child_project
         if not self.server.new_hdf:
-            project = self.project
             where_dict = {
                 "job": str(job_name),
                 "project": str(self.project_hdf5.project_path),
@@ -800,7 +811,6 @@ class ParallelMaster(GenericMaster):
             else:
                 job_id = None
         else:
-            project = self.project.open(self.job_name + "_hdf5")
             job_id = project.get_job_id(job_specifier=job_name)
         if job_id is not None:
             ham = project.load(job_id)
@@ -819,7 +829,7 @@ class ParallelMaster(GenericMaster):
         job = self._load_all_child_jobs(job_to_load=job)
         if self.server.new_hdf:
             job.project_hdf5 = self.project_hdf5.create_hdf(
-                path=self.project.open(self.job_name + "_hdf5").path, job_name=job_name
+                path=self.child_project.path, job_name=job_name
             )
         else:
             job.project_hdf5 = self.project_hdf5.open(job_name)

--- a/pyiron_base/master/serial.py
+++ b/pyiron_base/master/serial.py
@@ -343,13 +343,7 @@ class SerialMasterBase(GenericMaster):
         self._logger.info("run serial master {}".format(self.job_info_str))
         job = self.pop(-1)
         job._master_id = self.job_id
-        if self.server.new_hdf:
-            job._hdf5 = self.project_hdf5.create_hdf(
-                path=self.child_project.path,
-                job_name=job.job_name,
-            )
-        else:
-            job._hdf5 = self.project_hdf5.open(job.job_name)
+        job._hdf5 = self.child_hdf(job.job_name)
         self._logger.info("SerialMaster: run job {}".format(job.job_name))
         return job
 

--- a/pyiron_base/master/serial.py
+++ b/pyiron_base/master/serial.py
@@ -345,7 +345,7 @@ class SerialMasterBase(GenericMaster):
         job._master_id = self.job_id
         if self.server.new_hdf:
             job._hdf5 = self.project_hdf5.create_hdf(
-                path=self.project.open(self.job_name + "_hdf5").path,
+                path=self.child_project.path,
                 job_name=job.job_name,
             )
         else:


### PR DESCRIPTION
This adds two properties that make the project in which the children live available.  I'll like to have this to combine pyiron tables with master jobs, otherwise I'll have to fiddle around a lot to find the project to set on the table.


This might also smooth out @liamhuber's problems in #109.  Loading a child job should (no tests on my side) work with
```python
master.child_project.load(job_name)
```

Btw. there's a possibilitiy @jan-janssen's suggestions didn't work.  If @liamhuber's master class sets `job.server.new_hdf=True`, then the project name is "{master_job_name}_hdf5".  I believe this is the default, but I just learned that this exists.  So what should work interim is
```python
pr["master_hdf5"].load(job_name)
```