### PR TITLE
Project data hotfix

### DIFF
--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -16,7 +16,7 @@ Spec:
 """
 
 from pyiron_base.generic.datacontainer import DataContainer
-from pyiron_base.generic.hdfio import FileHDFio
+from pyiron_base.generic.hdfio import ProjectHDFio
 
 __author__ = "Liam Huber"
 __copyright__ = (
@@ -45,18 +45,14 @@ class ProjectData(DataContainer):
         """
         super().__init__(*args, **kwargs)
         self._project = project
-        try:
-            self.read()
-        except KeyError:
-            pass
 
     def read(self):
         """Read existing data from project-level storage."""
-        hdf = FileHDFio(file_name=self._project.path + "project_data")
+        hdf = ProjectHDFio(self._project, file_name="project_data")
         if self.table_name not in hdf.list_groups():
             raise KeyError(f"Table name {self.table_name} was not found -- Project data is empty.")
         self.from_hdf(hdf=hdf)
 
     def write(self):
         """Write data to project-level storage."""
-        self.to_hdf(FileHDFio(file_name=self._project.path + "project_data"))
+        self.to_hdf(ProjectHDFio(self._project, file_name="project_data"))

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -174,6 +174,10 @@ class Project(ProjectPath):
     def data(self):
         if self._data is None:
             self._data = ProjectData(project=self, table_name="data")
+            try:
+                self._data.read()
+            except KeyError:
+                pass
         return self._data
 
     def copy(self):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -118,6 +118,7 @@ class Project(ProjectPath):
         self._filter = ["groups", "nodes", "objects"]
         self._inspect_mode = False
         self._store = None
+        self._data = None
         self._creator = Creator(project=self)
 
         if not s.database_is_disabled:
@@ -126,11 +127,6 @@ class Project(ProjectPath):
         else:
             self.db = FileTable(project=path)
         self.job_type = JobTypeChoice()
-
-        self._data = ProjectData(project=self, table_name="data")
-        # TODO: Read the data here, if it exists.
-        #       Currently this keeps giving a recursion error because ProjectHDFio instantiation copies the project
-        #       which then tries to read, which instantiates a ProjectHDFio, which copies the project... Ugh.
 
     @property
     def parent_group(self):
@@ -176,11 +172,8 @@ class Project(ProjectPath):
 
     @property
     def data(self):
-        if len(self._data) == 0:  # This is just a workaround because loading in __init__ is not working
-            try:
-                self._data.read()
-            except KeyError:
-                pass
+        if self._data is None:
+            self._data = ProjectData(project=self, table_name="data")
         return self._data
 
     def copy(self):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -128,6 +128,9 @@ class Project(ProjectPath):
         self.job_type = JobTypeChoice()
 
         self._data = ProjectData(project=self, table_name="data")
+        # TODO: Read the data here, if it exists.
+        #       Currently this keeps giving a recursion error because ProjectHDFio instantiation copies the project
+        #       which then tries to read, which instantiates a ProjectHDFio, which copies the project... Ugh.
 
     @property
     def parent_group(self):
@@ -173,6 +176,11 @@ class Project(ProjectPath):
 
     @property
     def data(self):
+        if len(self._data) == 0:  # This is just a workaround because loading in __init__ is not working
+            try:
+                self._data.read()
+            except KeyError:
+                pass
         return self._data
 
     def copy(self):

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -46,7 +46,10 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(data2.bar, self.data.bar)
 
     def test_reading_recursion(self):
-        self.data.baz = [1, 2, [3, 3]]
+        baz = self.data.create_group("baz")
+        baz[0] = 1
+        baz[1] = 2
+        baz[2] = [3, 3]
         self.data.write()
         self.assertEqual(3, len(self.data.baz))
         self.assertEqual(2, len(self.data.baz[-1]))

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -40,7 +40,8 @@ class TestProjectData(unittest.TestCase):
         self.data.write()
 
         data2 = ProjectData(project=self.project, table_name="data")
-        self.assertEqual(len(data2), len(self.data))  # Automatic reading on instantiation
+        self.assertEqual(len(data2), 0)
+        data2.read()
         self.assertEqual(data2.foo, self.data.foo)
         self.assertEqual(data2.bar, self.data.bar)
 
@@ -51,6 +52,7 @@ class TestProjectData(unittest.TestCase):
         self.assertEqual(2, len(self.data.baz[-1]))
 
         data2 = ProjectData(project=self.project, table_name="data")
+        data2.read()
         self.assertEqual(3, len(data2.baz))
         self.assertEqual(2, len(data2.baz[-1]))
 


### PR DESCRIPTION
Following [this](https://github.com/pyiron/pyiron_base/pull/314) discussion reverts the change to `FileHDFio`, delays the instantiation of `ProjectData` to break the recursion on init and expands to the test to catch this.