### PR TITLE
Add decorators to hide functions from __dir__

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -8,6 +8,7 @@ from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
+from pyiron_base.generic.user_dir import mangle_dir, user_facing
 from pyiron_base.generic.util import deprecate, deprecate_soon, ImportAlarm
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.external import Notebook

--- a/pyiron_base/generic/template.py
+++ b/pyiron_base/generic/template.py
@@ -23,6 +23,17 @@ class PyironObject(object):
     Template class to list the required properties and functions for every pyiron object.
     """
 
+    def __init__(self):
+        self._user_dir_active = True
+
+    def __dir__(self):
+        # accessing via __class__ makes sure we get the class attribute defined by the class decorator and cannot be
+        # overridden by instances
+        if not self._user_dir_active or len(self.__class__._user_dir) == 0:
+            return object.__dir__(self)
+        else:
+            return self.__class__._user_dir
+
     @property
     def id(self):
         """

--- a/pyiron_base/generic/user_dir.py
+++ b/pyiron_base/generic/user_dir.py
@@ -1,0 +1,18 @@
+"""
+Decorators to manipulate the __dir__ of user facing classes to show UI functions only.
+"""
+
+def add_user_facing_attr(inst, name):
+    inst._user_dir.append(name)
+
+def user_facing(method):
+    method.user_facing = True
+    return method
+
+def mangle_dir(cls):
+    dir_list = getattr(cls, "_user_dir", [])
+    for name, desc in cls.__dict__.items():
+        if hasattr(desc, "user_facing"):
+            dir_list.append(name)
+    cls._user_dir = dir_list
+    return cls


### PR DESCRIPTION
This adds a method decorator and a class decorator to mark methods of a as "user facing" which will then be shown in `__dir__`.  The class decorator is also needed to make the method decorators work.  It has a toggle on each job instance to restore the default `__dir__`, maybe we rather want that to live in the `Settings` object.

Short example of usage (modulo naming)
```python
from pyiron_base import GenericJob, mangle_dir, user_facing

@mangle_dir
class A(GenericJob):

    def plumbing(self):
        return 42

    @user_facing
    def ui(self):
        return 23
```

Alternatives are #143, #147.