### PR TITLE
Strip first axis when creating array in add_chunk

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -431,8 +431,13 @@ class FlattenedStorage:
                 if len(a.shape) > 0 and a.shape[0] == n:
                     self.add_array(k, shape=a.shape[1:], dtype=a.dtype, per="element")
                 else:
-                    self.add_array(k, shape=a.shape, dtype=a.dtype, per="chunk")
-            # if the first axis was added by the caller to force to add a per chunk array, remove it again here
+                    shape = a.shape
+                    # if the first axis was added by the caller to force to add a per chunk array, remove it again here
+                    if len(shape) > 0 and a.shape[0] == 1:
+                        shape = shape[1:]
+                    self.add_array(k, shape=shape, dtype=a.dtype, per="chunk")
+            # same as above: if the first axis was added by the caller to force to add a per chunk array, remove it
+            # again here
             if k in self._per_chunk_arrays and len(a.shape) > 0 and a.shape[0] == 1:
                 a = a[0]
             self.set_array(k, self.current_chunk_index, a)

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -146,6 +146,10 @@ class TestFlattenedStorage(unittest.TestCase):
             self.fail("add_chunk should not raise an exception when passed a value for an existing per-chunk array.")
         self.assertTrue(np.array_equal(val, cont.get_array("perchunk", 0)),
                         "add_chunk did not remove first axis on a per chunk array!")
+        # test the same, but now let the array be created by add_chunk, instead of doing it on our own
+        cont.add_chunk(2, perelem=[1,1], perchunk2=val[np.newaxis, :])
+        self.assertTrue(np.array_equal(val, cont.get_array("perchunk2", 1)),
+                        "add_chunk did not remove first axis on a per chunk array!")
 
 
     def test_get_array(self):


### PR DESCRIPTION
Previously this was only checked when the array already exists.  Adapted
tests to cover this as well.

This is also related to the error in
https://github.com/pyiron/pyiron_contrib/pull/197

Should fix the current failure in https://github.com/pyiron/pyiron_base/pull/388