### PR TITLE
Database Hotfix

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -152,6 +152,9 @@ options can be added to the :code:`~/.pyiron`:
 
 * :code:`JOB_TABLE` the name of the database table. pyiron is commonly using one table per user. 
 
+* :code:`CONNECTION_TIMEOUT` the time in seconds before an idle connection to the database server is closed, set to 0 to
+  close after every transaction.  Default is 60 seconds.
+
 A typical :code:`.pyiron` configuration with a `PostgreSQL <https://www.postgresql.org>`_ database might look like this: 
 
 .. code-block:: bash

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -128,12 +128,14 @@ class AutorestoredConnection:
         while True:
             try:
                 if self._conn is None or self._conn.closed:
-                    if self._conn is None:
-                        self._logger.info("Reconnecting to DB; connection not existing.")
-                    else:
-                        self._logger.info("Reconnecting to DB; connection closed.")
                     self._conn = self.engine.connect()
                     if self._timeout > 0:
+                        # only log reconnections when we keep the connection alive between requests otherwise we'll spam
+                        # the log
+                        if self._conn is None:
+                            self._logger.info("Reconnecting to DB; connection not existing.")
+                        else:
+                            self._logger.info("Reconnecting to DB; connection closed.")
                         if self._watchdog is not None:
                             # in case connection is dead, but watchdog is still up, something else killed the connection,
                             # make the watchdog quit, then making a new one

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -89,7 +89,10 @@ class ConnectionWatchDog(Thread):
             kicked = self._queue.get(timeout=self._timeout)
             if not kicked:
                 with self._lock:
-                    self._conn.close()
+                    try:
+                        self._conn.close()
+                    except:
+                        pass
                     break
 
     def kick(self):

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -28,7 +28,7 @@ from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import select
 from sqlalchemy.exc import OperationalError, DatabaseError
 from threading import Thread, Lock
-from queue import SimpleQueue
+from queue import SimpleQueue, Empty as QueueEmpty
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -86,7 +86,10 @@ class ConnectionWatchDog(Thread):
         Starts the watchdog.
         """
         while True:
-            kicked = self._queue.get(timeout=self._timeout)
+            try:
+                kicked = self._queue.get(timeout=self._timeout)
+            except QueueEmpty:
+                kicked = False
             if not kicked:
                 with self._lock:
                     try:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -5,11 +5,12 @@
 DatabaseAccess class deals with accessing the database
 """
 
+import pyiron_base.settings.logger
+
 import numpy as np
 import re
 import time
 import warnings
-import logging
 import os
 from datetime import datetime
 from sqlalchemy import (
@@ -120,7 +121,7 @@ class AutorestoredConnection:
         self._conn = None
         self._lock = Lock()
         self._watchdog = None
-        self._logger = logging.getLogger("pyiron_log")
+        self._logger = pyiron_base.settings.logger.get_logger()
 
     def execute(self, *args, **kwargs):
         while True:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -99,6 +99,7 @@ class DatabaseAccess(object):
                     poolclass=NullPool,
                 )
                 self.conn = AutorestoredConnection(self._engine)
+                self._keep_connection = True
             else:
                 self._engine = create_engine(connection_string)
                 self.conn = self._engine.connect()

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -8,6 +8,7 @@ DatabaseAccess class deals with accessing the database
 import numpy as np
 import re
 import time
+import warnings
 import os
 from datetime import datetime
 from sqlalchemy import (
@@ -38,7 +39,6 @@ __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
-
 class AutorestoredConnection:
     def __init__(self, engine):
         self.engine = engine
@@ -47,9 +47,14 @@ class AutorestoredConnection:
     def execute(self, *args, **kwargs):
         try:
             if self._conn is None or self._conn.closed:
+                if self._conn is None:
+                    print("Reconnecting to DB; connection not existing.")
+                else:
+                    print("Reconnecting to DB; connection closed.")
                 self._conn = self.engine.connect()
             result = self._conn.execute(*args, **kwargs)
-        except OperationalError:
+        except OperationalError as e:
+            print(f"Database connection failed with operational error {e}, waiting 5s, then re-trying.")
             time.sleep(5)
             result = self.execute(*args, **kwargs)
         return result

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -10,7 +10,6 @@ import pyiron_base.settings.logger
 import numpy as np
 import re
 import time
-import warnings
 import os
 from datetime import datetime
 from sqlalchemy import (

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -45,18 +45,19 @@ class AutorestoredConnection:
         self._conn = None
 
     def execute(self, *args, **kwargs):
-        try:
-            if self._conn is None or self._conn.closed:
-                if self._conn is None:
-                    print("Reconnecting to DB; connection not existing.")
-                else:
-                    print("Reconnecting to DB; connection closed.")
-                self._conn = self.engine.connect()
-            result = self._conn.execute(*args, **kwargs)
-        except OperationalError as e:
-            print(f"Database connection failed with operational error {e}, waiting 5s, then re-trying.")
-            time.sleep(5)
-            result = self.execute(*args, **kwargs)
+        while True:
+            try:
+                if self._conn is None or self._conn.closed:
+                    if self._conn is None:
+                        print("Reconnecting to DB; connection not existing.")
+                    else:
+                        print("Reconnecting to DB; connection closed.")
+                    self._conn = self.engine.connect()
+                result = self._conn.execute(*args, **kwargs)
+                break
+            except OperationalError as e:
+                print(f"Database connection failed with operational error {e}, waiting 5s, then re-trying.")
+                time.sleep(5)
         return result
 
     def close(self):

--- a/pyiron_base/job/wrapper.py
+++ b/pyiron_base/job/wrapper.py
@@ -126,6 +126,13 @@ def job_wrapper_function(working_directory, job_id=None, file_path=None, submit_
         debug (bool): enable debug mode
         submit_on_remote (bool): submit to queuing system on remote host
     """
+
+    # always close the database connection in calculations on the cluster to avoid high number of concurrent
+    # connections.
+    s.close_connection()
+    s.connection_timeout = 0
+    s.open_connection()
+
     if job_id is not None:
         job = JobWrapper(
             working_directory=working_directory,

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -432,12 +432,12 @@ class Settings(metaclass=Singleton):
                 self._configuration["sql_view_user_key"] = parser.get(
                     section, "VIEWERPASSWD"
                 )
-            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", default=60)
+            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", fallback=60)
         elif self._configuration["sql_type"] == "SQLalchemy":
             self._configuration["sql_connection_string"] = parser.get(
                 section, "CONNECTION"
             )
-            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", default=60)
+            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", fallback=60)
         else:  # finally we assume an SQLite connection
             if parser.has_option(section, "FILE"):
                 self._configuration["sql_file"] = parser.get(section, "FILE").replace(

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -60,6 +60,7 @@ class Settings(metaclass=Singleton):
             "user": "pyiron",
             "resource_paths": [],
             "project_paths": [],
+            "connection_timeout": 60,
             "sql_connection_string": None,
             "sql_table_name": "jobs_pyiron",
             "sql_view_connection_string": None,
@@ -200,6 +201,7 @@ class Settings(metaclass=Singleton):
             self._database = DatabaseAccess(
                 self._configuration["sql_connection_string"],
                 self._configuration["sql_table_name"],
+                timeout=self._configuration["connection_timeout"]
             )
 
     def switch_to_local_database(self, file_name="pyiron.db", cwd=None):
@@ -416,10 +418,12 @@ class Settings(metaclass=Singleton):
                 self._configuration["sql_view_user_key"] = parser.get(
                     section, "VIEWERPASSWD"
                 )
+            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", default=60)
         elif self._configuration["sql_type"] == "SQLalchemy":
             self._configuration["sql_connection_string"] = parser.get(
                 section, "CONNECTION"
             )
+            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", default=60)
         else:  # finally we assume an SQLite connection
             if parser.has_option(section, "FILE"):
                 self._configuration["sql_file"] = parser.get(section, "FILE").replace(

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -192,6 +192,20 @@ class Settings(metaclass=Singleton):
         """
         return self._configuration["resource_paths"]
 
+    @property
+    def connection_timeout(self):
+        """
+        Get the connection timeout in seconds.  Zero means close the database after every connection.
+
+        Returns:
+            int: timeout in seconds
+        """
+        return self._configuration["connection_timeout"]
+
+    @connection_timeout.setter
+    def connection_timeout(self, val):
+        self._configuration["connection_timeout"] = val
+
     def open_connection(self):
         """
         Internal function to open the connection to the database. Only after this function is called the database is

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -432,12 +432,12 @@ class Settings(metaclass=Singleton):
                 self._configuration["sql_view_user_key"] = parser.get(
                     section, "VIEWERPASSWD"
                 )
-            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", fallback=60)
+            self._configuration["connection_timeout"] = parser.get(section, "CONNECTION_TIMEOUT", fallback=60)
         elif self._configuration["sql_type"] == "SQLalchemy":
             self._configuration["sql_connection_string"] = parser.get(
                 section, "CONNECTION"
             )
-            self._configuration["connection_timeout"] = parser.get(section, "connection_timeout", fallback=60)
+            self._configuration["connection_timeout"] = parser.get(section, "CONNECTION_TIMEOUT", fallback=60)
         else:  # finally we assume an SQLite connection
             if parser.has_option(section, "FILE"):
                 self._configuration["sql_file"] = parser.get(section, "FILE").replace(

--- a/pyiron_base/settings/logger.py
+++ b/pyiron_base/settings/logger.py
@@ -68,3 +68,13 @@ def setup_logger():
         logger.addHandler(fh)
 
     return logger
+
+_logger = setup_logger()
+def get_logger():
+    """
+    Return global instance of the default logger to the log file at `pyiron.log`.
+
+    This exists only to circumvent recursive imports for modules that implement functionality for :class:`.Settings`,
+    normal code should rely on the logger defined at :attribute:`.Settings.logger`.
+    """
+    return _logger


### PR DESCRIPTION
@raynol-dsouza alerted me yesterday that pyiron was generally slow on the cluster, saving jobs etc could take up to a minute.  It turns out that the problem was with the database.  Our `DatabaseAccess` has an attribute `_keep_connection` which was set to `False` in the case of postgres, which in turns means every database look up would open a connection, do its thing, then closing it again.  One database connection takes ~1s, but e.g. saving a job requires ~20 database accesses so it stacks.

For now I've simply set `_keep_connection` to `True` in every case, but I'm not sure if that has any unintended side effects.  I'm not really sure why this wasn't an issue before.  I've briefly scanned the sqlalchemy changelog, but didn't find anything interesting.

On a side note there's a problem with logging in the database module right now. I would like log (re-)connections to the database, so it's quicker to debug in the future, but I also cannot import the settings module to access the global logger, since that would create a circular import (settings needs database access).  I have left simple print calls now, but this should be changed before merging.