### PR TITLE
Use test class filepath instead of parent class filepath

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -5,10 +5,11 @@
 """Classes to help developers avoid code duplication when writing tests for pyiron."""
 
 import unittest
-from os.path import dirname, abspath, join
+from os.path import split, join
 from os import remove
 from pyiron_base.project.generic import Project
 from abc import ABC
+from inspect import getfile
 
 __author__ = "Liam Huber"
 __copyright__ = (
@@ -29,9 +30,8 @@ class TestWithProject(unittest.TestCase, ABC):
 
     @classmethod
     def setUpClass(cls):
-        cls.file_location = dirname(abspath(__file__)).replace("\\", "/")
-        cls.project_name = "test_project"
-        cls.project_path = join(cls.file_location, cls.project_name).replace("\\", "/")
+        cls.project_path = getfile(cls)[:-3].replace("\\", "/")
+        cls.file_location, cls.project_name = split(cls.project_path)
         cls.project = Project(cls.project_path)
 
     @classmethod

--- a/tests/test_testwithproject.py
+++ b/tests/test_testwithproject.py
@@ -9,7 +9,7 @@ from os.path import abspath, dirname
 class TestTestWithProject(TestWithProject):
     def test_location(self):
         self.assertEqual(
-            dirname(abspath(__file__)),
+            dirname(abspath(__file__)).replace("\\", "/"),
             self.file_location,
             msg="Projects will not be instantiated where their invoking script is."
         )

--- a/tests/test_testwithproject.py
+++ b/tests/test_testwithproject.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base._tests import TestWithProject
+from os.path import abspath, dirname
+
+
+class TestTestWithProject(TestWithProject):
+    def test_location(self):
+        self.assertEqual(
+            dirname(abspath(__file__)),
+            self.file_location,
+            msg="Projects will not be instantiated where their invoking script is."
+        )


### PR DESCRIPTION
`TestWithProject` was using its own filepath for creating projects, which lead to headaches as discussed [here]() when tests were run in parallel. Now it uses the filepath of the child class, so each test module gets its own unique project name.

@pmrv and @jan-janssen I still don't know enough about how parallelized the remote testing environment is -- is it sufficient if each test module gets its own project, or does each test class within that project need one? e.g. right now the tests for `pyiron_base/generic/object` make three test classes inside a single module.