### PR TITLE
Fix #230

### DIFF
--- a/pyiron_base/generic/filedata.py
+++ b/pyiron_base/generic/filedata.py
@@ -131,7 +131,7 @@ class FileData:
         self._hasdata = True if self._data is not None else False
 
     @property
-    @lru_cache
+    @lru_cache()
     def data(self):
         """Return the associated data."""
         if self._hasdata:


### PR DESCRIPTION
This seems to be a documentation bug in python.  You're supposed to be able to use it without calling `lru_cache`, but that seems to be broken for methods.