### PR TITLE
Copy deprecator instance on decorating

### DIFF
--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -6,6 +6,7 @@
 Utility functions used in pyiron.
 """
 
+from copy import copy
 import functools
 import types
 import warnings
@@ -144,15 +145,21 @@ class Deprecator:
         self.version = version
         self.category = PendingDeprecationWarning if pending else DeprecationWarning
 
+    def __copy__(self):
+        cp = type(self)(message=self.message, version=self.version)
+        cp.category = self.category
+        return cp
+
     def __call__(self, message=None, version=None, arguments=None, **kwargs):
+        depr = copy(self)
         if isinstance(message, types.FunctionType):
-            return self.__deprecate_function(message)
+            return depr.__deprecate_function(message)
         else:
-            self.message = message
-            self.version = version
-            self.arguments = arguments if arguments is not None else {}
-            self.arguments.update(kwargs)
-            return self.wrap
+            depr.message = message
+            depr.version = version
+            depr.arguments = arguments if arguments is not None else {}
+            depr.arguments.update(kwargs)
+            return depr.wrap
 
     def _build_message(self):
         if self.category == PendingDeprecationWarning:

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -26,6 +26,8 @@ class TestJobType(unittest.TestCase):
         )
         self.assertRaises(TypeError, static_isinstance, list(), 1)
 
+
+class TestDeprecator(unittest.TestCase):
     def test_deprecate(self):
         """Function decorated with `deprecate` should raise a warning."""
         @deprecate
@@ -101,6 +103,21 @@ class TestJobType(unittest.TestCase):
                              "return value")
         self.assertEqual(len(w), 0, "Warning raised, but deprecated argument was not given.")
 
+    def test_instances(self):
+        """Subsequent calls to a Deprecator instance must not interfere with each other."""
+
+        @deprecate(bar="use baz instead")
+        def foo(bar=None, baz=None):
+            pass
+
+        @deprecate(baz="use bar instead")
+        def food(bar=None, baz=None):
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            foo(bar=True)
+            food(baz=True)
+        self.assertEqual(len(w), 2, "Not all warnings preserved.")
 
 class TestImportAlarm(unittest.TestCase):
 


### PR DESCRIPTION
Decorating a function with the Deprecator can change its instance
attributes (if you pass arguments when decorating).  That means that
when decorating different functions the warning shown used only the
arguments from the last call to the deprecator instance.

This is fixed now by copying the deprecator instance before wrapping the
given function.