### PR TITLE
Use correct project in copy_to

### DIFF
--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -269,7 +269,7 @@ class GenericMaster(GenericJob):
             for child_id in original.child_ids:
                 child = original.project.load(child_id)
                 new_child = child.copy_to(
-                    project=file_project.open(self.job_name + "_hdf5"),
+                    project=self.project.open(self.job_name + "_hdf5"),
                     new_database_entry=new_database_entry,
                 )
                 if new_database_entry and child.parent_id:


### PR DESCRIPTION
Should fix #362 

If I see this correctly `file_project` originally referred to the project from `_get_project_for_copy`, which in turn should be the project the new job is located in turn and since the `_after_generic_copy_to` is called on the new job this would be identical to `self.project`.