### PR TITLE
Move deprecate to __init__.py

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -2,12 +2,13 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-# API of the pyiron_base module
+# API of the pyiron_base module - in alphabetical order 
+from pyiron_base.generic.factory import PyironFactory
 from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
-from pyiron_base.generic.factory import PyironFactory
+from pyiron_base.generic.util import deprecate
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.external import Notebook
 from pyiron_base.job.generic import GenericJob

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -8,7 +8,7 @@ from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
-from pyiron_base.generic.util import deprecate
+from pyiron_base.generic.util import deprecate, deprecate_soon
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.external import Notebook
 from pyiron_base.job.generic import GenericJob


### PR DESCRIPTION
To enable: 
```
from pyiron_base import deprecate
```