### PR TITLE
clear_job - remove entries already included in the del function

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -443,19 +443,12 @@ class GenericJob(JobCore):
         del self.__name__
         del self.__version__
         del self._executable
-        del self._name
         del self._server
         del self._logger
-        del self._parent_id
-        del self._master_id
         del self._import_directory
         del self._status
         del self._restart_file_list
         del self._restart_file_dict
-        # del self._process
-        # del self._hdf5
-        del self._job_id
-        del self._status
 
     def copy(self):
         """


### PR DESCRIPTION
Fix error messages like: 
```
Exception ignored in: <function JobCore.__del__ at 0x7ff13c4d1a60>
Traceback (most recent call last):
  File "/home/muhammad/miniconda3/envs/workshop_test/lib/python3.8/site-packages/pyiron_base/job/core.py", line 851, in __del__
    del self._name
AttributeError: _name
```