### PR TITLE
Use input_only in GenericJob.copy_to

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -545,7 +545,7 @@ class GenericJob(JobCore):
             for group in new_job_core.project_hdf5.list_groups():
                 if "output" in group:
                     del new_job_core.project_hdf5[posixpath.join(new_job_core.project_hdf5.h5_path, group)]
-            new_job_core._status = "initialized"
+            new_job_core.status.initialized = True
         new_job_core._after_generic_copy_to(self, new_database_entry=new_database_entry, reloaded=reloaded)
         return new_job_core
 

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -526,6 +526,11 @@ class GenericJob(JobCore):
         Returns:
             GenericJob: GenericJob object pointing to the new location.
         """
+        # Update flags
+        if input_only and new_database_entry:
+            warnings.warn("input_only conflicts new_database_entry; setting new_database_entry=False")
+            new_database_entry = False
+
         # Call the copy_to() function defined in the JobCore
         new_job_core, file_project, hdf5_project, reloaded = self._internal_copy_to(
             project=project,
@@ -534,6 +539,13 @@ class GenericJob(JobCore):
             copy_files=False,
             delete_existing_job=delete_existing_job
         )
+
+        # Remove output if it should not be copied
+        if input_only:
+            for group in new_job_core.project_hdf5.list_groups():
+                if "output" in group:
+                    del new_job_core.project_hdf5[posixpath.join(new_job_core.project_hdf5.h5_path, group)]
+            new_job_core._status = "initialized"
         new_job_core._after_generic_copy_to(self, new_database_entry=new_database_entry, reloaded=reloaded)
         return new_job_core
 


### PR DESCRIPTION
I made a mistake in the refactor in #320 and didn't use the argument `input_only` in the method `GenericJob.copy_to`, because I had moved it to `JobCore.copy_to`.  However, the former doesn't actually call the later so it got ignored.  This in turn caused tests in [pyiron_atomistics](https://github.com/pyiron/pyiron_atomistics/pull/221/checks?check_run_id=2719264280) to fail.

The ugly fix here is to just copy some code from `JobCore`, so we can ship a working version straight-away.  I'll look into doing some re-architecture to avoid the duplication tomorrow.