### PR TITLE
Add class to hide members of others

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -8,6 +8,7 @@ from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
+from pyiron_base.generic.uiwrapper import UIWrapper, user_facing
 from pyiron_base.generic.util import deprecate, deprecate_soon, ImportAlarm
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.external import Notebook

--- a/pyiron_base/generic/uiwrapper.py
+++ b/pyiron_base/generic/uiwrapper.py
@@ -1,0 +1,43 @@
+import inspect
+
+def user_facing(method):
+    method.user_facing = True
+    return method
+
+class UIWrapper:
+
+    __slots__ = ["_delegate", "_public"]
+
+    def __init__(self, delegate, public=None):
+        self._delegate = delegate
+        self._public   = getattr(delegate, "_user_facing", [])
+        if public is not None:
+            self._public += public
+        members = inspect.getmembers(self._delegate)
+        for name, attr in members:
+            if inspect.ismethod(attr) and hasattr(attr, "user_facing"):
+                self._public.append(name)
+        # if no user_facing are found, give full access to the wrapped instance
+        if len(self._public) == 0:
+            self._public = list(members.keys())
+
+    def __getattr__(self, name):
+        if name in self._public:
+            return getattr(self._delegate, name)
+        else:
+            raise AttributeError("'{}' object has no attribute '{}'".format(self._delegate.__class__, name))
+
+    def __setattr__(self, name, value):
+        if name in self.__slots__:
+            object.__setattr__(self, name, value)
+        elif name in self._public:
+            return setattr(self._delegate, name, value)
+        else:
+            raise AttributeError("'{}' object has no attribute '{}'".format(self._delegate.__class__, name))
+
+    def __dir__(self):
+        return self._public
+
+    @property
+    def wrapped(self):
+        return self._delegate


### PR DESCRIPTION
Adds a method that wraps the job class and is given a list of attributes/methods.  All access to these attributes is proxied to the job, otherwise an `AttributeError` is raised.

Short usage example
```python
from pyiron_base import GenericJob, UIWrapper, user_facing

class A(GenericJob):
    def __init__(self, *args):
        super().__init__(*args)
        self.a = 42
        self._user_facing=['a']
    def f(self):
        pass
    @user_facing
    def g(self):
        pass

...

j = UIWrapper(pr.create_job(A, 'test'))
j.f()
j.a = 24
assert j.wrapped.a == 24
```

We could then modify the JobCreators to wrap jobs in this class before giving the references to the user.

Alternatives are #143, #146.
