### PR TITLE
Re-export FlexibleMaster

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -21,6 +21,7 @@ from pyiron_base.master.generic import GenericMaster, get_function_from_string
 from pyiron_base.master.list import ListMaster
 from pyiron_base.master.parallel import ParallelMaster, JobGenerator
 from pyiron_base.master.serial import SerialMasterBase
+from pyiron_base.master.flexible import FlexibleMaster
 from pyiron_base.project.generic import Project, Creator
 from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
 from pyiron_base.server.queuestatus import validate_que_request


### PR DESCRIPTION
For some reason all the other master are re-exported at the pyiron_base top-level, but this one isn't.