### PR TITLE
Cache access to ProjectHDFio

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -4,6 +4,7 @@ dependencies:
   - coveralls
   - coverage
   - codacy-coverage
+  - cachetools =4.2.2
   - dill =0.3.3
   - future =0.18.2
   - gitpython =3.1.14

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -8,7 +8,7 @@ from pyiron_base.generic.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.generic.inputlist import InputList
 from pyiron_base.generic.parameters import GenericParameters
-from pyiron_base.generic.util import deprecate, deprecate_soon, ImportAlarm
+from pyiron_base.generic.util import deprecate, deprecate_soon, ImportAlarm, cached
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.external import Notebook
 from pyiron_base.job.generic import GenericJob

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -5,6 +5,7 @@
 Classes to map the Python objects to HDF5 data structures
 """
 
+from functools import lru_cache
 import h5py
 import os
 import importlib
@@ -700,6 +701,7 @@ class FileHDFio(object):
             key (str): key to store the data
             value (pandas.DataFrame, pandas.Series, dict, list, float, int): basically any kind of data is supported
         """
+        self.__getitem__.cache_clear()
         use_json = True
         if hasattr(value, "to_hdf") & (
             not isinstance(value, (pandas.DataFrame, pandas.Series))
@@ -780,6 +782,7 @@ class FileHDFio(object):
         except AttributeError:
             pass
 
+    @lru_cache(maxsize=32)
     def __getitem__(self, item):
         """
         Get/ read data from the HDF5 file

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -5,7 +5,7 @@
 Classes to map the Python objects to HDF5 data structures
 """
 
-from functools import lru_cache
+from pyiron_base.generic.util import cached
 import h5py
 import os
 import importlib
@@ -782,7 +782,7 @@ class FileHDFio(object):
         except AttributeError:
             pass
 
-    @lru_cache(maxsize=32)
+    @cached
     def __getitem__(self, item):
         """
         Get/ read data from the HDF5 file

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -329,7 +329,7 @@ def cached(function=None, maxsize=8*1024*1024*1024):
     def wrap(function):
         cache = cachetools.LFUCache(maxsize=maxsize, getsizeof=sys.getsizeof)
         wrapped = cachetools.cached(cache)(function)
-        wrapped.cache_clear = lambda: cache.clear()
+        wrapped.cache_clear = cache.clear
         return wrapped
     if function is None:
         return wrap

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     keywords='pyiron',
     packages=find_packages(exclude=["*tests*", "*docs*", "*binder*", "*conda*", "*notebooks*", "*.ci_support*"]),
     install_requires=[
+        'cachetools==4.2.2',
         'dill==0.3.3',
         'future==0.18.2',
         'gitpython==3.1.14',


### PR DESCRIPTION
Sketch of cached HDF5 access.  In case of loading a bunch of structures from an atomistic job with `get_structure()` as [here](https://github.com/pyiron/pyiron_atomistics/pull/189), this affords a 10x speed up. 