### PR TITLE
Fix deprecation warning for InputList, re-export it for now

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -6,6 +6,7 @@
 from pyiron_base.generic.factory import PyironFactory
 from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.datacontainer import DataContainer
+from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.template import PyironObject
 from pyiron_base.generic.util import deprecate, deprecate_soon, ImportAlarm

--- a/pyiron_base/generic/inputlist.py
+++ b/pyiron_base/generic/inputlist.py
@@ -5,11 +5,8 @@ Backwards compatible way of importing the DataContainer.
 from .datacontainer import DataContainer
 from .util import deprecate
 
-from functools import wraps
-
 class InputList(DataContainer):
 
     @deprecate("use DataContainer instead", version="0.3.0")
-    @wraps(DataContainer.__init__)
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, init=None, table_name=None):
+        super().__init__(init=init, table_name=table_name)


### PR DESCRIPTION
I re-export the `InputList` at top-level pyiron_base for now, so that down stream packages don't immediately break.