### PR TITLE
Fix iterating for an empty project while passing `status`

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -532,7 +532,7 @@ class Project(ProjectPath):
             job_id_lst = self.get_jobs(recursive)["id"]
         else:
             df = self.job_table(recursive=True)
-            job_id_lst = list(df[df["status"] == status]["id"])
+            job_id_lst = list(df[df["status"] == status]["id"]) if not df.empty else []
         for job_id in job_id_lst:
             if path is not None:
                 yield self.load(job_id, convert_to_object=False)[path]

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -39,6 +39,21 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(1, len(project2.data))
         self.assertEqual(self.project.data.foo, project2.data.foo)
 
+    def test_iterjobs(self):
+
+        try:
+            for j in self.project.iter_jobs():
+                pass
+        except:
+            self.fail("Iterating over empty project should not raise exception.")
+
+
+        try:
+            for j in self.project.iter_jobs(status="finished"):
+                pass
+        except:
+            self.fail("Iterating over empty project with set status flag should not raise exception.")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As per the commit messages, previously calling `Project().iter_jobs(status=...)` caused a weird error because we indexed an empty pandas table.