### PR TITLE
Add hook after copy_to on Jobs

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -762,10 +762,9 @@ class JobCore:
 
         # Remove output if it should not be copied
         if input_only:
-            if "output" in new_job_core.project_hdf5.list_groups():
-                del new_job_core.project_hdf5[
-                    posixpath.join(new_job_core.project_hdf5.h5_path, "output")
-                ]
+            for group in new_job_core.project_hdf5.list_groups():
+                if "output" in group:
+                    del new_job_core.project_hdf5[posixpath.join(new_job_core.project_hdf5.h5_path, group)]
             new_job_core.status.initialized = True
         return new_job_core
 

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -28,6 +28,7 @@ from pyiron_base.job.util import \
     _job_remove_folder
 from tables import NoSuchNodeError
 import shutil
+import warnings
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -751,6 +752,7 @@ class JobCore:
         """
         # Update flags
         if input_only and new_database_entry:
+            warnings.warn("input_only conflicts new_database_entry; setting new_database_entry=False")
             new_database_entry = False
 
         new_job_core, _, _, reloaded = self._internal_copy_to(

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -753,13 +753,13 @@ class JobCore:
         if input_only and new_database_entry:
             new_database_entry = False
 
-        new_job_core, _, _, reload = self._internal_copy_to(
+        new_job_core, _, _, reloaded = self._internal_copy_to(
             project=project,
             new_job_name=new_job_name,
             new_database_entry=new_database_entry,
             copy_files=copy_files
         )
-        if reload_flag:
+        if reloaded:
             return new_job_core
 
         # Remove output if it should not be copied

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -739,6 +739,8 @@ class JobCore:
 
         Args:
             project (JobCore/ProjectHDFio/Project): project to copy the job to
+            new_job_name (str): The new name to assign the duplicate job. Required if the project is `None` or the same
+                project as the copied job. (Default is None, try to keep the same name.)
             input_only (bool): [True/False] Whether to copy only the input. (Default is False.)
             new_database_entry (bool): [True/False] Whether to create a new database entry. If input_only is True then
                 new_database_entry is False. (Default is True.)

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -745,13 +745,20 @@ class JobCore:
         Returns:
             JobCore: JobCore object pointing to the new location.
         """
-        new_job_core, _, _, _ = self._internal_copy_to(
+        new_job_core, _, _, reload = self._internal_copy_to(
             project=project,
             new_job_name=new_job_name,
             new_database_entry=new_database_entry,
             copy_files=copy_files
         )
+        new_job_core._after_copy_to(reload=reload)
         return new_job_core
+
+    def _after_copy_to(self, reload=False):
+        """
+        Called after _internal_copy_to to allow sub classes to modify copy behavior.
+        """
+        pass
 
     def move_to(self, project):
         """

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -733,7 +733,7 @@ class JobCore:
             )
         return new_job_core, file_project, hdf5_project, False
 
-    def copy_to(self, project, new_job_name=None, new_database_entry=True, copy_files=True):
+    def copy_to(self, project, new_job_name=None, input_only=False, new_database_entry=True, copy_files=True):
         """
         Copy the content of the job including the HDF5 file to a new location
 

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -767,14 +767,7 @@ class JobCore:
                     posixpath.join(new_job_core.project_hdf5.h5_path, "output")
                 ]
             new_job_core.status.initialized = True
-        new_job_core._after_copy_to(reload=reload)
         return new_job_core
-
-    def _after_copy_to(self, reload=False):
-        """
-        Called after _internal_copy_to to allow sub classes to modify copy behavior.
-        """
-        pass
 
     def move_to(self, project):
         """

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -769,7 +769,7 @@ class JobCore:
             for group in new_job_core.project_hdf5.list_groups():
                 if "output" in group:
                     del new_job_core.project_hdf5[posixpath.join(new_job_core.project_hdf5.h5_path, group)]
-            new_job_core.status.initialized = True
+            new_job_core._status = "initialized"
         return new_job_core
 
     def move_to(self, project):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -53,7 +53,7 @@ class GenericJob(JobCore):
     all specific Hamiltonians are derived. Therefore it should contain the properties/routines common to all jobs.
     The functions in this module should be as generic as possible.
 
-    Sub classes that need to add special behavior after :method:`.copy_to()` can override :method:`._copy_to()`.
+    Sub classes that need to add special behavior after :method:`.copy_to()` can override :method:`._after_generic_copy_to()`.
 
     Args:
         project (ProjectHDFio): ProjectHDFio instance which points to the HDF5 file the job is stored in
@@ -534,10 +534,10 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
-        new_job_core._copy_to(new_database_entry=new_database_entry, reloaded=reloaded)
+        new_job_core._after_generic_copy_to(new_database_entry=new_database_entry, reloaded=reloaded)
         return new_job_core
 
-    def _copy_to(self, new_database_entry, reloaded):
+    def _after_generic_copy_to(self, new_database_entry, reloaded):
         """
         Called after _internal_copy_to to allow sub classes to modify copy behavior.
 

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -532,7 +532,14 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
+        new_job_core._after_copy_to()
         return new_job_core
+
+    def _after_copy_to(self):
+        """
+        Called after _internal_copy_to to allow sub classes to modify copy behavior.
+        """
+        pass
 
     def copy_file_to_working_directory(self, file):
         """

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -53,6 +53,8 @@ class GenericJob(JobCore):
     all specific Hamiltonians are derived. Therefore it should contain the properties/routines common to all jobs.
     The functions in this module should be as generic as possible.
 
+    Sub classes that need to add special behavior after :method:`.copy_to()` can override :method:`._copy_to()`.
+
     Args:
         project (ProjectHDFio): ProjectHDFio instance which points to the HDF5 file the job is stored in
         job_name (str): name of the job, which has to be unique within the project

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -483,15 +483,15 @@ class GenericJob(JobCore):
         )
 
         # Call the copy_to() function defined in the JobCore
-        new_job_core, file_project, hdf5_project, reload_flag = super(GenericJob, self)._internal_copy_to(
+        new_job_core, file_project, hdf5_project, reloaded = super(GenericJob, self)._internal_copy_to(
             project=project,
             new_job_name=new_job_name,
             new_database_entry=new_database_entry,
             copy_files=copy_files,
             delete_existing_job=delete_existing_job
         )
-        if reload_flag:
-            return new_job_core, file_project, hdf5_project, reload_flag
+        if reloaded:
+            return new_job_core, file_project, hdf5_project, reloaded
 
         # Reload object from HDF5 file
         if not static_isinstance(
@@ -504,7 +504,7 @@ class GenericJob(JobCore):
             )
         if delete_file_after_copy:
             self.project_hdf5.remove_file()
-        return new_job_core, file_project, hdf5_project, reload_flag
+        return new_job_core, file_project, hdf5_project, reloaded
 
     def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True,
                 delete_existing_job=False):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -532,10 +532,10 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
-        new_job_core._after_copy_to(new_database_entry=new_database_entry, reloaded=reloaded)
+        new_job_core._copy_to(new_database_entry=new_database_entry, reloaded=reloaded)
         return new_job_core
 
-    def _after_copy_to(self, new_database_entry, reloaded):
+    def _copy_to(self, new_database_entry, reloaded):
         """
         Called after _internal_copy_to to allow sub classes to modify copy behavior.
 

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -532,14 +532,15 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
-        new_job_core._after_copy_to(reloaded=reloaded)
+        new_job_core._after_copy_to(new_database_entry=new_database_entry, reloaded=reloaded)
         return new_job_core
 
-    def _after_copy_to(self, reloaded):
+    def _after_copy_to(self, new_database_entry, reloaded):
         """
         Called after _internal_copy_to to allow sub classes to modify copy behavior.
 
         Args:
+            new_database_entry (bool): Whether to create a new database entry was created.
             reloaded (bool): True if this job was reloaded instead of copied.
         """
         pass

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -524,10 +524,6 @@ class GenericJob(JobCore):
         Returns:
             GenericJob: GenericJob object pointing to the new location.
         """
-        # Update flags
-        if input_only and new_database_entry:
-            new_database_entry = False
-
         # Call the copy_to() function defined in the JobCore
         new_job_core, file_project, hdf5_project, reload_flag = self._internal_copy_to(
             project=project,
@@ -536,16 +532,6 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
-        if reload_flag:
-            return new_job_core
-
-        # Remove output if it should not be copied
-        if input_only:
-            if "output" in new_job_core.project_hdf5.list_groups():
-                del new_job_core.project_hdf5[
-                    posixpath.join(new_job_core.project_hdf5.h5_path, "output")
-                ]
-            new_job_core.status.initialized = True
         return new_job_core
 
     def copy_file_to_working_directory(self, file):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -525,19 +525,22 @@ class GenericJob(JobCore):
             GenericJob: GenericJob object pointing to the new location.
         """
         # Call the copy_to() function defined in the JobCore
-        new_job_core, file_project, hdf5_project, reload_flag = self._internal_copy_to(
+        new_job_core, file_project, hdf5_project, reloaded = self._internal_copy_to(
             project=project,
             new_job_name=new_job_name,
             new_database_entry=new_database_entry,
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
-        new_job_core._after_copy_to()
+        new_job_core._after_copy_to(reloaded=reloaded)
         return new_job_core
 
-    def _after_copy_to(self):
+    def _after_copy_to(self, reloaded):
         """
         Called after _internal_copy_to to allow sub classes to modify copy behavior.
+
+        Args:
+            reloaded (bool): True if this job was reloaded instead of copied.
         """
         pass
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -265,18 +265,17 @@ class GenericMaster(GenericJob):
         if reloaded:
             return
 
-        if new_job_core.job_id and new_database_entry and self._job_id:
+        if self.job_id and new_database_entry and self._job_id:
             for child_id in self.child_ids:
                 child = self.project.load(child_id)
                 new_child = child.copy_to(
-                    project=file_project.open(new_job_core.job_name + "_hdf5"),
+                    project=file_project.open(self.job_name + "_hdf5"),
                     new_database_entry=new_database_entry,
                 )
                 if new_database_entry and child.parent_id:
-                    new_child.parent_id = new_job_core.job_id
+                    new_child.parent_id = self.job_id
                 if new_database_entry and child.master_id:
-                    new_child.master_id = new_job_core.job_id
-        return new_job_core
+                    new_child.master_id = self.job_id
 
     def update_master(self):
         """

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -261,7 +261,7 @@ class GenericMaster(GenericJob):
                 child.move_to(project.open(self.job_name + "_hdf5"))
         super(GenericMaster, self).move_to(project)
 
-    def _after_copy_to(self, new_database_entry, reloaded):
+    def _copy_to(self, new_database_entry, reloaded):
         if reloaded:
             return
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -261,7 +261,7 @@ class GenericMaster(GenericJob):
                 child.move_to(project.open(self.job_name + "_hdf5"))
         super(GenericMaster, self).move_to(project)
 
-    def _copy_to(self, new_database_entry, reloaded):
+    def _after_generic_copy_to(self, new_database_entry, reloaded):
         if reloaded:
             return
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -261,7 +261,7 @@ class GenericMaster(GenericJob):
                 child.move_to(project.open(self.job_name + "_hdf5"))
         super(GenericMaster, self).move_to(project)
 
-    def _after_copy_to(self, reloaded):
+    def _after_copy_to(self, new_database_entry, reloaded):
         if reloaded:
             return
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -261,39 +261,9 @@ class GenericMaster(GenericJob):
                 child.move_to(project.open(self.job_name + "_hdf5"))
         super(GenericMaster, self).move_to(project)
 
-    def copy_to(
-        self, project=None, new_job_name=None, input_only=False, new_database_entry=True, delete_existing_job=False
-    ):
-        """
-        Copy the content of the job including the HDF5 file to a new location.
-
-        Args:
-            project (JobCore/ProjectHDFio/Project/None): The project to copy the job to.
-                (Default is None, use the same project.)
-            new_job_name (str): The new name to assign the duplicate job. Required if the project is `None` or the same
-                project as the copied job. (Default is None, try to keep the same name.)
-            input_only (bool): [True/False] Whether to copy only the input. (Default is False.)
-            new_database_entry (bool): [True/False] Whether to create a new database entry. If input_only is True then
-                new_database_entry is False. (Default is True.)
-            delete_existing_job (bool): [True/False] Delete existing job in case it exists already (Default is False.)
-
-        Returns:
-            GenericJob: GenericJob object pointing to the new location.
-        """
-        # Update flags
-        if input_only and new_database_entry:
-            new_database_entry = False
-
-        # Call the copy_to() function defined in the JobCore
-        new_job_core, file_project, hdf5_project, reload_flag = self._internal_copy_to(
-            project=project,
-            new_job_name=new_job_name,
-            new_database_entry=new_database_entry,
-            copy_files=False,
-            delete_existing_job=delete_existing_job
-        )
-        if reload_flag:
-            return new_job_core
+    def _after_copy_to(self, reloaded):
+        if reloaded:
+            return
 
         if new_job_core.job_id and new_database_entry and self._job_id:
             for child_id in self.child_ids:

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -357,32 +357,10 @@ class ParallelMaster(GenericMaster):
             new_job.ref_job = self.ref_job
         return new_job
 
-    def copy_to(
-        self, project=None, new_job_name=None, input_only=False, new_database_entry=True
-    ):
-        """
-        Copy the content of the job including the HDF5 file to a new location
-
-        Args:
-            project (JobCore/ProjectHDFio/Project/None): project to copy the job to
-            new_job_name (str): to duplicate the job within the same porject it is necessary to modify the job name
-                                - optional
-            input_only (bool): [True/False] to copy only the input - default False
-            new_database_entry (bool): [True/False] to create a new database entry - default True
-
-        Returns:
-            GenericJob: GenericJob object pointing to the new location.
-        """
-        new_generic_job = super(ParallelMaster, self).copy_to(
-            project=project,
-            new_job_name=new_job_name,
-            input_only=input_only,
-            new_database_entry=new_database_entry,
+    def _after_copy_to(self):
+        self.submission_status = SubmissionStatus(
+            db=self._hdf5.project.db, job_id=self.job_id
         )
-        new_generic_job.submission_status = SubmissionStatus(
-            db=new_generic_job._hdf5.project.db, job_id=new_generic_job.job_id
-        )
-        return new_generic_job
 
     def is_finished(self):
         """

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -357,7 +357,7 @@ class ParallelMaster(GenericMaster):
             new_job.ref_job = self.ref_job
         return new_job
 
-    def _after_copy_to(self, new_database_entry, reloaded):
+    def _copy_to(self, new_database_entry, reloaded):
         self.submission_status = SubmissionStatus(
             db=self._hdf5.project.db, job_id=self.job_id
         )

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -357,7 +357,7 @@ class ParallelMaster(GenericMaster):
             new_job.ref_job = self.ref_job
         return new_job
 
-    def _after_copy_to(self, reloaded):
+    def _after_copy_to(self, new_database_entry, reloaded):
         self.submission_status = SubmissionStatus(
             db=self._hdf5.project.db, job_id=self.job_id
         )

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -357,7 +357,7 @@ class ParallelMaster(GenericMaster):
             new_job.ref_job = self.ref_job
         return new_job
 
-    def _copy_to(self, new_database_entry, reloaded):
+    def _after_generic_copy_to(self, new_database_entry, reloaded):
         self.submission_status = SubmissionStatus(
             db=self._hdf5.project.db, job_id=self.job_id
         )

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -357,7 +357,7 @@ class ParallelMaster(GenericMaster):
             new_job.ref_job = self.ref_job
         return new_job
 
-    def _after_copy_to(self):
+    def _after_copy_to(self, reloaded):
         self.submission_status = SubmissionStatus(
             db=self._hdf5.project.db, job_id=self.job_id
         )

--- a/tests/job/test_copyto.py
+++ b/tests/job/test_copyto.py
@@ -29,6 +29,19 @@ class TestCopyTo(unittest.TestCase):
         self.assertTrue(job_ser['job_single/input/custom_dict'])
         job_ser.remove()
 
+        job = self.project.create.job.ScriptJob("job_script")
+
+        with open('foo.py', 'w') as f:
+            f.write("print(42)\n")
+
+        job.script_path = "foo.py"
+        job.save()
+        copy = job.copy_to(job.project_hdf5, "job_copy")
+        self.assertEqual(job.script_path, copy.script_path,
+                         "Script path not equal after copy.")
+
+        os.remove("foo.py")
+
     def test_copy_to_project(self):
         sub_project = self.project.copy()
         sub_project = sub_project.open("sub_project")

--- a/tests/job/test_copyto.py
+++ b/tests/job/test_copyto.py
@@ -40,6 +40,11 @@ class TestCopyTo(unittest.TestCase):
         self.assertEqual(job.script_path, copy.script_path,
                          "Script path not equal after copy.")
 
+        jobc = self.project.inspect(job.id)
+        copyc = jobc.copy_to(jobc.project_hdf5, "job_core_copy")
+        self.assertEqual(jobc.load_object().script_path, copyc.load_object().script_path,
+                         "Script path not equal after JobCore copy.")
+
         os.remove("foo.py")
 
     def test_copy_to_project(self):


### PR DESCRIPTION
Looking for ways to procrastinate I see [this](https://github.com/pyiron/pyiron_atomistics/pull/196), so I added a hook that runs after `copy_to` is called on jobs to handle any special needs of sub classes without them having to worry about all the arguments `copy_to` provides.