### PR TITLE
Add a util class for import warnings

### DIFF
--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -250,6 +250,13 @@ class ImportAlarm:
     ...         self.riddles = [Enigma(), Puzzle(), Conundrum()]
     """
     def __init__(self, message=None):
+        """
+        Initialize message value.
+
+        Args:
+            message (str): What to say alongside your ImportError when the decorated function is called. (Default is
+                None, which says nothing and raises no error.)
+        """
         self.message = message
 
     def __call__(self, func):

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -248,6 +248,10 @@ class ImportAlarm:
     ...     def __init__(self, project, job_name)
     ...         super().__init__()
     ...         self.riddles = [Enigma(), Puzzle(), Conundrum()]
+
+    This class is also a context manager that can be used as a short-cut, like this:
+    >>> with ImportAlarm("MysteryJob relies on mystery_package, but this was unavailable.") as import_alarm:
+    ...     import mystery_package
     """
     def __init__(self, message=None):
         """
@@ -269,3 +273,18 @@ class ImportAlarm:
                 warnings.warn(self.message, category=ImportWarning)
             return function(*args, **kwargs)
         return decorator
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type == exc_value == traceback == None:
+            # import successful, so silence our warning
+            self.message = None
+            return
+        if issubclass(exc_type, ImportError):
+            # import broken; retain message, but suppress error
+            return True
+        else:
+            # unrelated error during import, re-raise
+            return False

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -6,6 +6,7 @@ import unittest
 import warnings
 from pyiron_base.generic.util import static_isinstance
 from pyiron_base.generic.util import deprecate, deprecate_soon
+from pyiron_base.generic.util import ImportAlarm
 
 
 class TestJobType(unittest.TestCase):
@@ -99,6 +100,31 @@ class TestJobType(unittest.TestCase):
                              "Decorated function does not return original "
                              "return value")
         self.assertEqual(len(w), 0, "Warning raised, but deprecated argument was not given.")
+
+
+class TestImportAlarm(unittest.TestCase):
+
+    def setUp(self):
+        self.import_alarm = ImportAlarm()
+
+        @self.import_alarm
+        def add_one(x):
+            return x + 1
+
+        self.add_one = add_one
+
+    def test_no_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.add_one(0)
+        self.assertEqual(len(w), 0, "Expected no warnings, but got {} warnings.".format(len(w)))
+
+    def test_has_warning(self):
+        self.import_alarm.message = "Now add_one should throw an ImportWarning"
+
+        with warnings.catch_warnings(record=True, ) as w:
+            self.add_one(1)
+        self.assertEqual(len(w), 1, "Expected one warning, but got {} warnings.".format(len(w)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -111,7 +111,23 @@ class TestImportAlarm(unittest.TestCase):
         def add_one(x):
             return x + 1
 
+        with ImportAlarm("Broken import") as alarm_broken:
+            import ASDF
+
+        @alarm_broken
+        def add_two(x):
+            return x + 2
+
+        with ImportAlarm("Working import") as alarm_working:
+            import sys
+
+        @alarm_working
+        def add_three(x):
+            return x + 3
+
         self.add_one = add_one
+        self.add_two = add_two
+        self.add_three = add_three
 
     def test_no_warning(self):
         with warnings.catch_warnings(record=True) as w:
@@ -121,10 +137,26 @@ class TestImportAlarm(unittest.TestCase):
     def test_has_warning(self):
         self.import_alarm.message = "Now add_one should throw an ImportWarning"
 
-        with warnings.catch_warnings(record=True, ) as w:
+        with warnings.catch_warnings(record=True) as w:
             self.add_one(1)
         self.assertEqual(len(w), 1, "Expected one warning, but got {} warnings.".format(len(w)))
 
+    def test_context(self):
+        """
+        Usage via context manager should give same results and not suppress other errors.
+        """
+
+        with warnings.catch_warnings(record=True) as w:
+            self.add_two(0)
+        self.assertEqual(len(w), 1, "Expected one warning, but got {} warnings.".format(len(w)))
+
+        with warnings.catch_warnings(record=True) as w:
+            self.add_three(0)
+        self.assertEqual(len(w), 0, "Expected one warning, but got {} warnings.".format(len(w)))
+
+        with self.assertRaises(ZeroDivisionError, msg="Context manager should swallow unrelated exceptions"), \
+             ImportAlarm("Unrelated"):
+            print(1/0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As part of resolving [pyiron/pyiron issue #1230](https://github.com/pyiron/pyiron/pull/1230/files), which tackles the problem of not letting users know they're missing imports until they call `run`.

Going forward we could think about automating parts of the message as in the deprecation warning class.