### PR TITLE
Enable to remove a job with loading the full job object.

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -6,12 +6,15 @@ The JobCore the most fundamental pyiron job class.
 """
 
 import copy
+import math
 import os
 import posixpath
-import math
-from pyiron_base.settings.generic import Settings
+import shutil
+import warnings
+
+from tables import NoSuchNodeError
+
 from pyiron_base.interfaces.has_groups import HasGroups
-from pyiron_base.generic.util import static_isinstance
 from pyiron_base.job.util import \
     _get_project_for_copy, \
     _copy_database_entry, \
@@ -27,9 +30,7 @@ from pyiron_base.job.util import \
     _job_delete_files, \
     _job_delete_hdf, \
     _job_remove_folder
-from tables import NoSuchNodeError
-import shutil
-import warnings
+from pyiron_base.settings.generic import Settings
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -429,6 +430,23 @@ class JobCore(HasGroups):
         internal function to remove command that removes also child jobs.
         Do never use this command, since it will destroy the integrity of your project.
         """
+        # Check if the job requires to be removed from the full object (This is the case for external Storage)
+        print(f"Enter base/job/core/JobCore.remove_child with self={type(self)} with path={self.path}")
+        try:
+            print("try")
+            requires_full_object = self.get('REQ_OBJ_RM')
+            print("Found!")
+        except ValueError as e:
+            print(e)
+            requires_full_object = False
+
+        print("Check if requires full object:")
+        if requires_full_object:
+            print("require full obj!")
+            job = self.to_object()
+            job.remove_child()
+
+        print('Go on with unchanged implementation')
         # Delete job from HPC-computing-queue if it is still running.
         job_status = str(self.status)
         if (

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -431,10 +431,7 @@ class JobCore(HasGroups):
         Do never use this command, since it will destroy the integrity of your project.
         """
         # Check if the job requires to be removed from the full object (This is the case for external Storage)
-        try:
-            requires_full_object = self.get('REQ_OBJ_RM')
-        except ValueError as e:
-            requires_full_object = False
+        requires_full_object = self.get('REQ_OBJ_RM', default=False)
 
         if requires_full_object:
             job = self.to_object()

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -431,22 +431,15 @@ class JobCore(HasGroups):
         Do never use this command, since it will destroy the integrity of your project.
         """
         # Check if the job requires to be removed from the full object (This is the case for external Storage)
-        print(f"Enter base/job/core/JobCore.remove_child with self={type(self)} with path={self.path}")
         try:
-            print("try")
             requires_full_object = self.get('REQ_OBJ_RM')
-            print("Found!")
         except ValueError as e:
-            print(e)
             requires_full_object = False
 
-        print("Check if requires full object:")
         if requires_full_object:
-            print("require full obj!")
             job = self.to_object()
             job.remove_child()
 
-        print('Go on with unchanged implementation')
         # Delete job from HPC-computing-queue if it is still running.
         job_status = str(self.status)
         if (

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -436,8 +436,8 @@ class JobCore(HasGroups):
 
         if requires_full_object:
             job = self.to_object()
-            job.remove_child()
-
+            job._before_generic_remove_child()
+            
         # Delete job from HPC-computing-queue if it is still running.
         job_status = str(self.status)
         if (

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -431,7 +431,8 @@ class JobCore(HasGroups):
         Do never use this command, since it will destroy the integrity of your project.
         """
         # Check if the job requires to be removed from the full object (This is the case for external Storage)
-        requires_full_object = self.get('REQ_OBJ_RM', default=False)
+        # TODO: remove this workaround once the database lookup is aware of external storage types.
+        requires_full_object = self._hdf5.get('REQUIRE_FULL_OBJ_FOR_RM', default=False)
 
         if requires_full_object:
             job = self.to_object()

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -437,7 +437,7 @@ class JobCore(HasGroups):
         if requires_full_object:
             job = self.to_object()
             job._before_generic_remove_child()
-            
+
         # Delete job from HPC-computing-queue if it is still running.
         job_status = str(self.status)
         if (


### PR DESCRIPTION
For external storage types, we would need to remove the job using the fully loaded job object with the information how to reach the external storage. Therefore, I added a flag at the hdf level which is used to trigger a full load of the job.