### PR TITLE
Move initialization of ref_job to GenericMaster._init_child_job

### DIFF
--- a/pyiron_base/job/interactivewrapper.py
+++ b/pyiron_base/job/interactivewrapper.py
@@ -153,15 +153,6 @@ class InteractiveWrapper(GenericMaster):
         self.send_to_database()
         self.update_master()
 
-    def _init_child_job(self, parent):
-        """
-        Set the job that created us as reference job.
-
-        Args:
-            master (:class:`.GenericJob`): job instance that this job was created from
-        """
-        self.ref_job = parent
-
     def __getitem__(self, item):
         """
         Get/ read data from the GenericMaster

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -626,6 +626,14 @@ class GenericMaster(GenericJob):
         """
         pass
 
+    def _init_child_job(self, parent):
+        """
+        Update our reference job.
+
+        Args:
+            parent (:class:`.GenericJob`): job instance that this job was created from
+        """
+        self.ref_job = parent
 
 def get_function_from_string(function_str):
     """

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -858,7 +858,7 @@ class ParallelMaster(GenericMaster):
         Args:
             parent (:class:`.GenericJob`): job instance that this job was created from
         """
-        self.ref_job = parent
+        super()._init_child_job(parent)
         if parent.server.run_mode.non_modal:
             self.server.run_mode.non_modal = True
         elif (

--- a/pyiron_base/master/serial.py
+++ b/pyiron_base/master/serial.py
@@ -509,7 +509,7 @@ class SerialMasterBase(GenericMaster):
         Args:
             parent (:class:`.GenericJob`): job instance that this job was created from
         """
-        self.ref_job = parent
+        super()._init_child_job(parent)
         if parent.server.run_mode.non_modal:
             self.server.run_mode.non_modal = True
         elif (


### PR DESCRIPTION
This way also FlexibleMaster can use it and we save some lines in the other masters.