### PR TITLE
Copy files in copy_to

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -721,9 +721,12 @@ class JobCore(HasGroups):
 
         # Copy files outside the HDF5 file
         if copy_files and os.path.exists(self.working_directory):
+            if len(os.listdir(new_job_core.working_directory)) > 0:
+                raise RuntimeError("Target directory for copy not empty!")
             shutil.copytree(
                 self.working_directory,
                 new_job_core.working_directory,
+                dirs_exist_ok=True
             )
         return new_job_core, file_project, hdf5_project, False
 

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -721,12 +721,13 @@ class JobCore(HasGroups):
 
         # Copy files outside the HDF5 file
         if copy_files and os.path.exists(self.working_directory):
-            if len(os.listdir(new_job_core.working_directory)) > 0:
+            if len(os.listdir(new_job_core.working_directory)) == 0:
+                os.rmdir(new_job_core.working_directory)
+            else:
                 raise RuntimeError("Target directory for copy not empty!")
             shutil.copytree(
                 self.working_directory,
-                new_job_core.working_directory,
-                dirs_exist_ok=True
+                new_job_core.working_directory
             )
         return new_job_core, file_project, hdf5_project, False
 

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -705,6 +705,7 @@ class JobCore(HasGroups):
         new_job_core._parent_id = self._parent_id
         new_job_core._master_id = self._master_id
         new_job_core._status = self._status
+        new_job_core._create_working_directory()
         if new_job_name == self.job_name:
             self.project_hdf5.copy_to(destination=hdf5_project.open(".."))
         else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -509,7 +509,7 @@ class GenericJob(JobCore):
         return new_job_core, file_project, hdf5_project, reloaded
 
     def copy_to(self, project=None, new_job_name=None, input_only=False, new_database_entry=True,
-                delete_existing_job=False):
+                delete_existing_job=False, copy_files=True):
         """
         Copy the content of the job including the HDF5 file to a new location.
 
@@ -522,6 +522,7 @@ class GenericJob(JobCore):
             new_database_entry (bool): [True/False] Whether to create a new database entry. If input_only is True then
                 new_database_entry is False. (Default is True.)
             delete_existing_job (bool): [True/False] Delete existing job in case it exists already (Default is False.)
+            copy_files (bool): If True copy all files the working directory of the job, too
 
         Returns:
             GenericJob: GenericJob object pointing to the new location.
@@ -536,7 +537,7 @@ class GenericJob(JobCore):
             project=project,
             new_job_name=new_job_name,
             new_database_entry=new_database_entry,
-            copy_files=False,
+            copy_files=copy_files,
             delete_existing_job=delete_existing_job
         )
 


### PR DESCRIPTION
`GenericJob` could previously copy files from the working directory, but didn't by default.  I exposed `copy_files` as an argument and change the default to `True`, same as in `JobCore`.

Fixes #348.