### PR TITLE
Add workflow to update the environment.yml in PRs from dependabot

### DIFF
--- a/.github/workflows/UpdateDependabotPR.yml
+++ b/.github/workflows/UpdateDependabotPR.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-          token: ${{ secrets.WORFKLOW_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
       - name: UpdateEnvironmentFile
         shell: bash -l {0}
         run: |
@@ -29,5 +29,5 @@ jobs:
       - name: UpdateDependabotPR push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.WORFKLOW_TOKEN }}
+          github_token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
           branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/UpdateDependabotPR.yml
+++ b/.github/workflows/UpdateDependabotPR.yml
@@ -1,0 +1,33 @@
+name: UpdateDependabotPR
+
+on:
+  pull_request_target:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: (github.actor == 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          token: ${{ secrets.WORFKLOW_TOKEN }}
+      - name: UpdateEnvironmentFile
+        shell: bash -l {0}
+        run: |
+          package=$(echo "${{ github.event.pull_request.title }}" | awk '{print $2}')
+          from=$(echo "${{ github.event.pull_request.title }}" | awk '{print $4}')
+          to=$(echo "${{ github.event.pull_request.title }}" | awk '{print $6}')
+          sed -i "/${package}/s/${from}/${to}/g" .ci_support/environment.yml
+      - name: UpdateDependabotPR commit
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "[dependabot skip] Update environment" -a
+      - name: UpdateDependabotPR push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.WORFKLOW_TOKEN }}
+          branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
This workflow uses the title of the dependabot PR `Bump package_name from some_version to updated_version` to replace the `some_version` of `package_name` by `updated_version` in our `environment.yml` within the dependabot PR. 
To get this working we need other credentials than the usual `secrets.GITHUB_TOKEN` since if this one is used in a workflow no subsequent workflow run (our CI) is triggered (see [here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow)). 
Therefore, @muh-hassani do we have another token which might be used? Otherwise we would need another token (I called it `WORFKLOW_TOKEN` in the action for now) with write access to the repository.