### PR TITLE
Change lookup order in JobCore.__getitem__

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -873,11 +873,9 @@ class JobCore:
             dict, list, float, int, None: data or data object; if nothing is found None is returned
         """
         try:
-            hdf5_item = self._hdf5[item]
+            return self._hdf5[item]
         except ValueError:
-            hdf5_item = None
-        if hdf5_item is not None:
-            return hdf5_item
+            pass
 
         name_lst = item.split("/")
         item_obj = name_lst[0]


### PR DESCRIPTION
This checks the job HDF5 first and only then looks in HDF5 files of
child jobs.  This avoids database lookups (for the child jobs) in the
common case of accessing a jobs HDF5 storage.

As discussed [here](https://github.com/pyiron/pyiron_atomistics/pull/189) this speeds up HDF5 access quite significantly.