### PR TITLE
New tables

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import select
 from sqlalchemy.exc import OperationalError, DatabaseError
-from pyiron_base.database.tables import SimulationTable
+from pyiron_base.database.tables import simulation_table
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -99,7 +99,7 @@ class DatabaseAccess(object):
             raise ValueError("Connection to database failed: " + str(except_msg))
 
         self.__reload_db()
-        self.simulation_table = SimulationTable(str(table_name), self.metadata).table
+        self.simulation_table = simulation_table(table_name, self.metadata, extend_existing=True)
         self.metadata.create_all()
         self._viewer_mode = False
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -11,13 +11,8 @@ import time
 import os
 from datetime import datetime
 from sqlalchemy import (
-    Column,
     create_engine,
-    DateTime,
-    Float,
-    Integer,
     MetaData,
-    String,
     Table,
     text,
     and_,
@@ -26,6 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import select
 from sqlalchemy.exc import OperationalError, DatabaseError
+from pyiron_base.database.tables import SimulationTable
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -103,27 +99,7 @@ class DatabaseAccess(object):
             raise ValueError("Connection to database failed: " + str(except_msg))
 
         self.__reload_db()
-        self.simulation_table = Table(
-            str(table_name),
-            self.metadata,
-            Column("id", Integer, primary_key=True, autoincrement=True),
-            Column("parentid", Integer),
-            Column("masterid", Integer),
-            Column("projectpath", String(50)),
-            Column("project", String(255)),
-            Column("job", String(50)),
-            Column("subjob", String(255)),
-            Column("chemicalformula", String(30)),
-            Column("status", String(20)),
-            Column("hamilton", String(20)),
-            Column("hamversion", String(50)),
-            Column("username", String(20)),
-            Column("computer", String(100)),
-            Column("timestart", DateTime),
-            Column("timestop", DateTime),
-            Column("totalcputime", Float),
-            extend_existing=True,
-        )
+        self.simulation_table = SimulationTable(str(table_name), self.metadata).table
         self.metadata.create_all()
         self._viewer_mode = False
 

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Classes defining the shape of pyiron's database tables.
+"""
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    String,
+    Table,
+)
+from abc import ABC
+
+__author__ = "Liam Huber, Murat Han Celik"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH"
+    " - Computational Materials Design (CM) Department"
+)
+__version__ = "0.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "development"
+__date__ = "Mar 24, 2021"
+
+
+class PyironTable(ABC):
+    def __init__(self, table_name, metadata):
+        self._table = None
+
+    @property
+    def table(self):
+        return self._table
+
+
+class ObjectTable(PyironTable):
+    """
+    A table for storing pyiron objects. Only very primitive metadata is stored and more complex queries should use
+    a `PyironTable`.
+    """
+    def __init__(self, table_name, metadata):
+        super().__init__(table_name, metadata)
+        self._table = Table(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),  # Globally unique
+            Column("location", String(511)),  # How expensive would it be to make this even bigger???
+            Column("name", String(50)),  # Unique within location
+            # Note: location+name provides exact location of serialized data
+            Column("pyiron", String(20)),  # e.g. pyiron_base, pyiron_contrib
+            Column("version", String(20)),  # Which version of pyiron used
+            Column("class", String(255)),  # Where to locate the class within pyiron
+            # e.g.
+            # pyiron=pyiron_base, class=ScriptJob; pyiron=pyiron_atomistics, class=not.a.thing.in.init.ClassName; etc.
+            # pyiron+version+class provides all necessary information to re-instantiate the right object
+            # (pyiron+version+class)+(location+name) gives all necessary information to fully recreate object instance
+            Column("created", DateTime),  # When the object was first saved
+            Column("status", String(20)),  # For data-like objects always simple like "created", for job-like is complex
+            Column("username", String(20)),  # Who's doing this (for access filtering)
+            extend_existing=True,
+        )
+
+
+class RelationTable(PyironTable):
+    """
+    A table for storing relational links between pyiron objects. Only the existence of the link is stored, the nature
+    of the link must be found by examining the pyiron object itself.
+    """
+    def __init__(self, table_name, metadata):
+        super().__init__(table_name, metadata)
+        self._table = Table(
+            table_name,
+            metadata,
+            Column("id1", Integer),
+            Column("id2", Integer),
+            extend_existing=True,
+        )

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     String,
     Table,
 )
-from abc import ABC
 
 __author__ = "Liam Huber, Murat Han Celik"
 __copyright__ = (
@@ -27,80 +26,66 @@ __status__ = "development"
 __date__ = "Mar 24, 2021"
 
 
-class PyironTable(ABC):
-    def __init__(self, table_name, metadata):
-        self._table = None
+def simulation_table(table_name, metadata, extend_existing=True):
+    """The historical table."""
+    return Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("parentid", Integer),
+        Column("masterid", Integer),
+        Column("projectpath", String(50)),
+        Column("project", String(255)),
+        Column("job", String(50)),
+        Column("subjob", String(255)),
+        Column("chemicalformula", String(30)),
+        Column("status", String(20)),
+        Column("hamilton", String(20)),
+        Column("hamversion", String(50)),
+        Column("username", String(20)),
+        Column("computer", String(100)),
+        Column("timestart", DateTime),
+        Column("timestop", DateTime),
+        Column("totalcputime", Float),
+        extend_existing=extend_existing
+    )
 
-    @property
-    def table(self):
-        return self._table
 
-
-class ObjectTable(PyironTable):
+def object_table(table_name, metadata, extend_existing=True):
     """
     A table for storing pyiron objects. Only very primitive metadata is stored and more complex queries should use
     a `PyironTable`.
     """
-    def __init__(self, table_name, metadata):
-        super().__init__(table_name, metadata)
-        self._table = Table(
-            table_name,
-            metadata,
-            Column("id", Integer, primary_key=True, autoincrement=True),  # Globally unique
-            Column("location", String(511)),  # How expensive would it be to make this even bigger???
-            Column("name", String(50)),  # Unique within location
-            # Note: location+name provides exact location of serialized data
-            Column("pyiron", String(20)),  # e.g. pyiron_base, pyiron_contrib
-            Column("version", String(20)),  # Which version of pyiron used
-            Column("class", String(255)),  # Where to locate the class within pyiron
-            # e.g.
-            # pyiron=pyiron_base, class=ScriptJob; pyiron=pyiron_atomistics, class=not.a.thing.in.init.ClassName; etc.
-            # pyiron+version+class provides all necessary information to re-instantiate the right object
-            # (pyiron+version+class)+(location+name) gives all necessary information to fully recreate object instance
-            Column("created", DateTime),  # When the object was first saved
-            Column("status", String(20)),  # For data-like objects always simple like "created", for job-like is complex
-            Column("username", String(20)),  # Who's doing this (for access filtering)
-            extend_existing=True,
-        )
+    return Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),  # Globally unique
+        Column("location", String(511)),  # How expensive would it be to make this even bigger???
+        Column("name", String(50)),  # Unique within location
+        # Note: location+name provides exact location of serialized data
+        Column("pyiron", String(20)),  # e.g. pyiron_base, pyiron_contrib
+        Column("version", String(20)),  # Which version of pyiron used
+        Column("class", String(255)),  # Where to locate the class within pyiron
+        # e.g.
+        # pyiron=pyiron_base, class=ScriptJob; pyiron=pyiron_atomistics, class=not.a.thing.in.init.ClassName; etc.
+        # pyiron+version+class provides all necessary information to re-instantiate the right object
+        # (pyiron+version+class)+(location+name) gives all necessary information to fully recreate object instance
+        Column("created", DateTime),  # When the object was first saved
+        Column("status", String(20)),  # For data-like objects always simple like "created", for job-like is complex
+        Column("username", String(20)),  # Who's doing this (for access filtering)
+        extend_existing=extend_existing
+    )
 
 
-class RelationTable(PyironTable):
+def relation_table(table_name, metadata, extend_existing=True):
     """
     A table for storing relational links between pyiron objects. Only the existence of the link is stored, the nature
     of the link must be found by examining the pyiron object itself.
     """
-    def __init__(self, table_name, metadata):
-        super().__init__(table_name, metadata)
-        self._table = Table(
-            table_name,
-            metadata,
-            Column("id1", Integer),
-            Column("id2", Integer),
-            extend_existing=True,
-        )
-
-
-class SimulationTable(PyironTable):
-    def __init__(self, table_name, metadata):
-        super().__init__(table_name, metadata)
-        self._table = Table(
-            table_name,
-            metadata,
-            Column("id", Integer, primary_key=True, autoincrement=True),
-            Column("parentid", Integer),
-            Column("masterid", Integer),
-            Column("projectpath", String(50)),
-            Column("project", String(255)),
-            Column("job", String(50)),
-            Column("subjob", String(255)),
-            Column("chemicalformula", String(30)),
-            Column("status", String(20)),
-            Column("hamilton", String(20)),
-            Column("hamversion", String(50)),
-            Column("username", String(20)),
-            Column("computer", String(100)),
-            Column("timestart", DateTime),
-            Column("timestop", DateTime),
-            Column("totalcputime", Float),
-            extend_existing=True,
-        )
+    return Table(
+        table_name,
+        metadata,
+        Column("id1", Integer),
+        Column("id2", Integer),
+        extend_existing=extend_existing
+    )

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -8,6 +8,7 @@ Classes defining the shape of pyiron's database tables.
 from sqlalchemy import (
     Column,
     DateTime,
+    Float,
     Integer,
     String,
     Table,
@@ -75,5 +76,31 @@ class RelationTable(PyironTable):
             metadata,
             Column("id1", Integer),
             Column("id2", Integer),
+            extend_existing=True,
+        )
+
+
+class SimulationTable(PyironTable):
+    def __init__(self, table_name, metadata):
+        super().__init__(table_name, metadata)
+        self._table = Table(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("parentid", Integer),
+            Column("masterid", Integer),
+            Column("projectpath", String(50)),
+            Column("project", String(255)),
+            Column("job", String(50)),
+            Column("subjob", String(255)),
+            Column("chemicalformula", String(30)),
+            Column("status", String(20)),
+            Column("hamilton", String(20)),
+            Column("hamversion", String(50)),
+            Column("username", String(20)),
+            Column("computer", String(100)),
+            Column("timestart", DateTime),
+            Column("timestop", DateTime),
+            Column("totalcputime", Float),
             extend_existing=True,
         )


### PR DESCRIPTION
As discussed in the last tech dev meeting, we will need new pyiron database tables going forward.

Git is the one true way to iteratively collaborate on written material, so I am just immediately including this in the codebase. I also extracted out [the existing table](https://github.com/pyiron/pyiron_base/blob/e59f4682ba6228f725c0a8d10c8b2ed93551890e/pyiron_base/database/generic.py#L106) the exact same way, so we can clearly see how to use these. Once we have something we're happy with we can also just inline the tables again if we don't want this extra module kicking around.

Let's play around with it! I really streamlined down the existing table so the columns should be compatible even with data objects (as opposed to our jobs which actually run) and the needs of experimentalists, although @niklassiemer you should give feedback on that front. I also included a simple pair-relationship table as suggested by @pmrv.