### PR TITLE
Allow recursive appending

### DIFF
--- a/pyiron_base/generic/inputlist.py
+++ b/pyiron_base/generic/inputlist.py
@@ -207,7 +207,7 @@ class InputList(MutableMapping):
 
         if isinstance(key, tuple):
             if key[0] not in self.keys():
-                self[key[0]] = InputList()
+                self[key[0]] = type(self)()
             self[key[0]][key[1:]] = val
         elif isinstance(key, int):
             if key < len(self):

--- a/pyiron_base/generic/inputlist.py
+++ b/pyiron_base/generic/inputlist.py
@@ -206,6 +206,8 @@ class InputList(MutableMapping):
         key = _normalize(key)
 
         if isinstance(key, tuple):
+            if key[0] not in self.keys():
+                self[key[0]] = InputList()
             self[key[0]][key[1:]] = val
         elif isinstance(key, int):
             if key < len(self):

--- a/tests/generic/test_inputlist.py
+++ b/tests/generic/test_inputlist.py
@@ -414,6 +414,13 @@ class TestInputList(unittest.TestCase):
             self.assertEqual(len(w), 1,
                     "Trying to change read-only flag back didn't raise warning.")
 
+    def test_recursive_append(self):
+        input_tmp = InputList()
+        input_tmp['some/argument/inside/another/argument'] = 3
+        self.assertEqual(input_tmp['some/argument/inside/another/argument'], 3)
+        self.assertEqual(input_tmp.some.argument.inside.another.argument, 3)
+        self.assertEqual(type(input_tmp.some), InputList)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I have to admit I know little about `InputList`, but I thought it would nice to have recursive appending, for example:

```
some_input = InputList()
some_input['entry/with/new/value'] = 0
```

-> this feature is included with this PR.