### PR TITLE
Fix HDF of FlattenedStorage

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -487,8 +487,13 @@ class FlattenedStorage:
     def from_hdf(self, hdf, group_name="flat_storage"):
         with hdf.open(group_name) as hdf_s_lst:
             version = hdf_s_lst.get("HDF_VERSION", "0.0.0")
-            num_chunks = hdf_s_lst["num_chunks"] or hdf_s_lst["num_structures"]
-            num_elements = hdf_s_lst["num_elements"] or hdf_s_lst["num_atoms"]
+            try:
+                num_chunks = hdf_s_lst["num_chunks"]
+                num_elements = hdf_s_lst["num_elements"]
+            except KeyError:
+                num_chunks = hdf_s_lst["num_structures"]
+                num_elements = hdf_s_lst["num_atoms"]
+
             self._num_chunks_alloc = self.num_chunks = self.current_chunk_index = num_chunks
             self._num_elements_alloc = self.num_elements = self.current_element_index = num_elements
 

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -18,8 +18,6 @@ __status__ = "production"
 __date__ = "Jul 16, 2020"
 
 
-from itertools import chain
-
 import numpy as np
 import h5py
 
@@ -132,7 +130,7 @@ class FlattenedStorage:
     """
 
     __version__ = "0.1.0"
-    __hdf_version__ = "0.1.0"
+    __hdf_version__ = "0.2.0"
 
     def __init__(self, num_chunks=1, num_elements=1, **kwargs):
         """
@@ -469,20 +467,27 @@ class FlattenedStorage:
             hdf_s_lst["num_elements"] =  self._num_elements_alloc
             hdf_s_lst["num_chunks"] = self._num_chunks_alloc
 
-            hdf_arrays = hdf_s_lst.open("arrays")
-            for k, a in chain(self._per_element_arrays.items(), self._per_chunk_arrays.items()):
-                if a.dtype.char == "U":
+            def write_array(name, array, hdf):
+                if array.dtype.char == "U":
                     # numpy stores unicode data in UTF-32/UCS-4, but h5py wants UTF-8, so we manually encode them here
                     # TODO: string arrays with shape != () not handled
-                    hdf_arrays[k] = np.array([s.encode("utf8") for s in a],
-                                             # each character in a utf8 string might be encoded in up to 4 bytes, so to
-                                             # make sure we can store any string of length n we tell h5py that the
-                                             # string will be 4 * n bytes; numpy's dtype does this calculation already
-                                             # in itemsize, so we don't need to repeat it here
-                                             # see also https://docs.h5py.org/en/stable/strings.html
-                                             dtype=h5py.string_dtype('utf8', a.dtype.itemsize))
+                    hdf[name] = np.array([s.encode("utf8") for s in array],
+                                         # each character in a utf8 string might be encoded in up to 4 bytes, so to
+                                         # make sure we can store any string of length n we tell h5py that the
+                                         # string will be 4 * n bytes; numpy's dtype does this calculation already
+                                         # in itemsize, so we don't need to repeat it here
+                                         # see also https://docs.h5py.org/en/stable/strings.html
+                                         dtype=h5py.string_dtype('utf8', array.dtype.itemsize))
                 else:
-                    hdf_arrays[k] = a
+                    hdf[name] = array
+
+            hdf_arrays = hdf_s_lst.open("element_arrays")
+            for k, a in self._per_element_arrays.items():
+                write_array(k, a, hdf_arrays)
+
+            hdf_arrays = hdf_s_lst.open("chunk_arrays")
+            for k, a in self._per_chunk_arrays.items():
+                write_array(k, a, hdf_arrays)
 
     def from_hdf(self, hdf, group_name="flat_storage"):
         with hdf.open(group_name) as hdf_s_lst:
@@ -497,21 +502,36 @@ class FlattenedStorage:
             self._num_chunks_alloc = self.num_chunks = self.current_chunk_index = num_chunks
             self._num_elements_alloc = self.num_elements = self.current_element_index = num_elements
 
-            with hdf_s_lst.open("arrays") as hdf_arrays:
-                for k in hdf_arrays.list_nodes():
-                    a = np.array(hdf_arrays[k])
-                    if a.dtype.char == "S":
-                        # if saved as bytes, we wrote this as an encoded unicode string, so manually decode here
-                        # TODO: string arrays with shape != () not handled
-                        a = np.array([s.decode("utf8") for s in a],
-                                    # itemsize of original a is four bytes per character, so divide by four to get
-                                    # length of the orignal stored unicode string; np.dtype('U1').itemsize is just a
-                                    # platform agnostic way of knowing how wide a unicode charater is for numpy
-                                    dtype=f"U{a.dtype.itemsize//np.dtype('U1').itemsize}")
-                    if a.shape[0] == self._num_elements_alloc:
-                        self._per_element_arrays[k] = a
-                    elif a.shape[0] == self._num_chunks_alloc:
-                        self._per_chunk_arrays[k] = a
+            def read_array(name, hdf):
+                a = np.array(hdf[name])
+                if a.dtype.char == "S":
+                    # if saved as bytes, we wrote this as an encoded unicode string, so manually decode here
+                    # TODO: string arrays with shape != () not handled
+                    a = np.array([s.decode("utf8") for s in a],
+                                # itemsize of original a is four bytes per character, so divide by four to get
+                                # length of the orignal stored unicode string; np.dtype('U1').itemsize is just a
+                                # platform agnostic way of knowing how wide a unicode charater is for numpy
+                                dtype=f"U{a.dtype.itemsize//np.dtype('U1').itemsize}")
+                return a
+
+            if version == "0.1.0":
+                with hdf_s_lst.open("arrays") as hdf_arrays:
+                    for k in hdf_arrays.list_nodes():
+                        a = read_array(k, hdf_arrays)
+                        if a.shape[0] == self._num_elements_alloc:
+                            self._per_element_arrays[k] = a
+                        elif a.shape[0] == self._num_chunks_alloc:
+                            self._per_chunk_arrays[k] = a
+            elif version == "0.2.0":
+                with hdf_s_lst.open("element_arrays") as hdf_arrays:
+                    for k in hdf_arrays.list_nodes():
+                        self._per_element_arrays[k] = read_array(k, hdf_arrays)
+                with hdf_s_lst.open("chunk_arrays") as hdf_arrays:
+                    for k in hdf_arrays.list_nodes():
+                        self._per_chunk_arrays[k] = read_array(k, hdf_arrays)
+            else:
+                raise RuntimeError(f"Unsupported HDF version {version}; use an older version of pyiron to load this job!")
+
             for k, a in self._per_chunk_arrays.items():
                 if a.shape[0] != self._num_chunks_alloc:
                     raise RuntimeError(f"per-chunk array {k} read inconsistently from HDF: "

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -495,7 +495,7 @@ class FlattenedStorage:
             try:
                 num_chunks = hdf_s_lst["num_chunks"]
                 num_elements = hdf_s_lst["num_elements"]
-            except KeyError:
+            except ValueError:
                 num_chunks = hdf_s_lst["num_structures"]
                 num_elements = hdf_s_lst["num_atoms"]
 

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -507,3 +507,11 @@ class FlattenedStorage:
                         self._per_element_arrays[k] = a
                     elif a.shape[0] == self._num_chunks_alloc:
                         self._per_chunk_arrays[k] = a
+            for k, a in self._per_chunk_arrays.items():
+                if a.shape[0] != self._num_chunks_alloc:
+                    raise RuntimeError(f"per-chunk array {k} read inconsistently from HDF: "
+                                       f"shape {a.shape[0]} does not match global allocation {self._num_chunks_alloc}!")
+            for k, a in self._per_element_arrays.items():
+                if a.shape[0] != self._num_elements_alloc:
+                    raise RuntimeError(f"per-element array {k} read inconsistently from HDF: "
+                                       f"shape {a.shape[0]} does not match global allocation {self._num_elements_alloc}!")

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -1,9 +1,9 @@
-import unittest
 import numpy as np
 
+from pyiron_base._tests import TestWithProject
 from pyiron_base.generic.flattenedstorage import FlattenedStorage
 
-class TestFlattenedStorage(unittest.TestCase):
+class TestFlattenedStorage(TestWithProject):
 
     @classmethod
     def setUpClass(cls):
@@ -195,3 +195,30 @@ class TestFlattenedStorage(unittest.TestCase):
         self.assertEqual(info["per"], "element", "has_array returns wrong per for per atom array.")
 
         self.assertEqual(store.has_array("missing"), None, "has_array does not return None for nonexisting array.")
+
+
+    def test_hdf_chunklength_one(self):
+        """Reading a storage with all chunks of length one should give back exactly what was written!"""
+        # Regression test if all stored chunks are of length 1: there used to be a bug that read all arrays as per
+        # element in this case
+        store = FlattenedStorage()
+        store.add_array('foo', dtype=np.int64, shape=(), per="element")
+        store.add_array('bar', dtype=np.int64, shape=(), per="chunk")
+        for i in range(5):
+            store.add_chunk(1, foo=i, bar=i**2)
+        hdf = self.project.create_hdf(self.project.path, "test")
+        store.to_hdf(hdf)
+        read = FlattenedStorage()
+        try:
+            read.from_hdf(hdf)
+        except RuntimeError as e:
+            self.fail(f"Reading storage from HDF failed with {e}")
+        self.assertEqual(len(store), len(read), "Length not equal after reading from HDF!")
+        for i in range(5):
+            store_foo = store.get_array("foo", i)
+            read_foo = read.get_array("foo", i)
+            self.assertTrue(np.array_equal(store_foo, read_foo),
+                            f"per element values not equal after reading from HDF! {store_foo} != {read_foo}")
+            self.assertEqual(store.get_array("bar", i), read.get_array("bar", i),
+                             "per chunk values not equal after reading from HDF!")
+


### PR DESCRIPTION
Before both per element and per chunk arrays were stored in one HDF group, which meant that on reading I had to guess which are which.  In the case of storages that have only have chunks of length one both types of arrays have the same overall length, so the code got confused.  I fixed that now by storing them in different HDF groups.

@Leimeroth Since this changes HDF group names it might interact with the atomicrex classes.  Loading old versions should be compatible, but please check if there's other problems.