### PR TITLE
Increase chemical formula limit to 50 characters

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -102,7 +102,7 @@ class DatabaseAccess(object):
         except Exception as except_msg:
             raise ValueError("Connection to database failed: " + str(except_msg))
 
-        self._chem_formula_lim_length=30
+        self._chem_formula_lim_length = 50
         self.__reload_db()
         self.simulation_table = Table(
             str(table_name),


### PR DESCRIPTION
I have increase the character limit of chemical formula to 50 in our database, therefore I changed the limit in the code as well.