### PR TITLE
Allow lazy loading of DataContainers

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -250,8 +250,9 @@ class DataContainer(MutableMapping, HasGroups):
 
         return instance
 
-    def __init__(self, init=None, table_name=None):
+    def __init__(self, init=None, table_name=None, lazy=False):
         self.table_name = table_name
+        self._lazy = lazy
         if init is not None:
             self.update(init, wrap=True)
 

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -12,9 +12,9 @@ from collections.abc import Sequence, Set, Mapping, MutableMapping
 
 import numpy as np
 
+from pyiron_base.generic.fileio import read, write
+from pyiron_base.generic.hdfstub import HDFStub
 from pyiron_base.interfaces.has_groups import HasGroups
-from .fileio import read, write
-from .hdfstub import HDFStub
 
 __author__ = "Marvin Poul"
 __copyright__ = (

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from pyiron_base.interfaces.has_groups import HasGroups
 from .fileio import read, write
-from .hdfstub import HDF5Stub
+from .hdfstub import HDFStub
 
 __author__ = "Marvin Poul"
 __copyright__ = (
@@ -49,7 +49,7 @@ def _normalize(key):
 
     return key
 
-HDF5Stub.register('DataContainer', lambda h, g: h[g].to_object(lazy=True))
+HDFStub.register('DataContainer', lambda h, g: h[g].to_object(lazy=True))
 
 class DataContainer(MutableMapping, HasGroups):
     """
@@ -277,10 +277,10 @@ class DataContainer(MutableMapping, HasGroups):
         elif isinstance(key, int):
             try:
                 v = self._store[key]
-                if not isinstance(v, HDF5Stub):
+                if not isinstance(v, HDFStub):
                     return v
                 else:
-                    v = self._store[key] = v.realize()
+                    v = self._store[key] = v.load()
                     return v
             except IndexError:
                 raise IndexError("list index out of range") from None
@@ -288,10 +288,10 @@ class DataContainer(MutableMapping, HasGroups):
         elif isinstance(key, str):
             try:
                 v = self._store[self._indices[key]]
-                if not isinstance(v, HDF5Stub):
+                if not isinstance(v, HDFStub):
                     return v
                 else:
-                    v = self._store[self._indices[key]] = v.realize()
+                    v = self._store[self._indices[key]] = v.load()
                     return v
             except KeyError:
                 raise KeyError(repr(key)) from None
@@ -757,9 +757,9 @@ class DataContainer(MutableMapping, HasGroups):
             for n in hdf.list_nodes():
                 if n in _internal_hdf_nodes:
                     continue
-                items.append( (*normalize_key(n), hdf[n] if not self._lazy else HDF5Stub(hdf, n)) )
+                items.append( (*normalize_key(n), hdf[n] if not self._lazy else HDFStub(hdf, n)) )
             for g in hdf.list_groups():
-                items.append( (*normalize_key(g), hdf[g].to_object() if not self._lazy else HDF5Stub(hdf, g)) )
+                items.append( (*normalize_key(g), hdf[g].to_object() if not self._lazy else HDFStub(hdf, g)) )
 
 
             for _, k, v in sorted(items, key=lambda x: x[0]):

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -278,7 +278,8 @@ class DataContainer(MutableMapping, HasGroups):
                 if not isinstance(v, HDF5Stub):
                     return v
                 else:
-                    return v.realize()
+                    v = self._store[key] = v.realize()
+                    return v
             except IndexError:
                 raise IndexError("list index out of range") from None
 
@@ -288,7 +289,8 @@ class DataContainer(MutableMapping, HasGroups):
                 if not isinstance(v, HDF5Stub):
                     return v
                 else:
-                    return v.realize()
+                    v = self._store[self._indices[key]] = v.realize()
+                    return v
             except KeyError:
                 raise KeyError(repr(key)) from None
 

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -396,7 +396,10 @@ class DataContainer(MutableMapping, HasGroups):
     def __repr__(self):
         name = self.__class__.__name__
         if self.has_keys():
-            return name + "({" + ", ".join("{!r}: {!r}".format(k, v) for k, v in self.items()) + "})"
+            # access _store and _indices directly to avoid forcing HDFStubs
+            index2key = {v: k for k, v in self._indices.items()}
+            return name + "({" + ", ".join("{!r}: {!r}".format(index2key.get(i, i), self._store[i])
+                                                for i in range(len(self))) + "})"
         else:
             return name + "([" + ", ".join("{!r}".format(v) for v in self._store) + "])"
 

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from pyiron_base.interfaces.has_groups import HasGroups
 from .fileio import read, write
-from .hdfstub import HDF5Stub, SimpleStub, ObjectStub, DataContainerStub
+from .hdfstub import HDF5Stub
 
 __author__ = "Marvin Poul"
 __copyright__ = (
@@ -49,6 +49,7 @@ def _normalize(key):
 
     return key
 
+HDF5Stub.register('DataContainer', lambda h, g: h[g].to_object(lazy=True))
 
 class DataContainer(MutableMapping, HasGroups):
     """
@@ -756,18 +757,9 @@ class DataContainer(MutableMapping, HasGroups):
             for n in hdf.list_nodes():
                 if n in _internal_hdf_nodes:
                     continue
-                items.append( (*normalize_key(n), hdf[n] if not self._lazy else SimpleStub(hdf, n)) )
+                items.append( (*normalize_key(n), hdf[n] if not self._lazy else HDF5Stub(hdf, n)) )
             for g in hdf.list_groups():
-                # poor programmer's static type check, if this is called on DataContainer and is reading a DataContainer
-                # in HDF5 this be True and also when this is called on a subclass of DataContainer and is reading either
-                # the same subclass or a DataContainer in HDF.  It will not work when one subclass is reading another or
-                # a DataContainer is reading a subclass.
-                if hdf[g]['NAME'] in ("DataContainer", self.__class__.__name__):
-                    items.append( (*normalize_key(g),
-                                    hdf[g].to_object() if not self._lazy else DataContainerStub(hdf, g)) )
-                else:
-                    items.append( (*normalize_key(g),
-                                    hdf[g].to_object() if not self._lazy else ObjectStub(hdf, g)) )
+                items.append( (*normalize_key(g), hdf[g].to_object() if not self._lazy else HDF5Stub(hdf, g)) )
 
 
             for _, k, v in sorted(items, key=lambda x: x[0]):

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -159,7 +159,6 @@ class DataContainer(MutableMapping, HasGroups):
     >>> list(pl.keys())
     [0, 1, 2, 3]
 
-
     Implements :class:`.HasGroups`.  Groups are nested data containers and nodes are everything else.
 
     >>> p = DataContainer({"a": 42, "b": [0, 1, 2]})
@@ -167,6 +166,12 @@ class DataContainer(MutableMapping, HasGroups):
     ['b']
     >>> p.list_nodes()
     ['a']
+
+    If instantiated with the argument `lazy=True`, data read from HDF5 later via :method:`.from_hdf` are not actually
+    read, but only earmarked to be read later when actually accessed via :class:`.HDFStub`.  This is largely
+    transparent, i.e. when accessing an earmarked value it will automatically be loaded and this loaded value is stored
+    in container.  The only difference is in the string representation of the container, values not read yet appear as
+    'HDFStub(...)' in the output.
 
     .. attention:: Subclasses beware!
 
@@ -252,6 +257,15 @@ class DataContainer(MutableMapping, HasGroups):
         return instance
 
     def __init__(self, init=None, table_name=None, lazy=False):
+        """
+        Create new container.
+
+        Args:
+            init (Sequence, Mapping): initial data for the container, nested occurances of Sequence and Mapping are
+                                      translated to nested containers
+            table_name (str): default name of the data container in HDF5
+            lazy (bool): if True, use :class:`.HDFStub` to load values lazily from HDF5
+        """
         self.table_name = table_name
         self._lazy = lazy
         if init is not None:

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -30,6 +30,9 @@ class HDF5Stub(ABC):
     def realize(self):
         pass
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._hdf}, {self._group_name})"
+
 class SimpleStub(HDF5Stub):
 
     def realize(self):

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -1,0 +1,39 @@
+"""
+Convenience class to lazily read values from HDF.
+"""
+
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+__author__ = "Marvin Poul"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Marvin Poul"
+__email__ = "poul@mpie.de"
+__status__ = "production"
+__date__ = "Apr 26, 2021"
+
+
+
+class HDF5Stub(ABC):
+
+    def __init__(self, hdf, group_name):
+        self._hdf = hdf
+        self._group_name = group_name
+
+    @abstractmethod
+    def realize(self):
+        pass
+
+class SimpleStub(HDF5Stub):
+
+    def realize(self):
+        return self._hdf[self._group_name]
+
+class ObjectStub(HDF5Stub):
+
+    def realize(self):
+        return self._hdf[self._group_name].to_object()

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -5,8 +5,6 @@ Convenience class to lazily read values from HDF.
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from abc import ABC, abstractmethod
-
 __author__ = "Marvin Poul"
 __copyright__ = (
     "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
@@ -19,20 +17,76 @@ __status__ = "production"
 __date__ = "Apr 26, 2021"
 
 
-
 class HDF5Stub:
+    """
+    Provides lazy loading of data from HDF.
+
+    Instead of accessing an HDF group directly
+
+    >>> hdf[group_name]
+    ...
+
+    you can wrap this with this class
+
+    >>> stub = HDF5Stub(hdf, group_name)
+
+    and then later perform this lookup with :method:`.realize`
+
+    >>> stub.realize() == hdf[group_name]
+    True
+
+    For simple datatypes there's not a big advantages to this, but :class:`.DataContainer` uses this to load its
+    contents lazily and ensure that nested containers are also lazily loaded.  This is done by customizing what happend
+    on :method:`.realize` via :method:`.register`.  This class method adds a callback to the class that will be called
+    when the specified type name is found in the hdf group that is to be loaded.
+
+    >>> hdf['mytype/NAME']
+    MyType
+    >>> HDF5Stub.register('MyType', lambda hdf, group: print(42) or hdf[group].to_object())
+    >>> my = HDF5Stub(hdf, 'mytype').realize()
+    42
+    >>> my
+    MyType(...)
+
+    This is intended to allow classes that want to be lazily loaded in a certain way to customize what arguments they
+    pass `to_object()` (and therefore to their own initializers).
+    """
 
     _realize_functions = {}
 
     def __init__(self, hdf, group_name):
+        """
+        Create new stub.
+
+        Args:
+            hdf (:class:`.ProjectHDFio`): hdf object to load from
+            group_name (str): node or group name to load from the hdf object
+        """
         self._hdf = hdf
         self._group_name = group_name
 
     @classmethod
     def register(cls, type_name, realize):
+        """
+        Register call back for a new type.
+
+        Args:
+            type_name (str): the class name of the type to be register, corresponds to what pyiron object save in 'NAME'
+                             field of their HDF groups
+            realize (function): callback that is called on :method:`.realize` when the type matches `type_name`, must
+                             accept `hdf` and `group_name` corresponding to the init paramters of this class and return
+                             (lazily) loaded object
+        """
         cls._realize_functions[type_name] = realize
 
     def realize(self):
+        """
+        Read value from HDF.
+
+        If `group_name` is a node in HDF, simply its value will be returned.  If it is a group in HDF and the 'NAME'
+        node matches any of the types registered with :method:`.register`, it will be loaded with the provided callback.
+        Otherwise it will be loaded with :method:`.ProjectHDFio.to_object()`.
+        """
         if self._group_name in self._hdf.list_nodes():
             return self._hdf[self._group_name]
         realize = self._realize_functions.get(

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -75,7 +75,7 @@ class HDFStub:
         Args:
             type (type): class to be registered
             load (function): callback that is called on :method:`.load` when the type matches `type_name`, must
-                             accept `hdf` and `group_name` corresponding to the init paramters of this class and return
+                             accept `hdf` and `group_name` corresponding to the init parameters of this class and return
                              (lazily) loaded object
         """
         cls._load_functions[str(type)] = load

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -5,6 +5,8 @@ Convenience class to lazily read values from HDF.
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
+from abc import ABC, abstractmethod
+
 __author__ = "Marvin Poul"
 __copyright__ = (
     "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
@@ -37,3 +39,10 @@ class ObjectStub(HDF5Stub):
 
     def realize(self):
         return self._hdf[self._group_name].to_object()
+
+# exists to pass lazy=True, to make sure we can be recursively lazy!
+class DataContainerStub(HDF5Stub):
+
+    def realize(self):
+        return self._hdf[self._group_name].to_object(lazy=True)
+

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -17,7 +17,7 @@ __status__ = "production"
 __date__ = "Apr 26, 2021"
 
 
-class HDF5Stub:
+class HDFStub:
     """
     Provides lazy loading of data from HDF.
 
@@ -28,22 +28,22 @@ class HDF5Stub:
 
     you can wrap this with this class
 
-    >>> stub = HDF5Stub(hdf, group_name)
+    >>> stub = HDFStub(hdf, group_name)
 
-    and then later perform this lookup with :method:`.realize`
+    and then later perform this lookup with :method:`.load`
 
-    >>> stub.realize() == hdf[group_name]
+    >>> stub.load() == hdf[group_name]
     True
 
     For simple datatypes there's not a big advantages to this, but :class:`.DataContainer` uses this to load its
     contents lazily and ensure that nested containers are also lazily loaded.  This is done by customizing what happend
-    on :method:`.realize` via :method:`.register`.  This class method adds a callback to the class that will be called
+    on :method:`.load` via :method:`.register`.  This class method adds a callback to the class that will be called
     when the specified type name is found in the hdf group that is to be loaded.
 
     >>> hdf['mytype/NAME']
     MyType
-    >>> HDF5Stub.register('MyType', lambda hdf, group: print(42) or hdf[group].to_object())
-    >>> my = HDF5Stub(hdf, 'mytype').realize()
+    >>> HDFStub.register('MyType', lambda hdf, group: print(42) or hdf[group].to_object())
+    >>> my = HDFStub(hdf, 'mytype').load()
     42
     >>> my
     MyType(...)
@@ -52,7 +52,7 @@ class HDF5Stub:
     pass `to_object()` (and therefore to their own initializers).
     """
 
-    _realize_functions = {}
+    _load_functions = {}
 
     def __init__(self, hdf, group_name):
         """
@@ -66,20 +66,20 @@ class HDF5Stub:
         self._group_name = group_name
 
     @classmethod
-    def register(cls, type_name, realize):
+    def register(cls, type_name, load):
         """
         Register call back for a new type.
 
         Args:
             type_name (str): the class name of the type to be register, corresponds to what pyiron object save in 'NAME'
                              field of their HDF groups
-            realize (function): callback that is called on :method:`.realize` when the type matches `type_name`, must
+            load (function): callback that is called on :method:`.load` when the type matches `type_name`, must
                              accept `hdf` and `group_name` corresponding to the init paramters of this class and return
                              (lazily) loaded object
         """
-        cls._realize_functions[type_name] = realize
+        cls._load_functions[type_name] = load
 
-    def realize(self):
+    def load(self):
         """
         Read value from HDF.
 
@@ -89,11 +89,11 @@ class HDF5Stub:
         """
         if self._group_name in self._hdf.list_nodes():
             return self._hdf[self._group_name]
-        realize = self._realize_functions.get(
+        load = self._load_functions.get(
                 self._hdf[self._group_name]['NAME'],
                 lambda h, g: h[g].to_object()
         )
-        return realize(self._hdf, self._group_name)
+        return load(self._hdf, self._group_name)
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self._hdf}, {self._group_name})"

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -482,7 +482,7 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(not isinstance(ll._store[0], HDFStub),
                         "Loaded value not stored back into container!")
 
-    def test_stub(self):
+    def test_stub_sublasses(self):
         """Sub classes of DataContainer should also be able to be lazily loaded."""
 
         sl = Sub(self.pl.to_builtin())

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -488,8 +488,6 @@ class TestDataContainer(TestWithCleanProject):
         sl = Sub(self.pl.to_builtin())
 
         sl.to_hdf(self.hdf, "lazy_sub")
-        # breakpoint()
-        # ll = self.hdf["lazy_sub"].to_object(lazy=True)
         ll = Sub(lazy=True)
         ll.from_hdf(self.hdf, "lazy_sub")
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -472,6 +472,10 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),
                         "Some stubs have been loaded after getting string repr of container!")
 
+        ll0 = ll[0]
+        self.assertTrue(all(isinstance(v, HDFStub) for v in ll0._store),
+                        "Recursive datacontainers not lazily loaded!")
+
         self.assertEqual(ll[0].foo, self.pl[0].foo,
                          "Lazily loaded list not equal to orignal list!")
 

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -468,7 +468,7 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),
                         "Not all values loaded as stubs!")
 
-        ll_repr = repr(ll)
+        repr(ll)
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),
                         "Some stubs have been loaded after getting string repr of container!")
 
@@ -495,7 +495,7 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),
                         "Not all values loaded as stubs!")
 
-        ll_repr = repr(ll)
+        repr(ll)
         self.assertTrue(all(isinstance(v, HDFStub) for v in ll._store),
                         "Some stubs have been loaded after getting string repr of container!")
 

--- a/tests/generic/test_hdfstub.py
+++ b/tests/generic/test_hdfstub.py
@@ -1,0 +1,25 @@
+from pyiron_base._tests import TestWithProject
+from pyiron_base.generic.datacontainer import DataContainer
+from pyiron_base.generic.hdfstub import HDFStub
+
+import numpy as np
+
+class TestHDFStub(TestWithProject):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.hdf = cls.project.create_hdf(cls.project.path, "hdf")
+        cls.hdf["number"] = 42
+        cls.hdf["array"] = np.arange(100)
+        cls.data = DataContainer([1, 2, "three", 4.0])
+        cls.data.to_hdf(cls.hdf, "data")
+
+    def test_load(self):
+        """Lazily and eagerly read values should be the same."""
+        self.assertEqual(HDFStub(self.hdf, "number").load(), self.hdf["number"],
+                         "Simple number read with load() not equal to eager read.")
+        self.assertTrue(np.all( HDFStub(self.hdf, "array").load() == self.hdf["array"] ),
+                        "Numpy array read with load() not equal to eager read.")
+        for v1, v2 in zip(HDFStub(self.hdf, "data").load(), self.data):
+            self.assertEqual(v1, v2, "Data container values read with load() not equal to original container.")


### PR DESCRIPTION
With this data containers (and potentially other data types) can be loaded "on demand" from HDF5 instead of all at once.  In my simple example below this saves ~90% time on load.

The way it works is that in `from_hdf` values of the data container are not loading right away but just the hdf object and the path are saved in a "stub" object, that is then later transparently loaded upon item access.

Tests and design spec follow when we discussed this.

This should help with #364 and inspect mode in general.  My vision would be that expensive to load objects should be using data container for all storage and can then be `load()`ed with `lazy=True` instead of `inspect()`ed.

Here's an example that can be run with `ipython -i`

```python
# coding: utf-8
from pyiron_base import Project
import pyiron_base.generic.datacontainer as D
import numpy as np

d = D.DataContainer()
pr = Project('asdf')
h = pr.create_hdf(pr.path, 'test')

K = 'abcdefghijklmnop'
for c in K:
    dd = d.get(c, create=True)
    for c in K:
        dd[c] = np.random.rand(1024)

d.to_hdf(h, 'lazy')
# ~2s
get_ipython().run_line_magic('time', "d_normal = h['lazy'].to_object()")
# ~150ms
get_ipython().run_line_magic('time', "d_lazy = h['lazy'].to_object(lazy=True)")

assert (d_normal.a.a == d_lazy.a.a).all()
```