### PR TITLE
Remove dicttoxml

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -4,7 +4,6 @@ dependencies:
   - coveralls
   - coverage
   - codacy-coverage
-  - dicttoxml =1.7.4
   - dill =0.3.3
   - future =0.18.2
   - gitpython =3.1.13
@@ -20,4 +19,4 @@ dependencies:
   - six =1.14.0
   - sqlalchemy =1.3.23
   - tqdm =4.58.0
-  - xmltodict =0.11.0
+  - xmltodict =0.12.0

--- a/pyiron_base/generic/fileio.py
+++ b/pyiron_base/generic/fileio.py
@@ -172,7 +172,7 @@ def _to_xml(data, file_name):
         data (nested dict/list): data to save to file, dictionary keys must be str!
         file_name(str): the name of the file to be writen to.
     """
-    xml_data = xmltodict.unparse({"root": data})
+    xml_data = xmltodict.unparse({"root": data}, pretty=True)
     with open(file_name, 'w') as xmlfile:
         xmlfile.write(parseString(xml_data).toprettyxml())
 

--- a/pyiron_base/generic/fileio.py
+++ b/pyiron_base/generic/fileio.py
@@ -10,7 +10,6 @@ import os.path
 import yaml
 import warnings
 import xmltodict
-from dicttoxml import dicttoxml
 from defusedxml.minidom import parseString
 
 __author__ = "Muhammad Hassani, Marvin Poul"
@@ -165,18 +164,15 @@ def _to_yml(data, file_name):
     with open(file_name, 'w') as output:
         yaml.dump(data, output, default_flow_style=False)
 
-def _to_xml(data, file_name, attr_flag=False):
+def _to_xml(data, file_name):
     """
     Writes the DataContainer to an xml file.
 
     Args:
         data (nested dict/list): data to save to file, dictionary keys must be str!
         file_name(str): the name of the file to be writen to.
-        attr_flag(bool): if False, it will not include the type of data
-            in xml file if True, it also include the type
-            of the data in the xml file.
     """
-    xml_data = dicttoxml(data, attr_type=attr_flag)
+    xml_data = xmltodict.unparse(data)
     with open(file_name, 'w') as xmlfile:
         xmlfile.write(parseString(xml_data).toprettyxml())
 

--- a/pyiron_base/generic/fileio.py
+++ b/pyiron_base/generic/fileio.py
@@ -172,7 +172,7 @@ def _to_xml(data, file_name):
         data (nested dict/list): data to save to file, dictionary keys must be str!
         file_name(str): the name of the file to be writen to.
     """
-    xml_data = xmltodict.unparse(data)
+    xml_data = xmltodict.unparse({"root": data})
     with open(file_name, 'w') as xmlfile:
         xmlfile.write(parseString(xml_data).toprettyxml())
 

--- a/pyiron_base/generic/fileio.py
+++ b/pyiron_base/generic/fileio.py
@@ -174,7 +174,7 @@ def _to_xml(data, file_name):
     """
     xml_data = xmltodict.unparse({"root": data}, pretty=True)
     with open(file_name, 'w') as xmlfile:
-        xmlfile.write(parseString(xml_data).toprettyxml())
+        xmlfile.write(xml_data)
 
 FileAdapter = namedtuple('FileAdapter', ('parse', 'write'))
 YMLAdapter = FileAdapter(_parse_yml, _to_yml)

--- a/pyiron_base/generic/fileio.py
+++ b/pyiron_base/generic/fileio.py
@@ -85,7 +85,7 @@ def _parse_yml(file_name):
         try:
             return yaml.safe_load(input_src)
         except yaml.YAMLError as exc:
-            warnings.warn(exc)
+            warnings.warn(f"Failed to parse yaml file with error: {str(exc)}")
             return {}
 
 def _parse_xml(file_name):
@@ -149,8 +149,8 @@ def _parse_xml(file_name):
                 return output['root']
             else:
                 return output
-        except Exception as message:
-            warnings.warn(message)
+        except Exception as exc:
+            warnings.warn(f"Failed to parse xml file with: {str(exc)}")
             return {}
 
 def _to_yml(data, file_name):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     packages=find_packages(exclude=["*tests*", "*docs*", "*binder*", "*conda*", "*notebooks*", "*.ci_support*"]),
     install_requires=[
         'dill==0.3.3',
-        'dicttoxml==1.7.4',
         'future==0.18.2',
         'gitpython==3.1.13',
         'h5io==0.1.1',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'sqlalchemy==1.3.23',
         'tables==3.6.1',
         'tqdm==4.58.0',
-        'xmltodict==0.11.0'
+        'xmltodict==0.12.0'
     ],
     cmdclass=versioneer.get_cmdclass(),
 

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -15,7 +15,17 @@ class TestDataContainer(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.pl = DataContainer({
+        cls.pl = DataContainer([
+            {"foo": "bar"},
+            2,
+            42,
+            {"next":
+                [0,
+                    {"depth": 23}
+                ]
+            }
+        ], table_name = "input")
+        cls.pl_xml = DataContainer({
             "data": {"foo": "bar"},
             "numbers": [2, 42],
             "nested": {
@@ -23,6 +33,7 @@ class TestDataContainer(unittest.TestCase):
             }
         }, table_name = "input")
         cls.pl["tail"] = DataContainer([2,4,8])
+        cls.pl_xml["tail"] = DataContainer([2,4,8])
 
         file_location = os.path.dirname(os.path.abspath(__file__))
         cls.pr = Project(file_location)
@@ -492,10 +503,10 @@ class TestDataContainer(unittest.TestCase):
         os.remove(fn)
 
         fn = "pl.xml"
-        self.pl.write(fn)
+        self.pl_xml.write(fn)
         pl = DataContainer()
         pl.read(fn)
-        self.assertEqual(self.pl, pl, "Read container from xml, is not the same as written.")
+        self.assertEqual(self.pl_xml, pl, "Read container from xml, is not the same as written.")
         os.remove(fn)
 
 class TestInputList(unittest.TestCase):

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -15,16 +15,13 @@ class TestDataContainer(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.pl = DataContainer([
-                {"foo": "bar"},
-                2,
-                42,
-                {"next":
-                    [0,
-                        {"depth": 23}
-                    ]
-                }
-        ], table_name = "input")
+        cls.pl = DataContainer({
+            "data": {"foo": "bar"},
+            "numbers": [2, 42],
+            "nested": {
+                "next": {"depth": 23}
+            }
+        }, table_name = "input")
         cls.pl["tail"] = DataContainer([2,4,8])
 
         file_location = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Here is my current progress in debugging https://github.com/jan-janssen/xml-debug - xml is a mess - it seems like you can not use int as keys so what xmltodict does is adding an n in front of every int. While this produces a correct xml file I do not think this is a established convention.