### PR TITLE
Adding project.maintenance

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1519,7 +1519,7 @@ class Maintenance:
         self._local = None
 
     @property
-    def global(self):
+    def global_status(self):
         return self._global
 
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -18,7 +18,7 @@ from pyiron_base.project.path import ProjectPath
 from pyiron_base.database.filetable import FileTable
 from pyiron_base.settings.generic import Settings
 from pyiron_base.settings.publications import list_publications
-from pyiron_base import get_database_statistics
+from pyiron_base.database.performance import get_database_statistics
 from pyiron_base.database.jobtable import (
     get_db_columns,
     get_job_ids,
@@ -1502,7 +1502,15 @@ class Project(ProjectPath, HasGroups):
 
 
 class Maintenance:
+    """
+    The purpose of maintenance class is to provide
+    some measures of perfomance for pyiron
+    """
     def __init__(self):
+        """
+        initialize the flag self._check_postgres, to control whether pyiron is
+        set to communicate with a postgres database.
+        """
         s = Settings()
         connection_string = s._configuration['sql_connection_string']
         if "postgresql" not in connection_string:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1513,16 +1513,14 @@ class Maintenance:
     """
     def __init__(self):
         """
-        initialize the local and global attributes to None
+        initialize the local and global attributes
         """
-        self._global = None
+        self._global = GlobalMaintenance()
         self._local = None
 
     @property
-    def global_status(self):
-        if self._global is None:
-            self._global = GlobalMaintenance()
-            return self._global
+    def global(self):
+        return self._global
 
 
 class GlobalMaintenance:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -131,8 +131,14 @@ class Project(ProjectPath, HasGroups):
             self.db = FileTable(project=path)
         self.job_type = JobTypeChoice()
 
-        self.maintenance = Maintenance()
+        self._maintenance = None
 
+
+    @property
+    def maintenance(self):
+        if self._maintenance is None:
+            self._maintenance = Maintenance()
+        return self._maintenance
     @property
     def parent_group(self):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1529,8 +1529,7 @@ class Maintenance:
         else:
             self._check_postgres = True
 
-    @property
-    def database_statistics(self):
+    def get_database_statistics(self):
         if self._check_postgres:
             return get_database_statistics()
         else:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -133,12 +133,12 @@ class Project(ProjectPath, HasGroups):
 
         self._maintenance = None
 
-
     @property
     def maintenance(self):
         if self._maintenance is None:
             self._maintenance = Maintenance()
         return self._maintenance
+
     @property
     def parent_group(self):
         """
@@ -1471,7 +1471,6 @@ class Project(ProjectPath, HasGroups):
                 for entry in db_entry_in_old_format:
                     self.db.item_update({"project": self.project_path}, entry["id"])
 
-
     def pack(self, destination_path, csv_file_name='export.csv', compress=True):
         """
         by this funtion, the job table is exported to a csv file
@@ -1488,7 +1487,6 @@ class Project(ProjectPath, HasGroups):
         )
         df = export_archive.export_database(self, directory_to_transfer, destination_path)
         df.to_csv(csv_file_name)
-
 
     def unpack(self, origin_path, csv_file_name='export.csv', compress=True):
         """
@@ -1510,8 +1508,24 @@ class Project(ProjectPath, HasGroups):
 class Maintenance:
     """
     The purpose of maintenance class is to provide
-    some measures of perfomance for pyiron
+    some measures of perfomance for pyiron, whether local to the project
+    or global (describing the status of pyiron on the running machine)
     """
+    def __init__(self):
+        """
+        initialize the local and global attributes to None
+        """
+        self._global = None
+        self._local = None
+
+    @property
+    def global_status(self):
+        if self._global is None:
+            self._global = GlobalMaintenance()
+            return self._global
+
+
+class GlobalMaintenance:
     def __init__(self):
         """
         initialize the flag self._check_postgres, to control whether pyiron is


### PR DESCRIPTION
Introduces `Maintenance` class, which returns `get_database_statistics` as an attribute of a pyiron project. Of course, the maintenance class can be further extended to include other performance measures, like disk spaces, available memory, etc.

The use case is:
```python3
from pyiron_base import Project
pr = Project()
pr.maintenance.database_statistics
```
this returns a dataframe including measure about postgres database statistics.