### PR TITLE
weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: monday
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: h5py


### PR DESCRIPTION
During the last pyiron meeting, it was suggested that it would be better to schedule the dependency updates weekly rather than daily. If this pull request is approved, I will do the same for our other repositories.