### PR TITLE
Always add HDF5 file extension to path

### DIFF
--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -111,8 +111,7 @@ class FileHDFio(object):
     """
 
     def __init__(self, file_name, h5_path="/", mode="a"):
-        if not file_name.endswith(".h5"):
-            file_name += ".h5"
+        file_name += ".h5" if not file_name.endswith(".h5") else ""
         if not os.path.isabs(file_name):
             raise ValueError("file_name must be given as absolute path name")
         self._file_name = None
@@ -1047,8 +1046,7 @@ class ProjectHDFio(FileHDFio):
     """
 
     def __init__(self, project, file_name, h5_path=None, mode=None):
-        if not file_name.endswith(".h5"):
-            file_name += ".h5"
+        file_name += ".h5" if not file_name.endswith(".h5") else ""
         self._file_name = file_name.replace("\\", "/")
         if h5_path is None:
             h5_path = "/"

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -111,6 +111,8 @@ class FileHDFio(object):
     """
 
     def __init__(self, file_name, h5_path="/", mode="a"):
+        if not file_name.endswith(".h5"):
+            file_name += ".h5"
         if not os.path.isabs(file_name):
             raise ValueError("file_name must be given as absolute path name")
         self._file_name = None
@@ -1045,9 +1047,9 @@ class ProjectHDFio(FileHDFio):
     """
 
     def __init__(self, project, file_name, h5_path=None, mode=None):
+        if not file_name.endswith(".h5"):
+            file_name += ".h5"
         self._file_name = file_name.replace("\\", "/")
-        if ".h5" not in file_name:
-            self._file_name += ".h5"
         if h5_path is None:
             h5_path = "/"
         self._project = project.copy()

--- a/tests/generic/test_filedata.py
+++ b/tests/generic/test_filedata.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from shutil import copyfile
 
 import pandas as pd
 
@@ -13,12 +14,10 @@ class TestLoadFile(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
-        hdf5 = FileHDFio(file_name=cls.current_dir + '/test_data')
-        with hdf5.open("content") as hdf:
-            hdf['key'] = "value"
         hdf5 = FileHDFio(file_name=cls.current_dir + "/test_data.h5")
         with hdf5.open("content") as hdf:
             hdf['key'] = "value"
+        copyfile(cls.current_dir + "/test_data.h5", cls.current_dir + "/test_data")
         with open(cls.current_dir + '/test_data.txt', 'w') as f:
             f.write("some text")
         with open(cls.current_dir + '/test_data2', 'w') as f:
@@ -132,8 +131,6 @@ class TestFileData(unittest.TestCase):
 
         data = FileData(self.filepath, filetype='.txt')
         self.assertEqual(data.data, some_data)
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#235 introduced a bug where previously project data is not read in again, because the filename was missing the correct extension.  This was due to the inconsistent interface between `ProjectHDFio` and `FileHDFio` so I fixed that.

I'm not sure why the tests didn't catch that, but we should update them before merging this.

EDIT: Actually there seem to be more problems. `FileHDFio` doesn't have the `to_object` method so actually reading data from `ProjectData` also fails, but I don't have time to investigate right now.

I pushed a hotfix [here](https://github.com/pyiron/pyiron_base/tree/project_data_hotfix).  I don't think reverting is necessary, but should work on a fix here, but I needed a working version right now.