### PR TITLE
Simplify logic when changing project_hdf5 of child jobs

### DIFF
--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -138,7 +138,7 @@ class GenericMaster(GenericJob):
         self._load_all_child_jobs(self)
         for child_job_name in self._job_name_lst:
             child_job = self._load_job_from_cache(child_job_name)
-            self._child_job_update_hdf(self, child_job)
+            self._child_job_update_hdf(child_job)
 
     @property
     def child_names(self):
@@ -230,7 +230,7 @@ class GenericMaster(GenericJob):
             self.server.cores = job.server.cores
         if job.job_name not in self._job_name_lst:
             self._job_name_lst.append(job.job_name)
-            self._child_job_update_hdf(parent_job=self, child_job=job)
+            self._child_job_update_hdf(job)
 
     def pop(self, i=-1):
         """
@@ -566,19 +566,18 @@ class GenericMaster(GenericJob):
         else:
             return super(GenericMaster, self).__getitem__(item)
 
-    def _child_job_update_hdf(self, parent_job, child_job):
+    def _child_job_update_hdf(self, child_job):
         """
 
         Args:
-            parent_job:
             child_job:
         """
         child_job.project_hdf5 = ProjectHDFio(
                 project=child_job.project_hdf5.project,
-                file_name=parent_job.project_hdf5.file_name,
-                h5_path=parent_job.project_hdf5.h5_path + "/" + child_job.job_name
+                file_name=self.project_hdf5.file_name,
+                h5_path=self.project_hdf5.h5_path + "/" + child_job.job_name
         )
-        parent_job.job_object_dict[child_job.job_name] = child_job
+        self.job_object_dict[child_job.job_name] = child_job
 
     def _executable_activate_mpi(self):
         """

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -7,6 +7,7 @@ The GenericMaster is the template class for all meta jobs
 
 import inspect
 import textwrap
+from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
 
@@ -562,9 +563,10 @@ class GenericMaster(GenericJob):
             parent_job:
             child_job:
         """
-        child_job.project_hdf5.file_name = parent_job.project_hdf5.file_name
-        child_job.project_hdf5.h5_path = (
-            parent_job.project_hdf5.h5_path + "/" + child_job.job_name
+        child_job.project_hdf5 = ProjectHDFio(
+                project=child_job.project_hdf5.project,
+                file_name=parent_job.project_hdf5.file_name,
+                h5_path=parent_job.project_hdf5.h5_path + "/" + child_job.job_name
         )
         if isinstance(child_job, GenericMaster):
             for sub_job_name in child_job._job_name_lst:

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -789,9 +789,6 @@ class ParallelMaster(GenericMaster):
         job = self.ref_job.copy()
         job = self._load_all_child_jobs(job_to_load=job)
         job.project_hdf5 = self.child_hdf(job_name)
-        if isinstance(job, GenericMaster):
-            for sub_job in job._job_object_dict.values():
-                self._child_job_update_hdf(parent_job=job, child_job=sub_job)
         self._logger.debug(
             "create_job:: {} {} {} {}".format(
                 self.project_hdf5.path,


### PR DESCRIPTION
There were a few spots previously where would change the hdf5 of a child to a new path and then check if that child is a `GenericMaster`.  Instead I overload `project_hdf5` on `GenericMaster` to avoid that check.