### PR TITLE
Update scriptjob and external job tests

### DIFF
--- a/tests/job/test_external.py
+++ b/tests/job/test_external.py
@@ -1,7 +1,5 @@
 import os
-import unittest
-
-from pyiron_base import Project
+from pyiron_base._tests import TestWithProject
 
 job_py_source = """
 from pyiron_base import Notebook as nb
@@ -9,22 +7,20 @@ coeff_tot = nb.get_custom_dict()
 print(coeff_tot['value'])
 """
 
-class TestScriptJob(unittest.TestCase):
+
+class TestScriptJob(TestWithProject):
     @classmethod
     def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")  # replace to satisfy windows
+        super().setUpClass()
         cls.job_location = os.path.join(cls.file_location, "job.py")
-        cls.project = Project(os.path.join(cls.file_location, "test_notebook").replace("\\", "/"))
-        cls.job = cls.project.create_job(cls.project.job_type.ScriptJob,
-                                               "test")
+        cls.job = cls.project.create.job.ScriptJob("test")
         with open(cls.job_location, 'w') as f:
             f.write(job_py_source)
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         os.remove(cls.job_location)
-        cls.project.remove(enable=True)
-
 
     def test_notebook_input(self):
         """

--- a/tests/job/test_scriptjob.py
+++ b/tests/job/test_scriptjob.py
@@ -1,22 +1,11 @@
-import os
-import unittest
+from pyiron_base._tests import TestWithProject
 
-from pyiron_base import Project
 
-class TestScriptJob(unittest.TestCase):
+class TestScriptJob(TestWithProject):
     @classmethod
     def setUpClass(cls):
-        cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
-            "\\", "/"
-        )
-        cls.project = Project(os.path.join(cls.file_location, "test_scriptjob"))
-        cls.job = cls.project.create_job(cls.project.job_type.ScriptJob,
-                                               "test")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.project.remove(enable=True)
-
+        super().setUpClass()
+        cls.job = cls.project.create.job.ScriptJob("test")
 
     def test_notebook_input(self):
         """
@@ -27,4 +16,4 @@ class TestScriptJob(unittest.TestCase):
         self.job.input['value'] = 300
         self.job.save()
         self.assertTrue("custom_dict" in self.job["input"].list_groups(),
-                        "Input not saved in the 'custom_dict' group in HDF")
+                        msg="Input not saved in the 'custom_dict' group in HDF")


### PR DESCRIPTION
Remove code duplication in the tests for scriptjob and external job through reliance on `TestWithProject`.

Right now `TestWithProject` is creating its project in the same location across all instances, which can cause conflicts, as discussed [here](https://github.com/pyiron/pyiron_base/pull/262#issuecomment-805146076). This should stay a draft until that is resolved.