### PR TITLE
Set job class name from type(self), so sub classes don't have to

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -151,7 +151,7 @@ class GenericJob(JobCore):
 
     def __init__(self, project, job_name):
         super(GenericJob, self).__init__(project, job_name)
-        self.__name__ = "GenericJob"
+        self.__name__ = type(self).__name__
         self.__version__ = "0.4"
         self.__hdf_version__ = "0.1.0"
         self._server = Server()

--- a/pyiron_base/master/flexible.py
+++ b/pyiron_base/master/flexible.py
@@ -119,7 +119,6 @@ class FlexibleMaster(GenericMaster):
 
     def __init__(self, project, job_name):
         super(FlexibleMaster, self).__init__(project, job_name=job_name)
-        self.__name__ = "FlexibleMaster"
         self.__version__ = "0.1"
         self._step_function_lst = []
 

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -129,7 +129,6 @@ class ListMaster(GenericMaster):
     def __init__(self, project, job_name):
         self._input = GenericParameters("parameters")
         super(ListMaster, self).__init__(project, job_name=job_name)
-        self.__name__ = "ListMaster"
         self.__version__ = "0.1"
         self._input["mode"] = "parallel"
         self.submission_status = SubmissionStatus(db=project.db, job_id=self.job_id)

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -145,7 +145,6 @@ class ParallelMaster(GenericMaster):
     def __init__(self, project, job_name):
         self.input = GenericParameters("parameters")
         super(ParallelMaster, self).__init__(project, job_name=job_name)
-        self.__name__ = "ParallelMaster"
         self.__version__ = "0.3"
         self._ref_job = None
         self._output = GenericOutput()

--- a/pyiron_base/master/serial.py
+++ b/pyiron_base/master/serial.py
@@ -133,7 +133,6 @@ class SerialMasterBase(GenericMaster):
         self._input = GenericParameters("parameters")  # e.g. convergence goal
 
         super(SerialMasterBase, self).__init__(project, job_name=job_name)
-        self.__name__ = "SerialMaster"
         self.__version__ = "0.3"
 
         self._output = GenericOutput()


### PR DESCRIPTION
When creating new job classes, I keep forgetting to set `self.__name__` correctly.  This updates `GenericJob` to do it automatically.

EDIT: This could still make problems when deriving from sub-classes of `GenericJob` (i.e. masters and atomistic jobs), because they might overwrite it again, but I haven't checked it yet.