### PR TITLE
Add generic database interface -- IsDatabase

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -147,12 +147,14 @@ class FileTable(IsDatabase, metaclass=Singleton):
         return self._job_table.columns.values
 
     def _get_job_table(
-        self, 
-        project=None, 
-        recursive=True, 
-        columns=None, 
-        sort_by="id", 
-        max_colwidth=200, 
+        self,
+        sql_query,
+        user,
+        project=None,
+        recursive=True,
+        columns=None,
+        sort_by="id",
+        max_colwidth=200,
         job_name_contains=''
     ):
         self.update()

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -164,8 +164,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
             else:
                 df = self._job_table[self._job_table.project == project]
         else:
-            df = self._job_table
-        return df[columns]
+            return self._job_table
 
     def get_jobs(self, project=None, recursive=True, columns=None):
         if project is None:

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -150,7 +150,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
         self,
         sql_query,
         user,
-        project=None,
+        project_path=None,
         recursive=True,
         columns=None,
         sort_by="id",

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -5,13 +5,14 @@ import datetime
 import h5io
 from pyfileindex import PyFileIndex
 from pyiron_base.generic.util import Singleton
+from pyiron_base.database.generic import IsDatabase
 
 
 def filter_function(file_name):
     return '.h5' in file_name
 
 
-class FileTable(metaclass=Singleton):
+class FileTable(IsDatabase, metaclass=Singleton):
     def __init__(self, project):
         self._fileindex = None
         self._job_table = None
@@ -21,9 +22,8 @@ class FileTable(metaclass=Singleton):
                          'username']
         self.force_reset()
 
-    @property
-    def viewer_mode(self):
-        return None
+    def _get_view_mode(self):
+        return False
 
     def force_reset(self):
         self._fileindex = PyFileIndex(

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -151,19 +151,13 @@ class FileTable(IsDatabase, metaclass=Singleton):
         project=None, 
         recursive=True, 
         columns=None, 
-        all_columns=False, 
         sort_by="id", 
         max_colwidth=200, 
-        full_table=False, 
         job_name_contains=''
     ):
         self.update()
         if project is None:
             project = self._project
-        if columns is None:
-            columns = ["job", "project", "chemicalformula"]
-        if all_columns:
-            columns = self._columns
         if len(self._job_table) != 0:
             if recursive:
                 df = self._job_table[self._job_table.project.str.contains(project)]
@@ -171,13 +165,6 @@ class FileTable(IsDatabase, metaclass=Singleton):
                 df = self._job_table[self._job_table.project == project]
         else:
             df = self._job_table
-        if full_table:
-            pandas.set_option('display.max_rows', None)
-            pandas.set_option('display.max_columns', None)
-        else:
-            pandas.reset_option('display.max_rows')
-            pandas.reset_option('display.max_columns')
-        pandas.set_option("display.max_colwidth", max_colwidth)
         if len(df) == 0:
             return df
         if job_name_contains != '':

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -153,9 +153,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
         project_path=None,
         recursive=True,
         columns=None,
-        sort_by="id",
-        max_colwidth=200,
-        job_name_contains=''
+        element_lst=None
     ):
         self.update()
         if project is None:
@@ -167,12 +165,6 @@ class FileTable(IsDatabase, metaclass=Singleton):
                 df = self._job_table[self._job_table.project == project]
         else:
             df = self._job_table
-        if len(df) == 0:
-            return df
-        if job_name_contains != '':
-            df = df[df.job.str.contains(job_name_contains)]
-        if sort_by in columns:
-            return df[columns].sort_values(by=sort_by)
         return df[columns]
 
     def get_jobs(self, project=None, recursive=True, columns=None):

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -140,10 +140,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
             else:
                 self._job_table = df
 
-    def get_db_columns(self):
-        return self.get_table_headings()
-
-    def get_table_headings(self):
+    def _get_table_headings(self, table_name=None):
         return self._job_table.columns.values
 
     def _get_job_table(

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -157,6 +157,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
         full_table=False, 
         job_name_contains=''
     ):
+        self.update()
         if project is None:
             project = self._project
         if columns is None:

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -146,7 +146,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
     def get_table_headings(self):
         return self._job_table.columns.values
 
-    def job_table(
+    def _get_job_table(
         self, 
         project=None, 
         recursive=True, 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -450,8 +450,7 @@ class DatabaseAccess(IsDatabase):
             recursive=recursive,
             element_lst=element_lst,
         )
-        df = pandas.DataFrame(job_dict, columns=columns)
-        return df[columns]
+        return pandas.DataFrame(job_dict, columns=columns)
 
     # Internal functions
     def __del__(self):

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -67,6 +67,23 @@ class IsDatabase(ABC):
         return self.view_mode
     viewer_mode.__doc__ = view_mode.__doc__
 
+    @abstractmethod
+    def _get_job_table(
+            self,
+            sql_query,
+            user,
+            project_path,
+            recursive=True,
+            columns=None,
+            all_columns=False,
+            sort_by="id",
+            max_colwidth=200,
+            full_table=False,
+            element_lst=None,
+            job_name_contains='',
+    ):
+        pass
+
     def job_table(
             self,
             sql_query,

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -146,6 +146,8 @@ class IsDatabase(ABC):
             pandas.reset_option('display.max_columns')
         pandas.set_option("display.max_colwidth", max_colwidth)
         return self._get_job_table(
+                user=user,
+                sql_query=sql_query,
                 project=project_path,
                 recursive=recursive,
                 columns=columns,

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -427,6 +427,9 @@ class DatabaseAccess(IsDatabase):
         if element_lst is not None:
             dict_clause["element_lst"] = element_lst
 
+        # HACK: breaks circular dependency of Settings on DatabaseAccess
+        from pyiron_base.settings.generic import Settings
+        s = Settings()
         s.logger.debug("sql_query: %s", str(dict_clause))
         return self.get_items_dict(dict_clause)
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -148,7 +148,7 @@ class IsDatabase(ABC):
         return self._get_job_table(
                 user=user,
                 sql_query=sql_query,
-                project=project_path,
+                project_path=project_path,
                 recursive=recursive,
                 columns=columns,
                 sort_by=sort_by,

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -157,6 +157,66 @@ class IsDatabase(ABC):
             return df.sort_values(by=sort_by)
         return df
 
+    @abstractmethod
+    def _get_table_headings(self, table_name=None):
+        pass
+
+    def get_table_headings(self, table_name=None):
+        """
+        Get column names; if given table_name can select one of multiple tables defined in the database, but subclasses
+        may ignore it
+
+        Args:
+            table_name (str): simple string of a table_name like: 'jobs_username'
+
+        Returns:
+            list: list of column names like:
+                ['id',
+                'parentid',
+                'masterid',
+                'projectpath',
+                'project',
+                'job',
+                'subjob',
+                'chemicalformula',
+                'status',
+                'hamilton',
+                'hamversion',
+                'username',
+                'computer',
+                'timestart',
+                'timestop',
+                'totalcputime']
+        """
+        return self._get_table_headings(table_name=table_name)
+
+    @deprecate("use get_table_headings()")
+    def get_db_columns(self):
+        """
+        Get column names
+
+        Returns:
+            list: list of column names like:
+                ['id',
+                'parentid',
+                'masterid',
+                'projectpath',
+                'project',
+                'job',
+                'subjob',
+                'chemicalformula',
+                'status',
+                'hamilton',
+                'hamversion',
+                'username',
+                'computer',
+                'timestart',
+                'timestop',
+                'totalcputime']
+        """
+        return self.get_table_headings()
+
+
 class ConnectionWatchDog(Thread):
     """
     Helper class that closes idle connections after a given timeout.
@@ -494,7 +554,7 @@ class DatabaseAccess(IsDatabase):
             return reg.search(item) is not None
 
     # Table functions
-    def get_table_headings(self, table_name=None):
+    def _get_table_headings(self, table_name=None):
         """
         Get column names
 
@@ -533,6 +593,8 @@ class DatabaseAccess(IsDatabase):
         except Exception:
             raise ValueError(str(table_name) + " does not exist")
         return [column.name for column in iter(simulation_list.columns)]
+
+
 
     def add_column(self, col_name, col_type):
         """

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -52,12 +52,12 @@ class IsDatabase(ABC):
     @property
     def view_mode(self):
         """
-        Get viewer_mode - if viewer_moded is enable pyiron has read only access to the database.
+        Get view_mode - if view_moded is enable pyiron has read only access to the database.
 
         Some implementations do not allow to set this value.
 
         Returns:
-            bool: True when viewer_mode is enabled
+            bool: True when view_mode is enabled
         """
         return self._get_view_mode()
 
@@ -318,21 +318,21 @@ class DatabaseAccess(IsDatabase):
         self.__reload_db()
         self.simulation_table = HistoricalTable(str(table_name), self.metadata)
         self.metadata.create_all()
-        self._viewer_mode = False
+        self._view_mode = False
 
     def _get_view_mode(self):
-        return self._viewer_mode
+        return self._view_mode
 
     @IsDatabase.view_mode.setter
     def view_mode(self, value):
         """
-        Set viewer_mode - if viewer_mode is enable pyiron has read only access to the database.
+        Set view_mode - if view_mode is enable pyiron has read only access to the database.
 
         Args:
             value (bool): TRUE or FALSE
         """
         if isinstance(value, bool):
-            self._viewer_mode = value
+            self._view_mode = value
         else:
             raise TypeError("Viewmode can only be TRUE or FALSE.")
 
@@ -552,7 +552,7 @@ class DatabaseAccess(IsDatabase):
         Returns:
 
         """
-        if not self._viewer_mode:
+        if not self._view_mode:
             if isinstance(col_name, list):
                 col_name = col_name[-1]
             if isinstance(col_type, list):
@@ -575,7 +575,7 @@ class DatabaseAccess(IsDatabase):
         Returns:
 
         """
-        if not self._viewer_mode:
+        if not self._view_mode:
             if isinstance(col_name, list):
                 col_name = col_name[-1]
             if isinstance(col_type, list):
@@ -721,7 +721,7 @@ class DatabaseAccess(IsDatabase):
         Returns:
             int: Database ID of the item created as an int, like: 3
         """
-        if not self._viewer_mode:
+        if not self._view_mode:
             try:
                 par_dict = self._check_chem_formula_length(par_dict)
                 par_dict = dict(
@@ -802,7 +802,7 @@ class DatabaseAccess(IsDatabase):
         Returns:
 
         """
-        if not self._viewer_mode:
+        if not self._view_mode:
             if type(item_id) is list:
                 item_id = item_id[-1]  # sometimes a list is given, make it int
             if np.issubdtype(type(item_id), np.integer):
@@ -837,7 +837,7 @@ class DatabaseAccess(IsDatabase):
         Returns:
 
         """
-        if not self._viewer_mode:
+        if not self._view_mode:
             self.conn.execute(
                 self.simulation_table.delete(
                     self.simulation_table.c["id"] == int(item_id)

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -75,10 +75,8 @@ class IsDatabase(ABC):
             project_path,
             recursive=True,
             columns=None,
-            all_columns=False,
             sort_by="id",
             max_colwidth=200,
-            full_table=False,
             element_lst=None,
             job_name_contains='',
     ):
@@ -120,14 +118,39 @@ class IsDatabase(ABC):
         Returns:
             pandas.Dataframe: Return the result as a pandas.Dataframe object
         """
+        if columns is None:
+            columns = ["job", "project", "chemicalformula"]
+        if all_columns:
+            columns = [
+                "id",
+                "status",
+                "chemicalformula",
+                "job",
+                "subjob",
+                "projectpath",
+                "project",
+                "timestart",
+                "timestop",
+                "totalcputime",
+                "computer",
+                "hamilton",
+                "hamversion",
+                "parentid",
+                "masterid",
+            ]
+        if full_table:
+            pandas.set_option('display.max_rows', None)
+            pandas.set_option('display.max_columns', None)
+        else:
+            pandas.reset_option('display.max_rows')
+            pandas.reset_option('display.max_columns')
+        pandas.set_option("display.max_colwidth", max_colwidth)
         return self._get_job_table(
                 project=project_path,
                 recursive=recursive,
                 columns=columns,
-                all_columns=all_columns,
                 sort_by=sort_by,
                 max_colwidth=max_colwidth,
-                full_table=full_table,
                 job_name_contains=job_name_contains
         )
 
@@ -412,35 +435,11 @@ class DatabaseAccess(IsDatabase):
             project_path,
             recursive=True,
             columns=None,
-            all_columns=False,
             sort_by="id",
             max_colwidth=200,
-            full_table=False,
             element_lst=None,
             job_name_contains='',
     ):
-        if columns is None:
-            columns = ["job", "project", "chemicalformula"]
-        all_db = [
-            "id",
-            "status",
-            "chemicalformula",
-            "job",
-            "subjob",
-            "projectpath",
-            "project",
-            "timestart",
-            "timestop",
-            "totalcputime",
-            "computer",
-            "hamilton",
-            "hamversion",
-            "parentid",
-            "masterid",
-        ]
-
-        if all_columns:
-            columns = all_db
         job_dict = self._job_dict(
             sql_query=sql_query,
             user=user,
@@ -448,13 +447,6 @@ class DatabaseAccess(IsDatabase):
             recursive=recursive,
             element_lst=element_lst,
         )
-        if full_table:
-            pandas.set_option('display.max_rows', None)
-            pandas.set_option('display.max_columns', None)
-        else:
-            pandas.reset_option('display.max_rows')
-            pandas.reset_option('display.max_columns')
-        pandas.set_option("display.max_colwidth", max_colwidth)
         df = pandas.DataFrame(job_dict, columns=columns)
         if job_name_contains != '':
             df = df[df.job.str.contains(job_name_contains)]

--- a/pyiron_base/database/jobtable.py
+++ b/pyiron_base/database/jobtable.py
@@ -24,96 +24,6 @@ __date__ = "Sep 1, 2017"
 s = Settings()
 
 
-def _job_dict(
-    database,
-    sql_query,
-    user,
-    project_path,
-    recursive,
-    job=None,
-    sub_job_name="%",
-    element_lst=None,
-):
-    """
-    Internal function to access the database from the project directly.
-
-    Args:
-        database (DatabaseAccess): Database object
-        sql_query (str): SQL query to enter a more specific request
-        user (str): username of the user whoes user space should be searched
-        project_path (str): root_path - this is in contrast to the project_path in GenericPath
-        recursive (bool): search subprojects [True/False]
-        job (str): job_name - by default None
-        sub_job_name (str): path inside the HDF5 file - "%" by default to accept any path
-        element_lst (list): list of elements required in the chemical formular - by default None
-
-    Returns:
-        list: the function returns a list of dicts like get_items_sql, but it does not format datetime:
-             [{'chemicalformula': u'Ni108',
-              'computer': u'mapc157',
-              'hamilton': u'LAMMPS',
-              'hamversion': u'1.1',
-              'id': 24,
-              'job': u'DOF_1_0',
-              'parentid': 21L,
-              'project': u'lammps.phonons.Ni_fcc',
-              'projectpath': u'D:/PyIron/PyIron_data/projects',
-              'status': u'finished',
-              'timestart': datetime.datetime(2016, 6, 24, 10, 17, 3, 140000),
-              'timestop': datetime.datetime(2016, 6, 24, 10, 17, 3, 173000),
-              'totalcputime': 0.033,
-              'username': u'test'},
-             {'chemicalformula': u'Ni108',
-              'computer': u'mapc157',
-              'hamilton': u'LAMMPS',
-              'hamversion': u'1.1',
-              'id': 21,
-              'job': u'ref',
-              'parentid': 20L,
-              'project': u'lammps.phonons.Ni_fcc',
-              'projectpath': u'D:/PyIron/PyIron_data/projects',
-              'status': u'finished',
-              'timestart': datetime.datetime(2016, 6, 24, 10, 17, 2, 429000),
-              'timestop': datetime.datetime(2016, 6, 24, 10, 17, 2, 463000),
-              'totalcputime': 0.034,
-              'username': u'test'},.......]
-
-    """
-    dict_clause = {}
-    # FOR GET_ITEMS_SQL: clause = []
-    if user is not None:
-        dict_clause["username"] = str(user)
-        # FOR GET_ITEMS_SQL: clause.append("username = '" + self.user + "'")
-    if sql_query is not None:
-        # FOR GET_ITEMS_SQL: clause.append(self.sql_query)
-        if "AND" in sql_query:
-            cl_split = sql_query.split(" AND ")
-        elif "and" in sql_query:
-            cl_split = sql_query.split(" and ")
-        else:
-            cl_split = [sql_query]
-        dict_clause.update(
-            {str(element.split()[0]): element.split()[2] for element in cl_split}
-        )
-    if job is not None:
-        dict_clause["job"] = str(job)
-
-    if project_path == "./":
-        project_path = ""
-    if recursive:
-        dict_clause["project"] = str(project_path) + "%"
-    else:
-        dict_clause["project"] = str(project_path)
-    if sub_job_name is None:
-        dict_clause["subjob"] = None
-    elif sub_job_name != "%":
-        dict_clause["subjob"] = str(sub_job_name)
-    if element_lst is not None:
-        dict_clause["element_lst"] = element_lst
-
-    s.logger.debug("sql_query: %s", str(dict_clause))
-    return database.get_items_dict(dict_clause)
-
 
 def get_db_columns(database):
     """
@@ -182,49 +92,16 @@ def job_table(
         pandas.Dataframe: Return the result as a pandas.Dataframe object
     """
     if not isinstance(database, FileTable):
-        if columns is None:
-            columns = ["job", "project", "chemicalformula"]
-        all_db = [
-            "id",
-            "status",
-            "chemicalformula",
-            "job",
-            "subjob",
-            "projectpath",
-            "project",
-            "timestart",
-            "timestop",
-            "totalcputime",
-            "computer",
-            "hamilton",
-            "hamversion",
-            "parentid",
-            "masterid",
-        ]
-
-        if all_columns:
-            columns = all_db
-        job_dict = _job_dict(
-            database=database,
-            sql_query=sql_query,
-            user=user,
-            project_path=project_path,
+        return database.job_table(
+            project=project_path,
             recursive=recursive,
-            element_lst=element_lst,
+            columns=columns,
+            all_columns=all_columns,
+            sort_by=sort_by,
+            max_colwidth=200,
+            full_table=full_table,
+            job_name_contains=job_name_contains
         )
-        if full_table:
-            pandas.set_option('display.max_rows', None)
-            pandas.set_option('display.max_columns', None)
-        else:
-            pandas.reset_option('display.max_rows')
-            pandas.reset_option('display.max_columns')
-        pandas.set_option("display.max_colwidth", max_colwidth)
-        df = pandas.DataFrame(job_dict, columns=columns)
-        if job_name_contains != '':
-            df = df[df.job.str.contains(job_name_contains)]
-        if sort_by in columns:
-            return df[columns].sort_values(by=sort_by)
-        return df[columns]
     else:
         database.update()
         return database.job_table(
@@ -364,8 +241,7 @@ def get_job_id(database, sql_query, user, project_path, job_specifier):
             return job_specifier  # is id
 
         job_specifier.replace(".", "_")
-        job_dict = _job_dict(
-            database=database,
+        job_dict = database._job_dict(
             sql_query=sql_query,
             user=user,
             project_path=project_path,
@@ -373,8 +249,7 @@ def get_job_id(database, sql_query, user, project_path, job_specifier):
             job=job_specifier
         )
         if len(job_dict) == 0:
-            job_dict = _job_dict(
-                database=database,
+            job_dict = database._job_dict(
                 sql_query=sql_query,
                 user=user,
                 project_path=project_path,

--- a/pyiron_base/database/jobtable.py
+++ b/pyiron_base/database/jobtable.py
@@ -24,36 +24,6 @@ __date__ = "Sep 1, 2017"
 s = Settings()
 
 
-
-def get_db_columns(database):
-    """
-    Get column names
-
-    Args:
-        database (DatabaseAccess): Database object
-
-    Returns:
-        list: list of column names like:
-             ['id',
-             'parentid',
-             'masterid',
-             'projectpath',
-             'project',
-             'job',
-             'subjob',
-             'chemicalformula',
-             'status',
-             'hamilton',
-             'hamversion',
-             'username',
-             'computer',
-             'timestart',
-             'timestop',
-             'totalcputime']
-    """
-    return database.get_table_headings()
-
-
 def get_jobs(database, sql_query, user, project_path, recursive=True, columns=None):
     """
     Internal function to return the jobs as dictionary rather than a pandas.Dataframe

--- a/pyiron_base/database/jobtable.py
+++ b/pyiron_base/database/jobtable.py
@@ -54,68 +54,6 @@ def get_db_columns(database):
     return database.get_table_headings()
 
 
-def job_table(
-    database,
-    sql_query,
-    user,
-    project_path,
-    recursive=True,
-    columns=None,
-    all_columns=False,
-    sort_by="id",
-    max_colwidth=200,
-    full_table=False,
-    element_lst=None,
-    job_name_contains='',
-):
-    """
-    Access the job_table
-
-    Args:
-        database (DatabaseAccess): Database object
-        sql_query (str): SQL query to enter a more specific request
-        user (str): username of the user whoes user space should be searched
-        project_path (str): root_path - this is in contrast to the project_path in GenericPath
-        recursive (bool): search subprojects [True/False]
-        columns (list): by default only the columns ['job', 'project', 'chemicalformula'] are selected, but the
-                        user can select a subset of ['id', 'status', 'chemicalformula', 'job', 'subjob', 'project',
-                        'projectpath', 'timestart', 'timestop', 'totalcputime', 'computer', 'hamilton', 'hamversion',
-                        'parentid', 'masterid']
-        all_columns (bool): Select all columns - this overwrites the columns option.
-        sort_by (str): Sort by a specific column
-        max_colwidth (int): set the column width
-        full_table (bool): Whether to show the entire pandas table
-        element_lst (list): list of elements required in the chemical formular - by default None
-        job_name_contains (str): a string which should be contained in every job_name
-
-    Returns:
-        pandas.Dataframe: Return the result as a pandas.Dataframe object
-    """
-    if not isinstance(database, FileTable):
-        return database.job_table(
-            project=project_path,
-            recursive=recursive,
-            columns=columns,
-            all_columns=all_columns,
-            sort_by=sort_by,
-            max_colwidth=200,
-            full_table=full_table,
-            job_name_contains=job_name_contains
-        )
-    else:
-        database.update()
-        return database.job_table(
-            project=project_path,
-            recursive=recursive,
-            columns=columns,
-            all_columns=all_columns,
-            sort_by=sort_by,
-            max_colwidth=200,
-            full_table=full_table,
-            job_name_contains=job_name_contains
-        )
-
-
 def get_jobs(database, sql_query, user, project_path, recursive=True, columns=None):
     """
     Internal function to return the jobs as dictionary rather than a pandas.Dataframe
@@ -136,8 +74,7 @@ def get_jobs(database, sql_query, user, project_path, recursive=True, columns=No
     if not isinstance(database, FileTable):
         if columns is None:
             columns = ["id", "project"]
-        df = job_table(
-            database=database,
+        df = database.job_table(
             sql_query=sql_query,
             user=user,
             project_path=project_path,

--- a/pyiron_base/database/manager.py
+++ b/pyiron_base/database/manager.py
@@ -119,10 +119,10 @@ class DatabaseManager(metaclass=Singleton):
 
     def switch_to_viewer_mode(self):
         """
-        Switch from user mode to viewer mode - if viewer_mode is enable pyiron has read only access to the database.
+        Switch from user mode to viewer mode - if view_mode is enable pyiron has read only access to the database.
         """
         if s.configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
-            if self._database.viewer_mode:
+            if self._database.view_mode:
                 s.logger.log("Database is already in viewer mode!")
             else:
                 self.close_connection()
@@ -130,23 +130,23 @@ class DatabaseManager(metaclass=Singleton):
                     s.configuration["sql_view_connection_string"],
                     s.configuration["sql_view_table_name"],
                 )
-                self._database.viewer_mode = True
+                self._database.view_mode = True
 
         else:
             print("Viewer Mode is not available on this pyiron installation.")
 
     def switch_to_user_mode(self):
         """
-        Switch from viewer mode to user mode - if viewer_mode is enable pyiron has read only access to the database.
+        Switch from viewer mode to user mode - if view_mode is enable pyiron has read only access to the database.
         """
         if s.configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
-            if self._database.viewer_mode:
+            if self._database.view_mode:
                 self.close_connection()
                 self._database = DatabaseAccess(
                     s.configuration["sql_connection_string"],
                     s.configuration["sql_table_name"],
                 )
-                self._database.viewer_mode = True
+                self._database.view_mode = True
             else:
                 s.logger.log("Database is already in user mode!")
         else:

--- a/pyiron_base/generic/util.py
+++ b/pyiron_base/generic/util.py
@@ -6,6 +6,7 @@
 Utility functions used in pyiron.
 """
 
+from abc import ABCMeta
 from copy import copy
 import functools
 import types
@@ -23,7 +24,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-class Singleton(type):
+class Singleton(ABCMeta):
     """
     Implemented with suggestions from
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -26,7 +26,6 @@ from pyiron_base.database.jobtable import (
     get_job_ids,
     get_job_id,
     get_jobs,
-    job_table,
     set_job_status,
     get_child_ids,
     get_job_working_directory,
@@ -621,8 +620,7 @@ class Project(ProjectPath, HasGroups):
         Returns:
             pandas.Dataframe: Return the result as a pandas.Dataframe object
         """
-        return job_table(
-            database=self.db,
+        return self.db.job_table(
             sql_query=self.sql_query,
             user=self.user,
             project_path=self.project_path,

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -153,6 +153,7 @@ class Project(ProjectPath, HasGroups):
         return self.create_group("..")
 
     @property
+    @deprecate("use db.view_mode")
     def view_mode(self):
         """
         Get viewer_mode - if viewer_mode is enable pyiron has read only access to the database.
@@ -165,10 +166,7 @@ class Project(ProjectPath, HasGroups):
         Returns:
             bool: returns TRUE when viewer_mode is enabled
         """
-        if not isinstance(self.db, FileTable):
-            return self.db.viewer_mode
-        else:
-            return False
+        return self.db.view_mode
 
     @property
     def name(self):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -22,7 +22,6 @@ from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.settings.publications import list_publications
 from pyiron_base.database.performance import get_database_statistics
 from pyiron_base.database.jobtable import (
-    get_db_columns,
     get_job_ids,
     get_job_id,
     get_jobs,
@@ -367,7 +366,7 @@ class Project(ProjectPath, HasGroups):
                  'timestop',
                  'totalcputime']
         """
-        return get_db_columns(self.db)
+        return self.db.get_table_headings()
 
     def get_jobs(self, recursive=True, columns=None):
         """


### PR DESCRIPTION
Inspired by Friday, I've started worked to create a uniform interface for `DatabaseAccess` and `FileTable` called `IsDatabase`.

For now I've only touched `view_mode` and `job_table`, but the general recipe for this PR is to go through the generic interface

https://github.com/pyiron/pyiron_base/blob/master/pyiron_base/database/jobtable.py

and then move each function there to an abstract method in `IsDatabase` and split the implementation to methods in `DatabaseAccess` and `FileTable`.  Since the latter is newer, this mostly ends up moving stuff to methods in the former.

I'll be moving functions from time to time when I feel like it, but it's mostly copying code between places, so feel free to pick up some methods yourself, too.  In any case test coverage is light on `DatabaseAccess`, so tread lightly.  I would suggest that once we have a stable interface here, we add tests to cover at least the sqlite code path.