### PR TITLE
Project data

### DIFF
--- a/pyiron_base/job/external.py
+++ b/pyiron_base/job/external.py
@@ -25,6 +25,8 @@ __date__ = "Sep 1, 2019"
 class Notebook(object):
     """
     class for pyiron notebook objects
+
+    # TODO: Extract JSON functionality over to Project.data.read/write and remove this file.
     """
 
     @staticmethod

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -3,8 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 """
-A modified data container for storing associating data with a project. Here is more worthless text trying to see what
-it takes to get codacy to shut up.
+A modified data container for storing associating data with a project.
 
 Spec:
     The `Project` class should have data associated with it which can be stored to-file in our supported format(s)
@@ -39,8 +38,7 @@ class ProjectData(InputList):
 
     def __init__(self, *args, project=None, **kwargs):
         """
-        A data storage container which can store itself to/retrieve itself from file at the project level. This is some
-        extra text to try to get Codacy to shut up.
+        A data storage container which can store itself to/retrieve itself from file at the project level.
 
         Args:
             project (pyiron_base.Project): The project instance the storage is attached to.

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -48,16 +48,12 @@ class ProjectData(InputList):
         self._project = project
 
     def read(self):
-        """
-        Read existing data from project-level storage.
-        """
+        """Read existing data from project-level storage."""
         hdf = ProjectHDFio(self._project, file_name="project_data")
         if self.table_name not in hdf.list_groups():
             raise KeyError(f"Table name {self.table_name} was not found -- Project data is empty.")
         self.from_hdf(hdf=hdf)
 
     def write(self):
-        """
-        Write data to project-level storage.
-        """
+        """Write data to project-level storage."""
         self.to_hdf(ProjectHDFio(self._project, file_name="project_data"))

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -7,14 +7,13 @@ A modified data container for storing associating data with a project. Here is m
 it takes to get codacy to shut up.
 
 Spec:
+    The `Project` class should have data associated with it which can be stored to-file in our supported format(s)
+    (right now just hdf5). This should meet the following requirements:
 
-The `Project` class should have data associated with it which can be stored to-file in our supported format(s) (right
-now just hdf5). This should meet the following requirements:
-
-- Data storage is immediately accessible, i.e. appearing in the project tab-completion module
-- Data stored there should be readable and writeable with a single parameter-free call
-- When instantiated, new projects should automatically read any available data (not *quite* satisfied right now!)
-- The `Project` tab completion menu should not get cluttered (i.e. nest everything under `Project.foo`)
+    - Data storage is immediately accessible, i.e. appearing in the project tab-completion module
+    - Data stored there should be readable and writeable with a single parameter-free call
+    - When instantiated, new projects should automatically read any available data (not *quite* satisfied right now!)
+    - The `Project` tab completion menu should not get cluttered (i.e. nest everything under `Project.foo`)
 """
 
 from pyiron_base.generic.inputlist import InputList

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -4,6 +4,16 @@
 
 """
 A modified data container for storing associating data with a project.
+
+Spec:
+
+The `Project` class should have data associated with it which can be stored to-file in our supported format(s) (right
+now just hdf5). This should meet the following requirements:
+
+- Data storage is immediately accessible, i.e. appearing in the project tab-completion module
+- Data stored there should be readable and writeable with a single parameter-free call
+- When instantiated, new projects should automatically read any available data
+- The `Project` tab completion menu should not get cluttered (i.e. nest everything under `Project.foo`)
 """
 
 from pyiron_base.generic.inputlist import InputList

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -3,7 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 """
-A modified data container for storing associating data with a project.
+A modified data container for storing associating data with a project. Here is more worthless text trying to see what
+it takes to get codacy to shut up.
 
 Spec:
 

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -12,7 +12,7 @@ now just hdf5). This should meet the following requirements:
 
 - Data storage is immediately accessible, i.e. appearing in the project tab-completion module
 - Data stored there should be readable and writeable with a single parameter-free call
-- When instantiated, new projects should automatically read any available data
+- When instantiated, new projects should automatically read any available data (not *quite* satisfied right now!)
 - The `Project` tab completion menu should not get cluttered (i.e. nest everything under `Project.foo`)
 """
 
@@ -38,14 +38,26 @@ class ProjectData(InputList):
         return instance
 
     def __init__(self, *args, project=None, **kwargs):
+        """
+        A data storage container which can store itself to/retrieve itself from file at the project level.
+
+        Args:
+            project (pyiron_base.Project): The project instance the storage is attached to.
+        """
         super().__init__(*args, **kwargs)
         self._project = project
 
     def read(self):
+        """
+        Read existing data from project-level storage.
+        """
         hdf = ProjectHDFio(self._project, file_name="project_data")
         if self.table_name not in hdf.list_groups():
             raise KeyError(f"Table name {self.table_name} was not found -- Project data is empty.")
         self.from_hdf(hdf=hdf)
 
     def write(self):
+        """
+        Write data to project-level storage.
+        """
         self.to_hdf(ProjectHDFio(self._project, file_name="project_data"))

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -2,8 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-"""
-A modified data container for storing associating data with a project.
+"""A modified data container for storing associating data with a project.
 
 Spec:
 

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -2,7 +2,8 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-"""A modified data container for storing associating data with a project.
+"""
+A modified data container for storing associating data with a project.
 
 Spec:
 
@@ -38,7 +39,8 @@ class ProjectData(InputList):
 
     def __init__(self, *args, project=None, **kwargs):
         """
-        A data storage container which can store itself to/retrieve itself from file at the project level.
+        A data storage container which can store itself to/retrieve itself from file at the project level. This is some
+        extra text to try to get Codacy to shut up.
 
         Args:
             project (pyiron_base.Project): The project instance the storage is attached to.

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+"""
+A modified data container for storing associating data with a project.
+"""
+
+from pyiron_base.generic.inputlist import InputList
+from pyiron_base.generic.hdfio import ProjectHDFio
+
+__author__ = "Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "0.1"
+__maintainer__ = "Jan Janssen"
+__email__ = "janssen@mpie.de"
+__status__ = "production"
+__date__ = "Feb 19, 2021"
+
+
+class ProjectData(InputList):
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls, *args, **kwargs)
+        object.__setattr__(instance, "project", None)
+        return instance
+
+    def __init__(self, project, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.project = project
+
+    def read(self):
+        hdf = ProjectHDFio(self.project, file_name="project_data")
+        if self.table_name not in hdf.list_groups():
+            raise KeyError(f"Table name {self.table_name} was not found -- Project data is empty.")
+        self.from_hdf(hdf=hdf)
+
+    def write(self):
+        self.to_hdf(ProjectHDFio(self.project, file_name="project_data"))

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -15,8 +15,8 @@ __copyright__ = (
     "Computational Materials Design (CM) Department"
 )
 __version__ = "0.1"
-__maintainer__ = "Jan Janssen"
-__email__ = "janssen@mpie.de"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
 __status__ = "production"
 __date__ = "Feb 19, 2021"
 

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -37,7 +37,7 @@ class ProjectData(InputList):
         object.__setattr__(instance, "project", None)
         return instance
 
-    def __init__(self, project, *args, **kwargs):
+    def __init__(self, *args, project=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.project = project
 

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -34,18 +34,18 @@ __date__ = "Feb 19, 2021"
 class ProjectData(InputList):
     def __new__(cls, *args, **kwargs):
         instance = super().__new__(cls, *args, **kwargs)
-        object.__setattr__(instance, "project", None)
+        object.__setattr__(instance, "_project", None)
         return instance
 
     def __init__(self, *args, project=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.project = project
+        self._project = project
 
     def read(self):
-        hdf = ProjectHDFio(self.project, file_name="project_data")
+        hdf = ProjectHDFio(self._project, file_name="project_data")
         if self.table_name not in hdf.list_groups():
             raise KeyError(f"Table name {self.table_name} was not found -- Project data is empty.")
         self.from_hdf(hdf=hdf)
 
     def write(self):
-        self.to_hdf(ProjectHDFio(self.project, file_name="project_data"))
+        self.to_hdf(ProjectHDFio(self._project, file_name="project_data"))

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -75,53 +75,19 @@ class Project(ProjectPath):
                                     directory.
 
     Attributes:
-
-        .. attribute:: root_path
-
-            the pyiron user directory, defined in the .pyiron configuration
-
-        .. attribute:: project_path
-
-            the relative path of the current project / folder starting from the root path
-            of the pyiron user directory
-
-        .. attribute:: path
-
-            the absolute path of the current project / folder
-
-        .. attribute:: base_name
-
-            the name of the current project / folder
-
-        .. attribute:: history
-
-            previously opened projects / folders
-
-        .. attribute:: parent_group
-
-            parent project - one level above the current project
-
-        .. attribute:: user
-
-            current unix/linux/windows user who is running pyiron
-
-        .. attribute:: sql_query
-
-            an SQL query to limit the jobs within the project to a subset which matches the SQL query.
-
-        .. attribute:: db
-
-            connection to the SQL database
-
-        .. attribute:: job_type
-
-            Job Type object with all the available job types: ['ExampleJob', 'SerialMaster', 'ParallelMaster',
-                                                               'ScriptJob', 'ListMaster']
-
-        .. attribute:: view_mode
-
-            If viewer_mode is enable pyiron has read only access to the database.
-
+        root_path (): The pyiron user directory, defined in the .pyiron configuration.
+        project_path (): The relative path of the current project / folder starting from the root path of the pyiron
+                            user directory
+        path (): The absolute path of the current project / folder.
+        base_name (): The name of the current project / folder.
+        history (): Previously opened projects / folders.
+        parent_group (): Parent project - one level above the current project.
+        user (): Current unix/linux/windows user who is running pyiron
+        sql_query (): An SQL query to limit the jobs within the project to a subset which matches the SQL query.
+        db (): Connection to the SQL database.
+        job_type (): Job Type object with all the available job types: ['ExampleJob', 'SerialMaster', 'ParallelMaster',
+                        'ScriptJob', 'ListMaster'].
+        view_mode (): If viewer_mode is enable pyiron has read only access to the database.
     """
 
     def __init__(self, path="", user=None, sql_query=None, default_working_directory=False):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -43,6 +43,7 @@ from pyiron_base.server.queuestatus import (
     queue_check_job_is_waiting_or_running,
 )
 from pyiron_base.job.external import Notebook
+from pyiron_base.project.data import ProjectData
 
 from pyiron_base.archiving import import_archive, export_archive
 
@@ -147,6 +148,13 @@ class Project(ProjectPath):
             self.db = FileTable(project=path)
         self.job_type = JobTypeChoice()
 
+        self._data = ProjectData(project=self, table_name="data")
+        # Auto-loading existing data -- Explodes atm, but why?!
+        # try:
+        #     self._data.read()
+        # except (KeyError, AttributeError):
+        #     pass  # Don't worry if it's empty
+
     @property
     def parent_group(self):
         """
@@ -188,6 +196,10 @@ class Project(ProjectPath):
     @property
     def create(self):
         return self._creator
+
+    @property
+    def data(self):
+        return self._data
 
     def copy(self):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -149,11 +149,9 @@ class Project(ProjectPath):
         self.job_type = JobTypeChoice()
 
         self._data = ProjectData(project=self, table_name="data")
-        # Auto-loading existing data -- Explodes atm, but why?!
-        # try:
-        #     self._data.read()
-        # except (KeyError, AttributeError):
-        #     pass  # Don't worry if it's empty
+        # TODO: Read the data here, if it exists.
+        #       Currently this keeps giving a recursion error because ProjectHDFio instantiation copies the project
+        #       which then tries to read, which instantiates a ProjectHDFio, which copies the project... Ugh.
 
     @property
     def parent_group(self):
@@ -199,6 +197,11 @@ class Project(ProjectPath):
 
     @property
     def data(self):
+        if len(self._data) == 0:  # This is just a workaround because loading in __init__ is not working
+            try:
+                self._data.read()
+            except KeyError:
+                pass
         return self._data
 
     def copy(self):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -88,6 +88,18 @@ class Project(ProjectPath):
         job_type (): Job Type object with all the available job types: ['ExampleJob', 'SerialMaster', 'ParallelMaster',
                         'ScriptJob', 'ListMaster'].
         view_mode (): If viewer_mode is enable pyiron has read only access to the database.
+        data (pyiron_base.project.data.ProjectData): A storage container for project-level data.
+
+    Examples:
+
+        Storing data:
+            >>> pr = Project('example')
+            >>> pr.data.foo = 42
+            >>> pr.data.write()
+            Some time later or in a different notebook, but in the same file location...
+            >>> other_pr_instance = Project('example')
+            >>> print(pr.data)
+            {'foo': 42}
     """
 
     def __init__(self, path="", user=None, sql_query=None, default_working_directory=False):

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -12,7 +12,7 @@ class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project_name = join(cls.file_location, "test_sriptjob")
+        cls.project_name = join(cls.file_location, "test_sriptjob").replace("\\", "/")
         cls.project = Project(cls.project_name)
         cls.simple_script = join(cls.file_location, 'simple.py')
         cls.complex_script = join(cls.file_location, 'complex.py')

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -47,7 +47,6 @@ class TestScriptJob(unittest.TestCase):
         with open(self.complex_script, 'w') as f:
             f.write("from pyiron_base import Project\n")
             f.write(f"pr = Project('{self.project_name}')\n")
-            f.write("pr.data.read()\n")  # TODO: Remove this line once data is auto-reading
             f.write("pr.data.out = pr.data.in_ * 7\n")
             f.write("pr.data.write()\n")
         self.job.script_path = self.complex_script

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -12,8 +12,8 @@ class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project_name = join(cls.file_location, "test_sriptjob").replace("\\", "/")  # replace to satisfy windows
-        cls.project = Project(cls.project_name)
+        cls.project_abspath = join(cls.file_location, "test_sriptjob").replace("\\", "/")  # replace to satisfy windows
+        cls.project = Project(cls.project_abspath)
         cls.simple_script = join(cls.file_location, 'simple.py')
         cls.complex_script = join(cls.file_location, 'complex.py')
 
@@ -46,9 +46,11 @@ class TestScriptJob(unittest.TestCase):
         self.project.data.write()
         with open(self.complex_script, 'w') as f:
             f.write("from pyiron_base import Project\n")
-            f.write(f"pr = Project('{self.project_name}')\n")
+            f.write(f"pr = Project('{self.project_abspath}')\n")
             f.write("pr.data.out = pr.data.in_ * 7\n")
             f.write("pr.data.write()\n")
+        # WARNING: If a user parallelizes this with multiple ScriptJobs, it would be possible to get a log jam with
+        #          multiple simultaneous write-calls.
         self.job.script_path = self.complex_script
         self.job.run()
         self.project.data.read()

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -3,26 +3,25 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
-import os
+from os.path import dirname, abspath, join
 from pyiron_base.project.generic import Project
 
 
 class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
-            "\\", "/"
-        )
-        cls.project = Project(os.path.join(cls.file_location, "test_sriptjob"))
+        cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
+        cls.project = Project(join(cls.file_location, "test_sriptjob"))
 
     @classmethod
     def tearDownClass(cls):
         cls.project.remove(enable=True)
 
     def test_script_path(self):
-        job = self.project.create_job('ScriptJob', 'script')
+        job = self.project.create.job.ScriptJob('script')
         with self.assertRaises(TypeError):
             job.run()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -20,8 +20,11 @@ class TestScriptJob(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.project.remove(enable=True)
-        remove(cls.simple_script)
-        remove(cls.complex_script)
+        for file in [cls.simple_script, cls.complex_script]:
+            try:
+                remove(file)
+            except FileNotFoundError:
+                continue
 
     def setUp(self):
         self.job = self.project.create.job.ScriptJob('script')

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -12,7 +12,7 @@ class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project_name = join(cls.file_location, "test_sriptjob").replace("\\", "/")
+        cls.project_name = join(cls.file_location, "test_sriptjob").replace("\\", "/")  # replace to satisfy windows
         cls.project = Project(cls.project_name)
         cls.simple_script = join(cls.file_location, 'simple.py')
         cls.complex_script = join(cls.file_location, 'complex.py')

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -4,6 +4,7 @@
 
 import unittest
 from os.path import dirname, abspath, join
+from os import remove
 from pyiron_base.project.generic import Project
 
 
@@ -11,16 +12,45 @@ class TestScriptJob(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project = Project(join(cls.file_location, "test_sriptjob"))
+        cls.project_name = join(cls.file_location, "test_sriptjob")
+        cls.project = Project(cls.project_name)
+        cls.simple_script = join(cls.file_location, 'simple.py')
+        cls.complex_script = join(cls.file_location, 'complex.py')
 
     @classmethod
     def tearDownClass(cls):
         cls.project.remove(enable=True)
+        remove(cls.simple_script)
+        remove(cls.complex_script)
+
+    def setUp(self):
+        self.job = self.project.create.job.ScriptJob('script')
+
+    def tearDown(self):
+        self.project.remove_job('script')
 
     def test_script_path(self):
-        job = self.project.create.job.ScriptJob('script')
         with self.assertRaises(TypeError):
-            job.run()
+            self.job.run()
+
+        with open(self.simple_script, 'w') as f:
+            f.write("print(42)")
+        self.job.script_path = self.simple_script
+        self.job.run()
+
+    def test_project_data(self):
+        self.project.data.in_ = 6
+        self.project.data.write()
+        with open(self.complex_script, 'w') as f:
+            f.write("from pyiron_base import Project\n")
+            f.write(f"pr = Project('{self.project_name}')\n")
+            f.write("pr.data.read()\n")  # TODO: Remove this line once data is auto-reading
+            f.write("pr.data.out = pr.data.in_ * 7\n")
+            f.write("pr.data.write()\n")
+        self.job.script_path = self.complex_script
+        self.job.run()
+        self.project.data.read()
+        self.assertEqual(42, self.project.data.out)
 
 
 if __name__ == "__main__":

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -17,7 +17,10 @@ class TestProjectData(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        remove(join(cls.file_location, "pyiron.log"))
+        try:
+            remove(join(cls.file_location, "pyiron.log"))
+        except FileNotFoundError:
+            pass
 
     def tearDown(self):
         self.project.remove(enable=True)

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -24,7 +24,7 @@ class TestProjectData(unittest.TestCase):
 
     def setUp(self):
         self.project = Project(self.project_name)
-        self.data = ProjectData(self.project, table_name="data")
+        self.data = ProjectData(project=self.project, table_name="data")
         self.data.foo = "foo"
         self.data.bar = 42
 
@@ -36,7 +36,7 @@ class TestProjectData(unittest.TestCase):
     def test_new_instance(self):
         self.data.write()
 
-        data2 = ProjectData(self.project, table_name="data")
+        data2 = ProjectData(project=self.project, table_name="data")
         self.assertEqual(len(data2), 0)
         data2.read()
         self.assertEqual(data2.foo, self.data.foo)
@@ -48,7 +48,7 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(3, len(self.data.baz))
         self.assertEqual(2, len(self.data.baz[-1]))
 
-        data2 = ProjectData(self.project, table_name="data")
+        data2 = ProjectData(project=self.project, table_name="data")
         data2.read()
         self.assertEqual(3, len(data2.baz))
         self.assertEqual(2, len(data2.baz[-1]))

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+from os.path import dirname, join, abspath
+from os import remove
+from pyiron_base.project.generic import Project
+from pyiron_base.project.data import ProjectData
+
+
+class TestProjectData(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
+        cls.project_name = join(cls.file_location, "test_data")
+
+    @classmethod
+    def tearDownClass(cls):
+        remove(join(cls.file_location, "pyiron.log"))
+
+    def tearDown(self):
+        self.project.remove(enable=True)
+
+    def setUp(self):
+        self.project = Project(self.project_name)
+        self.data = ProjectData(self.project, table_name="data")
+        self.data.foo = "foo"
+        self.data.bar = 42
+
+    def test_empty_reading(self):
+        self.assertRaises(KeyError, self.data.read)
+        self.data.write()
+        self.data.read()
+
+    def test_new_instance(self):
+        self.data.write()
+
+        data2 = ProjectData(self.project, table_name="data")
+        self.assertEqual(len(data2), 0)
+        data2.read()
+        self.assertEqual(data2.foo, self.data.foo)
+        self.assertEqual(data2.bar, self.data.bar)
+
+    def test_reading_recursion(self):
+        self.data.baz = [1, 2, [3, 3]]
+        self.data.write()
+        self.assertEqual(3, len(self.data.baz))
+        self.assertEqual(2, len(self.data.baz[-1]))
+
+        data2 = ProjectData(self.project, table_name="data")
+        data2.read()
+        self.assertEqual(3, len(data2.baz))
+        self.assertEqual(2, len(data2.baz[-1]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -49,7 +49,6 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(2, len(self.data.baz[-1]))
 
         data2 = ProjectData(project=self.project, table_name="data")
-        data2.read()
         self.assertEqual(3, len(data2.baz))
         self.assertEqual(2, len(data2.baz[-1]))
 

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -49,6 +49,7 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(2, len(self.data.baz[-1]))
 
         data2 = ProjectData(project=self.project, table_name="data")
+        data2.read()
         self.assertEqual(3, len(data2.baz))
         self.assertEqual(2, len(data2.baz[-1]))
 

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -16,7 +16,10 @@ class TestProjectData(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        remove(join(cls.file_location, "pyiron.log"))
+        try:
+            remove(join(cls.file_location, "pyiron.log"))
+        except FileNotFoundError:
+            pass
 
     def setUp(self):
         self.project = Project(self.project_name)

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+from os.path import dirname, join, abspath
+from os import remove
+from pyiron_base.project.generic import Project
+
+
+class TestProjectData(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
+        cls.project_name = join(cls.file_location, "test_project")
+
+    @classmethod
+    def tearDownClass(cls):
+        remove(join(cls.file_location, "pyiron.log"))
+
+    def setUp(self):
+        self.project = Project(self.project_name)
+
+    def tearDown(self):
+        self.project.remove(enable=True)
+
+    def test_data(self):
+        self.assertRaises(KeyError, self.project.data.read)
+
+        self.project.data.foo = "foo"
+        self.project.data.write()
+        self.project.data.read()
+        self.assertEqual(1, len(self.project.data))
+
+        project2 = Project(self.project_name)
+        self.assertEqual(1, len(project2.data))
+        self.assertEqual(self.project.data.foo, project2.data.foo)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Projects now have an input list attached to themselves for storing project-level data. The motivation was to come up with a more transparent implementation of the current `Notebook` class and associated `Project.get_external_input` method. The original code is only used for `ScriptJob`, and I extended the test suite there to make sure this new functionality does indeed work for it, but I could imagine it being useful in other circumstances too.

@pmrv there are two outstanding issues I'm really having trouble with, and I left failing tests in for them both:
- `InputList` recursion isn't working well and complex data types get loaded as empty containers.
- I want projects to try to auto-load data on instantiation but I get caught in some horrible error loop I don't understand. I left a bit of commented out code in `Project.__init__` that I really *wish* worked.

@raynol-dsouza note that this will impact the syntax for #171.

I'm also open to some critical feedback on any bad side-effects this might have that I'm missing.