### PR TITLE
Fix loading jobs from imported projects

### DIFF
--- a/pyiron_base/job/path.py
+++ b/pyiron_base/job/path.py
@@ -473,7 +473,7 @@ class JobPath(JobPathBase):
             job_path = db_entry["projectpath"]
         else:
             job_path = ''
-        job_path += db_entry["project"] + hdf5_file + db_entry["subjob"]
+        job_path = os.path.join(job_path, db_entry["project"], hdf5_file) + db_entry["subjob"]
         super(JobPath, self).__init__(job_path=job_path)
 
         if "hamilton" in db_entry.keys():

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -19,6 +19,7 @@ class ToyJob(PythonTemplateJob):
             h5out["energy_tot"] = self.input["input_energy"]
         self.status.finished = True
 
+TEST_JOB_NAME="toy"
 
 class TestUnpacking(unittest.TestCase):
     @classmethod
@@ -29,7 +30,7 @@ class TestUnpacking(unittest.TestCase):
         cls.arch_dir_comp = cls.arch_dir+'_comp'
         cls.pr = Project('test')
         cls.pr.remove_jobs_silently(recursive=True)
-        cls.job = cls.pr.create_job(job_type=ToyJob, job_name='toy')
+        cls.job = cls.pr.create_job(job_type=ToyJob, job_name=TEST_JOB_NAME)
         cls.job.run()
         cls.pr.pack(destination_path=cls.arch_dir_comp, compress=True)
         cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
@@ -88,6 +89,14 @@ class TestUnpacking(unittest.TestCase):
         path_import = getdir(path_import)
         compare_obj = dircmp(path_original, path_import)
         self.assertEqual(len(compare_obj.diff_files), 0)
+
+    def test_load_job(self):
+        """Jobs should be able to load from the imported project."""
+
+        try:
+            j = self.imp_pr.load(TEST_JOB_NAME)
+        except Exception as e:
+            self.fail(msg="Loading job fails with {}".format(str(e)))
 
 
 if __name__ == "__main__":

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -93,11 +93,26 @@ class TestUnpacking(unittest.TestCase):
     def test_load_job(self):
         """Jobs should be able to load from the imported project."""
 
+        self.imp_pr.remove_jobs_silently(recursive=True)
+        self.pr.pack(destination_path=self.arch_dir_comp, compress=True)
+        self.imp_pr.unpack(origin_path=self.arch_dir_comp, compress=True)
         try:
             j = self.imp_pr.load(TEST_JOB_NAME)
         except Exception as e:
             self.fail(msg="Loading job fails with {}".format(str(e)))
 
+    def test_check_job_parameters(self):
+        """Imported jobs should be equal to their originals in all their parameters."""
+
+        self.imp_pr.remove_jobs_silently(recursive=True)
+        self.pr.pack(destination_path=self.arch_dir_comp, compress=True)
+        self.imp_pr.unpack(origin_path=self.arch_dir_comp, compress=True)
+
+        j = self.imp_pr.load(TEST_JOB_NAME)
+        self.assertEqual(self.job.input["input_energy"], j.input["input_energy"],
+                         "Input values not properly copied to imported job.")
+        self.assertEqual(self.job["output/energy_tot"], j["output/energy_tot"],
+                         "Input values not properly copied to imported job.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previously loading a job from an imported caused an error due to some wrong paths (see [here](https://github.com/pyiron/pyiron_base/pull/177/commits/38e3f0c4ace3a7d939ef3b4527c2f3741e082d8b)).  There was also an independent bug in `JobPath` when constructing the paths to the HDF5 file that was triggered by this. 

@muh-hassani I had to do some extra boilerplate in the new test cases because the other cases re-use `imp_pr`.  Without re-packing the original project it fails, can you take a look?   Generally please structure tests so that they may be run independently from each other, it greatly simplifies adding new tests.