### PR TITLE
Fix executable path for nested job classes

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1483,7 +1483,7 @@ class GenericJob(JobCore):
             if len(self.__module__.split(".")) > 1:
                 self._executable = Executable(
                     codename=self.__name__,
-                    module=self.__module__.split(".")[1],
+                    module=self.__module__.split(".")[-2],
                     path_binary_codes=s.resource_paths,
                 )
             else:


### PR DESCRIPTION
As discussed in #179.

I still think midterm we should add a way for a job class to specify a sub folder in the resources folder (maybe kwarg to `GenericJob.__init__`), but for now this should work.