### PR TITLE
Draft a test class parent

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -23,9 +23,10 @@ __date__ = "Mar 23, 2021"
 
 
 class TestWithProject(unittest.TestCase, ABC):
-
     """
     Tests that start and remove a project for their suite, and remove jobs from the project for each test.
+
+    Now this is not a one-line docstring.
     """
 
     @classmethod

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -26,23 +26,22 @@ __date__ = "Mar 23, 2021"
 
 class TestWithProject(unittest.TestCase, ABC):
     """
-    A class that spins up a clean project at the start of each test, and removes the pyiron log when everything is done.
+    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
     """
 
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
         cls.project_name = join(cls.file_location, "test_project")
+        cls.project = Project(cls.project_name)
 
     @classmethod
     def tearDownClass(cls):
+        cls.project.remove(enable=True)
         try:
             remove(join(cls.file_location, "pyiron.log"))
         except FileNotFoundError:
             pass
 
     def tearDown(self):
-        self.project.remove(enable=True)
-
-    def setUp(self):
-        self.project = Project(self.project_name)
+        self.project.remove_jobs_silently(recursive=True)

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -25,8 +25,6 @@ __date__ = "Mar 23, 2021"
 class TestWithProject(unittest.TestCase, ABC):
     """
     Tests that start and remove a project for their suite, and remove jobs from the project for each test.
-
-    Now this is not a one-line docstring.
     """
 
     @classmethod

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -23,6 +23,7 @@ __date__ = "Mar 23, 2021"
 
 
 class TestWithProject(unittest.TestCase, ABC):
+
     """Tests that start and remove a project for their suite, and remove jobs from the project for each test."""
 
     @classmethod

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -1,0 +1,48 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+"""
+Classes to help developers avoid code duplication when writing tests for pyiron.
+"""
+
+import unittest
+from os.path import dirname, abspath, join
+from os import remove
+from pyiron_base.project.generic import Project
+from abc import ABC
+
+__author__ = "Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "0.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "development"
+__date__ = "Mar 23, 2021"
+
+
+class TestWithProject(unittest.TestCase, ABC):
+    """
+    A class that spins up a clean project at the start of each test, and removes the pyiron log when everything is done.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
+        cls.project_name = join(cls.file_location, "test_project")
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            remove(join(cls.file_location, "pyiron.log"))
+        except FileNotFoundError:
+            pass
+
+    def tearDown(self):
+        self.project.remove(enable=True)
+
+    def setUp(self):
+        self.project = Project(self.project_name)

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -32,8 +32,9 @@ class TestWithProject(unittest.TestCase, ABC):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project_name = join(cls.file_location, "test_project")
-        cls.project = Project(cls.project_name)
+        cls.project_name = "test_project"
+        cls.project_path = join(cls.file_location, cls.project_name)
+        cls.project = Project(cls.project_path)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -2,9 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-"""
-Classes to help developers avoid code duplication when writing tests for pyiron.
-"""
+"""Classes to help developers avoid code duplication when writing tests for pyiron."""
 
 import unittest
 from os.path import dirname, abspath, join

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -23,9 +23,7 @@ __date__ = "Mar 23, 2021"
 
 
 class TestWithProject(unittest.TestCase, ABC):
-    """
-    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
-    """
+    """Tests that start and remove a project for their suite, and remove jobs from the project for each test."""
 
     @classmethod
     def setUpClass(cls):

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -24,7 +24,9 @@ __date__ = "Mar 23, 2021"
 
 class TestWithProject(unittest.TestCase, ABC):
 
-    """Tests that start and remove a project for their suite, and remove jobs from the project for each test."""
+    """
+    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
+    """
 
     @classmethod
     def setUpClass(cls):

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -34,11 +34,6 @@ class TestDataContainer(TestWithProject):
         cls.pl["tail"] = DataContainer([2, 4, 8])
         cls.hdf = cls.project.create_hdf(cls.project.path, "test")
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        os.remove(cls.hdf.file_name)
-
     # Init tests
     def test_init_none(self):
         pl = DataContainer()

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -1,8 +1,8 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
+from pyiron_base._tests import TestWithProject
 from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.generic.inputlist import InputList
-from pyiron_base.project.generic import Project
 from collections import Iterator
 import copy
 import os
@@ -17,10 +17,11 @@ class Sub(DataContainer):
         self.foo = 42
 
 
-class TestDataContainer(unittest.TestCase):
+class TestDataContainer(TestWithProject):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.pl = DataContainer([
             {"foo": "bar"},
             2,
@@ -31,13 +32,11 @@ class TestDataContainer(unittest.TestCase):
             ]}
         ], table_name="input")
         cls.pl["tail"] = DataContainer([2, 4, 8])
-
-        file_location = os.path.dirname(os.path.abspath(__file__))
-        cls.pr = Project(file_location)
-        cls.hdf = cls.pr.create_hdf(cls.pr.path, "test")
+        cls.hdf = cls.project.create_hdf(cls.project.path, "test")
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         os.remove(cls.hdf.file_name)
 
     # Init tests
@@ -364,8 +363,8 @@ class TestDataContainer(unittest.TestCase):
     def test_hdf_complex_members(self):
         """Values that implement to_hdf/from_hdf, should write themselves to the HDF file correctly."""
         pl = DataContainer(table_name="complex")
-        pl.append(self.pr.create_job(self.pr.job_type.ScriptJob, "dummy1"))
-        pl.append(self.pr.create_job(self.pr.job_type.ScriptJob, "dummy2"))
+        pl.append(self.project.create_job(self.project.job_type.ScriptJob, "dummy1"))
+        pl.append(self.project.create_job(self.project.job_type.ScriptJob, "dummy2"))
         pl.append(42)
         pl["foo"] = "bar"
         pl.to_hdf(hdf=self.hdf)

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -58,15 +58,11 @@ class TestGenericJob(TestWithProject):
         ham = self.project.create.job.ScriptJob("job_single_debug")
         self.assertEqual("job_single_debug", ham.job_name)
         self.assertEqual("/job_single_debug", ham.project_hdf5.h5_path)
-        self.assertEqual(
-            cwd + "/test_project/job_single_debug.h5", ham.project_hdf5.file_name
-        )
+        self.assertEqual("/".join([cwd, self.project_name, "job_single_debug.h5"]), ham.project_hdf5.file_name)
         ham.job_name = "job_single_move"
         ham.to_hdf()
         self.assertEqual("/job_single_move", ham.project_hdf5.h5_path)
-        self.assertEqual(
-            cwd + "/test_project/job_single_move.h5", ham.project_hdf5.file_name
-        )
+        self.assertEqual("/".join([cwd, self.project_name, "job_single_move.h5"]), ham.project_hdf5.file_name)
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.project_hdf5.remove_file()
         self.assertFalse(os.path.isfile(ham.project_hdf5.file_name))
@@ -74,18 +70,14 @@ class TestGenericJob(TestWithProject):
         ham.to_hdf()
         self.assertEqual("job_single_debug_2", ham.job_name)
         self.assertEqual("/job_single_debug_2", ham.project_hdf5.h5_path)
-        self.assertEqual(
-            cwd + "/test_project/job_single_debug_2.h5", ham.project_hdf5.file_name
-        )
+        self.assertEqual("/".join([cwd, self.project_name, "job_single_debug_2.h5"]), ham.project_hdf5.file_name)
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.job_name = "job_single_move_2"
         self.assertEqual("/job_single_move_2", ham.project_hdf5.h5_path)
-        self.assertEqual(
-            cwd + "/test_project/job_single_move_2.h5", ham.project_hdf5.file_name
-        )
+        self.assertEqual("/".join([cwd, self.project_name, "job_single_move_2.h5"]), ham.project_hdf5.file_name)
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.project_hdf5.remove_file()
-        self.assertFalse(os.path.isfile(cwd + "/test_project/job_single_debug_2.h5"))
+        self.assertFalse(os.path.isfile("/".join([cwd, self.project_name, "job_single_debug_2.h5"])))
         self.assertFalse(os.path.isfile(ham.project_hdf5.file_name))
 
     def test_move(self):
@@ -93,15 +85,15 @@ class TestGenericJob(TestWithProject):
         pr_b = self.project.open("project_b")
         ham = pr_a.create.job.ScriptJob("job_moving_easy")
         self.assertFalse(ham.project_hdf5.file_exists)
-        self.assertTrue("test_project/project_a/" in ham.project_hdf5.project_path)
+        self.assertTrue(self.project_name + "/project_a/" in ham.project_hdf5.project_path)
         self.assertFalse(ham.project_hdf5.file_exists)
         ham.move_to(pr_b)
-        self.assertTrue("test_project/project_b/" in ham.project_hdf5.project_path)
+        self.assertTrue(self.project_name + "/project_b/" in ham.project_hdf5.project_path)
         ham_2 = pr_a.create.job.ScriptJob("job_moving_diff")
         ham_2.to_hdf()
-        self.assertTrue("test_project/project_a/" in ham_2.project_hdf5.project_path)
+        self.assertTrue(self.project_name + "/project_a/" in ham_2.project_hdf5.project_path)
         ham_2.move_to(pr_b)
-        self.assertTrue("test_project/project_b/" in ham_2.project_hdf5.project_path)
+        self.assertTrue(self.project_name + "/project_b/" in ham_2.project_hdf5.project_path)
         ham_2.project_hdf5.remove_file()
         pr_a.remove(enable=True)
         pr_b.remove(enable=True)

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -4,24 +4,11 @@
 
 import unittest
 import os
-from pyiron_base.project.generic import Project
 from pyiron_base.job.generic import GenericJob
+from pyiron_base._tests import TestWithProject
 
 
-class TestGenericJob(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
-            "\\", "/"
-        )
-        cls.project = Project(os.path.join(cls.file_location, "test_genericjob"))
-
-    @classmethod
-    def tearDownClass(cls):
-        file_location = os.path.dirname(os.path.abspath(__file__))
-        project = Project(os.path.join(file_location, "test_genericjob"))
-        project.remove(enable=True)
-
+class TestGenericJob(TestWithProject):
     def test_db_entry(self):
         ham = self.project.create.job.ScriptJob("job_single_debug")
         db_entry = ham.db_entry()
@@ -72,13 +59,13 @@ class TestGenericJob(unittest.TestCase):
         self.assertEqual("job_single_debug", ham.job_name)
         self.assertEqual("/job_single_debug", ham.project_hdf5.h5_path)
         self.assertEqual(
-            cwd + "/test_genericjob/job_single_debug.h5", ham.project_hdf5.file_name
+            cwd + "/test_project/job_single_debug.h5", ham.project_hdf5.file_name
         )
         ham.job_name = "job_single_move"
         ham.to_hdf()
         self.assertEqual("/job_single_move", ham.project_hdf5.h5_path)
         self.assertEqual(
-            cwd + "/test_genericjob/job_single_move.h5", ham.project_hdf5.file_name
+            cwd + "/test_project/job_single_move.h5", ham.project_hdf5.file_name
         )
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.project_hdf5.remove_file()
@@ -88,17 +75,17 @@ class TestGenericJob(unittest.TestCase):
         self.assertEqual("job_single_debug_2", ham.job_name)
         self.assertEqual("/job_single_debug_2", ham.project_hdf5.h5_path)
         self.assertEqual(
-            cwd + "/test_genericjob/job_single_debug_2.h5", ham.project_hdf5.file_name
+            cwd + "/test_project/job_single_debug_2.h5", ham.project_hdf5.file_name
         )
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.job_name = "job_single_move_2"
         self.assertEqual("/job_single_move_2", ham.project_hdf5.h5_path)
         self.assertEqual(
-            cwd + "/test_genericjob/job_single_move_2.h5", ham.project_hdf5.file_name
+            cwd + "/test_project/job_single_move_2.h5", ham.project_hdf5.file_name
         )
         self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         ham.project_hdf5.remove_file()
-        self.assertFalse(os.path.isfile(cwd + "/test_genericjob/job_single_debug_2.h5"))
+        self.assertFalse(os.path.isfile(cwd + "/test_project/job_single_debug_2.h5"))
         self.assertFalse(os.path.isfile(ham.project_hdf5.file_name))
 
     def test_move(self):
@@ -106,15 +93,15 @@ class TestGenericJob(unittest.TestCase):
         pr_b = self.project.open("project_b")
         ham = pr_a.create.job.ScriptJob("job_moving_easy")
         self.assertFalse(ham.project_hdf5.file_exists)
-        self.assertTrue("test_genericjob/project_a/" in ham.project_hdf5.project_path)
+        self.assertTrue("test_project/project_a/" in ham.project_hdf5.project_path)
         self.assertFalse(ham.project_hdf5.file_exists)
         ham.move_to(pr_b)
-        self.assertTrue("test_genericjob/project_b/" in ham.project_hdf5.project_path)
+        self.assertTrue("test_project/project_b/" in ham.project_hdf5.project_path)
         ham_2 = pr_a.create.job.ScriptJob("job_moving_diff")
         ham_2.to_hdf()
-        self.assertTrue("test_genericjob/project_a/" in ham_2.project_hdf5.project_path)
+        self.assertTrue("test_project/project_a/" in ham_2.project_hdf5.project_path)
         ham_2.move_to(pr_b)
-        self.assertTrue("test_genericjob/project_b/" in ham_2.project_hdf5.project_path)
+        self.assertTrue("test_project/project_b/" in ham_2.project_hdf5.project_path)
         ham_2.project_hdf5.remove_file()
         pr_a.remove(enable=True)
         pr_b.remove(enable=True)


### PR DESCRIPTION
As discussed in the meeting, a parent class for reducing code duplication in tests.

I'll find a couple places to apply it before removing the draft status.

EDIT: Ok, here it is applied to the tests for `GenericJob` and `DataContainer`.