### PR TITLE
workaround the limitation for the length of the chemical formula in the database

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -372,6 +372,33 @@ class DatabaseAccess(object):
             output_list += [dict(zip(col.keys(), tmp_values))]
         return output_list
 
+    def _truncate_chem_formula(self, chem_formula):
+        """
+        this functions truncate the chemical formula to the last element,
+        up to the limit of the database.
+        arg:
+        chem_form(str): the chemical formula
+        """
+        acceptable_len=30
+        if len(chem_formula) >= acceptable_len:
+            for i in range(acceptable_len):
+                if not chem_formula[acceptable_len-i].isdigit():
+                    return chem_formula[:acceptable_len-i+1]
+            return chem_formula[:acceptable_len]
+        else:
+            return chem_formula
+
+    def _check_chem_formula_length(self, par_dict):
+        """
+        performs a check whether the length of chemical formula exceeds the defined limit
+        args:
+        par_dict(dict): dictionary of the parameter
+        """
+        for key, value in par_dict:
+            if key == 'chemicalformula':
+               par_dict[key] = self._truncate_chem_formula(value)
+        return par_dict
+
     # Item functions
     def add_item_dict(self, par_dict):
         """
@@ -400,6 +427,7 @@ class DatabaseAccess(object):
         """
         if not self._viewer_mode:
             try:
+                par_dict = self._check_chem_formula_length(par_dict)
                 par_dict = dict(
                     (key.lower(), value) for key, value in par_dict.items()
                 )  # make keys lowercase

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -39,6 +39,35 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+def _truncate_chem_formula(chem_formula):
+    """
+    this functions truncate the chemical formula to the last element,
+    up to the limit of the database.
+    arg:
+    chem_form(str): the chemical formula
+    """
+    acceptable_len=30
+    if len(chem_formula) >= acceptable_len:
+        for i in range(acceptable_len):
+            if not chem_formula[acceptable_len-i].isdigit():
+                return chem_formula[:acceptable_len-i+1]
+        return chem_formula[:acceptable_len]
+    else:
+        return chem_formula
+
+
+def _check_chem_formula_length( par_dict):
+    """
+    performs a check whether the length of chemical formula exceeds the defined limit
+    args:
+    par_dict(dict): dictionary of the parameter
+    """
+    for key, value in par_dict.items():
+        if key == 'chemicalformula' and not value is None:
+            par_dict[key] = _truncate_chem_formula(value)
+    return par_dict
+
+
 class AutorestoredConnection:
     def __init__(self, engine):
         self.engine = engine
@@ -372,33 +401,6 @@ class DatabaseAccess(object):
             output_list += [dict(zip(col.keys(), tmp_values))]
         return output_list
 
-    def _truncate_chem_formula(self, chem_formula):
-        """
-        this functions truncate the chemical formula to the last element,
-        up to the limit of the database.
-        arg:
-        chem_form(str): the chemical formula
-        """
-        acceptable_len=30
-        if len(chem_formula) >= acceptable_len:
-            for i in range(acceptable_len):
-                if not chem_formula[acceptable_len-i].isdigit():
-                    return chem_formula[:acceptable_len-i+1]
-            return chem_formula[:acceptable_len]
-        else:
-            return chem_formula
-
-    def _check_chem_formula_length(self, par_dict):
-        """
-        performs a check whether the length of chemical formula exceeds the defined limit
-        args:
-        par_dict(dict): dictionary of the parameter
-        """
-        for key, value in par_dict.items():
-            if key == 'chemicalformula' and not value is None:
-               par_dict[key] = self._truncate_chem_formula(value)
-        return par_dict
-
     # Item functions
     def add_item_dict(self, par_dict):
         """
@@ -427,7 +429,7 @@ class DatabaseAccess(object):
         """
         if not self._viewer_mode:
             try:
-                par_dict = self._check_chem_formula_length(par_dict)
+                par_dict = _check_chem_formula_length(par_dict)
                 par_dict = dict(
                     (key.lower(), value) for key, value in par_dict.items()
                 )  # make keys lowercase

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -102,7 +102,7 @@ class DatabaseAccess(object):
         except Exception as except_msg:
             raise ValueError("Connection to database failed: " + str(except_msg))
 
-        self._chem_formula_lim_lenght=30
+        self._chem_formula_lim_length=30
         self.__reload_db()
         self.simulation_table = Table(
             str(table_name),
@@ -114,7 +114,7 @@ class DatabaseAccess(object):
             Column("project", String(255)),
             Column("job", String(50)),
             Column("subjob", String(255)),
-            Column("chemicalformula", String(self._chem_formula_lim_lenght)),
+            Column("chemicalformula", String(self._chem_formula_lim_length)),
             Column("status", String(20)),
             Column("hamilton", String(20)),
             Column("hamversion", String(50)),
@@ -382,7 +382,7 @@ class DatabaseAccess(object):
         """
         for key, value in par_dict.items():
             if key == 'chemicalformula' and not value is None:
-                if len(value) > self._chem_formula_lim_lenght:
+                if len(value) > self._chem_formula_lim_length:
                     par_dict[key] = "OVERFLOW_ERROR"
         return par_dict
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -394,7 +394,7 @@ class DatabaseAccess(object):
         args:
         par_dict(dict): dictionary of the parameter
         """
-        for key, value in par_dict:
+        for key, value in par_dict.items():
             if key == 'chemicalformula':
                par_dict[key] = self._truncate_chem_formula(value)
         return par_dict

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -395,7 +395,7 @@ class DatabaseAccess(object):
         par_dict(dict): dictionary of the parameter
         """
         for key, value in par_dict.items():
-            if key == 'chemicalformula':
+            if key == 'chemicalformula' and not value is None:
                par_dict[key] = self._truncate_chem_formula(value)
         return par_dict
 


### PR DESCRIPTION
This fixes the issue with the limitation of the database with chemical formulas longer than 30 characters. The new code tests the length and truncates the formula to the last element.