### PR TITLE
enable delete_existing_job when job created via ref_job

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -975,7 +975,7 @@ class GenericJob(JobCore):
         if self.server.send_to_db:
             pass
 
-    def create_job(self, job_type, job_name):
+    def create_job(self, job_type, job_name, delete_existing_job=False):
         """
         Create one of the following jobs:
         - 'StructureContainer’:
@@ -1025,7 +1025,9 @@ class GenericJob(JobCore):
         Returns:
             GenericJob: job object depending on the job_type selected
         """
-        job = self.project.create_job(job_type=job_type, job_name=job_name)
+        job = self.project.create_job(
+            job_type=job_type, job_name=job_name, delete_existing_job=delete_existing_job
+        )
         if static_isinstance(
             obj=job.__class__,
             obj_type=[

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1021,6 +1021,7 @@ class GenericJob(JobCore):
                                              ’TransformationPath’, ‘ThermoIntEamQh’, ‘ThermoIntDftEam’, ‘ScriptJob’,
                                              ‘ListMaster']
             job_name (str): name of the job
+            delete_existing_job (bool): delete an existing job - default false
 
         Returns:
             GenericJob: job object depending on the job_type selected


### PR DESCRIPTION
What was (and still is) possible:

```
master_job = pr.create_job('SomeJob', 'some_job_name', delete_existing_job=True)
master_job.ref_job = child_job
```

What was **not** possible:

```
master_job = child_job.create_job('SomeJob', 'some_job_name', delete_existing_job=True)
```

And this is also what is going to be possible with this PR.