### PR TITLE
A generic units class for pyiron

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -12,6 +12,7 @@ dependencies:
 - numpy =1.21.1
 - pandas =1.3.1
 - pathlib2 =2.3.6
+- pint
 - psutil =5.8.0
 - pyfileindex =0.0.6
 - pysqa =0.0.15

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -4,12 +4,16 @@
 
 """Classes to help developers avoid code duplication when writing tests for pyiron."""
 
+from contextlib import redirect_stdout
+import doctest
+from io import StringIO
 import unittest
 from os.path import split, join
 from os import remove
 from pyiron_base.project.generic import Project
 from abc import ABC
 from inspect import getfile
+
 
 __author__ = "Liam Huber"
 __copyright__ = (
@@ -50,3 +54,23 @@ class TestWithCleanProject(TestWithProject, ABC):
 
     def tearDown(self):
         self.project.remove_jobs_silently(recursive=True)
+
+
+class TestWithDocstrings(unittest.TestCase, ABC):
+
+    """
+    Tests that also include testing the docstrings in the specified modules
+    """
+    def test_docstrings(self, module):
+        """
+        Fails with output if docstrings in the given module fails
+
+        Args:
+            module (module/string): The module or path to the module
+
+        Output capturing adapted from https://stackoverflow.com/a/22434594/12332968
+        """
+        with StringIO() as buf, redirect_stdout(buf):
+            result = doctest.testmod(module)
+            output = buf.getvalue()
+        self.failIf(result.failed > 0, msg=output)

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -61,16 +61,21 @@ class TestWithDocstrings(unittest.TestCase, ABC):
     """
     Tests that also include testing the docstrings in the specified modules
     """
-    def test_docstrings(self, module):
-        """
-        Fails with output if docstrings in the given module fails
 
-        Args:
-            module (module/string): The module or path to the module
+    @property
+    def docstring_module(self):
+        """
+        Define module whose docstrings will be tested
+        """
+        return None
+
+    def test_docstrings(self):
+        """
+        Fails with output if docstrings in the given module fails.
 
         Output capturing adapted from https://stackoverflow.com/a/22434594/12332968
         """
         with StringIO() as buf, redirect_stdout(buf):
-            result = doctest.testmod(module)
+            result = doctest.testmod(self.docstring_module)
             output = buf.getvalue()
         self.failIf(result.failed > 0, msg=output)

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -114,7 +114,8 @@ class PyironUnitRegistry:
             if quantity in self.unit_dict.keys():
                 self._quantity_dict[label] = quantity
             else:
-                raise KeyError("Quantity {} is not defined. Use `add_quantity` to register the unit of this label")
+                raise KeyError("Quantity {} is not defined. "
+                               "Use `add_quantity` to register the unit of this label".format(quantity))
 
     def __getitem__(self, item):
         """

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -104,7 +104,8 @@ class PyironUnitRegistry:
             quantity (str): Physical quantity associated with the labels
 
         Note: `quantity` should already be a key of unit_dict
-
+Raises:
+    ValueError: if quantity is not yet added with :method:`.add_quantity()`.
         """
         for label in labels:
             if quantity in self.unit_dict.keys():

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -63,7 +63,7 @@ class PyironUnitRegistry:
     @property
     def dtype_dict(self):
         """
-        A dictionary of the different physical quantities and the corresponding datatype in which they are to be stored
+        A dictionary of the names of the different physical quantities to the corresponding datatype in which they are to be stored
 
         Returns:
             dict

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -172,19 +172,19 @@ class UnitConverter:
     >>> base.add_quantity(quantity="energy", unit=pint_registry.eV)
     >>> code = PyironUnitRegistry()
     >>> code.add_quantity(quantity="energy",
-    >>>                         unit=pint_registry.kilocal / (pint_registry.mol * pint_registry.N_A))
+    ...                         unit=pint_registry.kilocal / (pint_registry.mol * pint_registry.N_A))
     >>> unit_converter = UnitConverter(base_registry=base, code_registry=code)
 
     The unit converter instance can then be used to obtain conversion factors between code and base units either as a
     `pint` quantity:
 
     >>> print(unit_converter.code_to_base_pint("energy"))
-    0.043364104241800934 electron_volt
+    0.04336410424180094 electron_volt
 
     or as a scalar:
 
     >>> print(unit_converter.code_to_base_value("energy"))
-    0.043364104241800934
+    0.04336410424180094
 
     Alternatively, the unit converter can also be used as decorators for functions that return an array scaled into
     appropriate units:
@@ -193,7 +193,7 @@ class UnitConverter:
     ... def return_ones():
     ...    return np.ones(5)
     >>> print(return_ones())
-    [0.0433641 0.0433641 0.0433641 0.0433641 0.0433641
+    [0.0433641 0.0433641 0.0433641 0.0433641 0.0433641]
 
     The decorator can also be used to assign units for numpy arrays
     (for more info see https://pint.readthedocs.io/en/0.10.1/numpy.html)

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -1,4 +1,67 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
 import functools
+
+__author__ = "Sudarsan Surendralal"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+
+
+class UnitsBase:
+
+    def __init__(self):
+        self._quantity_dict = dict()
+        self._dtype_dict = dict()
+        self._unit_dict = dict()
+
+    @property
+    def quantity_dict(self):
+        return self._quantity_dict
+
+    @property
+    def dtype_dict(self):
+        return self._dtype_dict
+
+    @property
+    def unit_dict(self):
+        return self._unit_dict
+
+    def add_quantity(self, quantity, unit, data_type=float):
+        self._unit_dict[quantity] = unit
+        self._dtype_dict[quantity] = data_type
+
+    def add_labels(self, labels, quantity):
+        for label in labels:
+            self._quantity_dict[label] = quantity
+
+    def __getitem__(self, item):
+        if item in self._unit_dict.keys():
+            return self._unit_dict[item]
+        elif item in self._quantity_dict.keys():
+            return self._unit_dict[self._quantity_dict[item]]
+
+
+class UnitConverter:
+
+    def __init__(self, base_units, code_units):
+        self._base_units = base_units
+        self._code_units = code_units
+
+    def code_to_base(self, quantity):
+        return (1 * self._code_units[quantity]).to(self._base_units[quantity])
+
+    def base_to_code(self, quantity):
+        return (1 * self._base_units[quantity]).to(self._code_units[quantity])
+
+    def code_to_base_value(self, quantity):
+        return self.code_to_base(quantity).magnitude
+
+    def base_to_code_value(self, quantity):
+        return self.base_to_code(quantity).magnitude
 
 
 class UnitsDecorator:
@@ -13,7 +76,8 @@ class UnitsDecorator:
         self._label = label
         return self.__decorate_to_pyiron
 
-    def __decorate_to_pyiron(self, function):
+    @staticmethod
+    def __decorate_to_pyiron(function):
         @functools.wraps(function)
         def dec(*args, **kwargs):
             return function(*args, **kwargs)

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -17,6 +17,7 @@ __copyright__ = (
 
 class PyironUnitRegistry:
     """
+
     Module to record units for physical quantities within pyiron. This module is used for defining the units
     for different pyiron submodules.
 
@@ -36,8 +37,15 @@ class PyironUnitRegistry:
     >>> base_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
 
     For more information on working with `pint`, see: https://pint.readthedocs.io/en/0.10.1/tutorial.html
+
     """
     def __init__(self):
+        """
+        Attributes:
+            self.quantity_dict
+            self.unit_dict
+            self.dtype_dict
+        """
         self._quantity_dict = dict()
         self._dtype_dict = dict()
         self._unit_dict = dict()
@@ -141,6 +149,7 @@ class PyironUnitRegistry:
 
 class UnitConverter:
     """
+
     Module to handle conversions between two different unit registries mainly use to convert units between codes and
     pyiron submodules.
 
@@ -183,6 +192,7 @@ class UnitConverter:
     >>>     return np.ones(5)
     >>> print(return_ones_ev())
     [1.0 1.0 1.0 1.0 1.0] electron_volt
+
     """
 
     def __init__(self, base_units, code_units):

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -188,16 +188,16 @@ class UnitConverter:
     Alternatively, the unit converter can also be used as decorators for functions that return an array scaled into
     appropriate units:
 
-    >>> @unit_converter(quantity="energy", conversion="code_to_base")
+    >>> @unit_converter.code_to_base(quantity="energy")
     ... def return_ones():
     ...    return np.ones(5)
     >>> print(return_ones())
-    [0.0433641 0.0433641 0.0433641 0.0433641 0.0433641]
+    [0.0433641 0.0433641 0.0433641 0.0433641 0.0433641
 
     The decorator can also be used to assign units for numpy arrays
     (for more info see https://pint.readthedocs.io/en/0.10.1/numpy.html)
 
-    >>> @unit_converter(quantity="energy", conversion="base_units")
+    >>> @unit_converter.base_units(quantity="energy")
     ... def return_ones_ev():
     ...     return np.ones(5)
     >>> print(return_ones_ev())
@@ -268,8 +268,13 @@ class UnitConverter:
         Function call operator used as a decorator for functions that return numpy array
 
         Args:
-            conversion (str):
-            quantity (str):
+            conversion (str): Conversion type which should be one of
+                'code_to_base' To multiply by the code to base units conversion factor
+                'base_to_code' To multiply by the base to code units conversion factor
+                'code_units' To assign code units to the nunpy array returned by the decorated function
+                'base_units' To assign base units to the nunpy array returned by the decorated function
+
+            quantity (str): Name of quantity
 
         Returns:
             function: Decorated function
@@ -309,14 +314,56 @@ class UnitConverter:
         else:
             raise ValueError("Conversion type {} not implemented!".format(conversion))
 
-    # def code_to_base(self, quantity):
-    #     return self(quantity=quantity, conversion="code_to_base")
-    #
-    # def base_to_code(self, quantity):
-    #     return self(quantity=quantity, conversion="base_to_code")
-    #
-    # def code_units(self, quantity):
-    #     return self(quantity=quantity, conversion="code_registry")
-    #
-    # def base_units(self, quantity):
-    #     return self(quantity=quantity, conversion="base_registry")
+    def code_to_base(self, quantity):
+        """
+        Decorator for functions that returns a numpy array. Multiples the function output by the code to base units
+        conversion factor
+
+        Args:
+            quantity (str):  Name of the quantity
+
+        Returns:
+            function: Decorated function
+
+        """
+        return self(quantity=quantity, conversion="code_to_base")
+
+    def base_to_code(self, quantity):
+        """
+        Decorator for functions that returns a numpy array. Multiples the function output by the base to code units
+        conversion factor
+
+        Args:
+            quantity (str):  Name of the quantity
+
+        Returns:
+            function: Decorated function
+
+        """
+        return self(quantity=quantity, conversion="base_to_code")
+
+    def code_units(self, quantity):
+        """
+        Decorator for functions that returns a numpy array. Assigns the code unit of the quantity to the function output
+
+        Args:
+            quantity (str):  Name of the quantity
+
+        Returns:
+            function: Decorated function
+
+        """
+        return self(quantity=quantity, conversion="code_units")
+
+    def base_units(self, quantity):
+        """
+        Decorator for functions that returns a numpy array. Assigns the base unit of the quantity to the function output
+
+        Args:
+            quantity (str):  Name of the quantity
+
+        Returns:
+            function: Decorated function
+
+        """
+        return self(quantity=quantity, conversion="base_units")

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -189,8 +189,8 @@ class UnitConverter:
     (for more info see https://pint.readthedocs.io/en/0.10.1/numpy.html)
 
     >>> @unit_converter(quantity="energy", conversion="base_units")
-    >>> def return_ones_ev():
-    >>>     return np.ones(5)
+    ... def return_ones_ev():
+    ...     return np.ones(5)
     >>> print(return_ones_ev())
     [1.0 1.0 1.0 1.0 1.0] electron_volt
 

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -180,8 +180,8 @@ class UnitConverter:
     appropriate units:
 
     >>> @unit_converter(quantity="energy", conversion="code_to_base")
-    >>>    def return_ones():
-    >>>        return np.ones(5)
+    ... def return_ones():
+    ...    return np.ones(5)
     >>> print(return_ones())
     [0.0433641 0.0433641 0.0433641 0.0433641 0.0433641]
 

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -200,7 +200,7 @@ class UnitConverter:
         """
 
         Args:
-            base_units (pyiron_base.generic.units.PyironUnitRegistry): Base unit registry
+            base_units (:class:`pyiron_base.generic.units.PyironUnitRegistry`): Base unit registry
             code_units (pyiron_base.generic.units.PyironUnitRegistry): Code specific unit registry
         """
         self._base_units = base_units

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -1,0 +1,28 @@
+import functools
+
+
+class UnitsDecorator:
+
+    def __init__(self):
+        self._units = None
+        self._label = None
+
+    def __call__(self, label, units=None):
+        if units is not None:
+            self._units = units
+        self._label = label
+        return self.__decorate_to_pyiron
+
+    def __decorate_to_pyiron(self, function):
+        @functools.wraps(function)
+        def dec(*args, **kwargs):
+            return function(*args, **kwargs)
+        return dec
+
+# def decorator(func):
+# @wraps(func)
+# def f(self, *args, **kwargs):
+#     units = unit_getter(self)
+#     return func(self, *args, **kwargs)
+
+# Quick sketch, unit_getter is something you have to define via a class decorator like you had

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -4,6 +4,7 @@
 
 import functools
 import numpy as np
+import pint
 
 __author__ = "Sudarsan Surendralal"
 __copyright__ = (
@@ -12,10 +13,27 @@ __copyright__ = (
 )
 
 
-class UnitsBase:
+class PyironUnitRegistry:
     """
-    Module to record units for physical quantities within pyiron
+    Module to record units for physical quantities within pyiron. This module is used for defining the units
+    for different pyiron submodules.
 
+    Useage:
+
+    >>> import pint
+    >>> from pyiron_base.generic.units import PyironUnitRegistry
+    >>> pint_registry = pint.UnitRegistry()
+
+    After instantiating, the `pint` units for different physical quantities can be registered as follows
+
+    >>> base_units = PyironUnitRegistry()
+    >>> base_units.add_quantity(quantity="energy", unit=pint_registry.eV, data_type=float)
+
+    Labels corresponding to a particular physical quantity can also be registered
+
+    >>> base_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
+
+    For more information on working with `pint`, see: https://pint.readthedocs.io/en/0.10.1/tutorial.html
     """
     def __init__(self):
         self._quantity_dict = dict()
@@ -24,35 +42,99 @@ class UnitsBase:
 
     @property
     def quantity_dict(self):
+        """
+        A dictionary of the different labels stored and the physical quantity they correspond to
+
+        Returns:
+            dict
+        """
         return self._quantity_dict
 
     @property
     def dtype_dict(self):
+        """
+        A dictionary of the different physical quantities and the corresponding datatype in which they are to be stored
+
+        Returns:
+            dict
+        """
         return self._dtype_dict
 
     @property
     def unit_dict(self):
+        """
+        A dictionary of the different physical quantities and the corresponding `pint` unit
+
+        Returns:
+            dict
+        """
         return self._unit_dict
 
     def add_quantity(self, quantity, unit, data_type=float):
+        """
+        Add a quantity to a registry
+
+        Args:
+            quantity (str): The physical quantity
+            unit (pint.unit.Unit/pint.quantity.Quantity): `pint` unit or quantity
+            data_type (type): Data type in which the quantity has to be stored
+
+        """
+        if not isinstance(unit, (pint.unit.Unit, pint.quantity.Quantity)):
+            raise ValueError("The unit should be a `pint` unit or quantity")
         self._unit_dict[quantity] = unit
         self._dtype_dict[quantity] = data_type
 
     def add_labels(self, labels, quantity):
+        """
+        Maps quantities with different labels to quantities already defined in the registry
+
+        Args:
+            labels (list/ndarray): List of labels
+            quantity (str): Physical quantity associated with the labels
+
+        Note: `quantity` should already be a key of unit_dict
+
+        """
         for label in labels:
-            self._quantity_dict[label] = quantity
+            if quantity in self.unit_dict.keys():
+                self._quantity_dict[label] = quantity
+            else:
+                raise ValueError("Quantity {} is not defined. Use `add_quantity` to register the unit of this label")
 
     def __getitem__(self, item):
+        """
+        Getter to return corresponding `pint` unit for a quantity
+
+        Args:
+            item (str):
+
+        Returns:
+            pint.unit.Unit/pint.quantity.Quantity: The corresponding `pint` unit/quantity
+        """
         if item in self._unit_dict.keys():
             return self._unit_dict[item]
         elif item in self._quantity_dict.keys():
             return self._unit_dict[self._quantity_dict[item]]
+        else:
+            raise ValueError("Quantity/label '{}' not registered in this unit registry".format(item))
 
-    def get_dtype(self, item):
-        if item in self._unit_dict.keys():
-            return self._dtype_dict[item]
-        elif item in self._quantity_dict.keys():
-            return self._dtype_dict[self._quantity_dict[item]]
+    def get_dtype(self, quantity):
+        """
+        Returns the data type in which the quantity will be stored
+
+        Args:
+            quantity (str): The quantity
+
+        Returns:
+            type: Corresponding data type
+        """
+        if quantity in self._unit_dict.keys():
+            return self._dtype_dict[quantity]
+        elif quantity in self._quantity_dict.keys():
+            return self._dtype_dict[self._quantity_dict[quantity]]
+        else:
+            raise ValueError("Quantity/label '{}' not registered in this unit registry".format(quantity))
 
 
 class UnitConverter:
@@ -75,20 +157,20 @@ class UnitConverter:
 
     def __call__(self, conversion, quantity):
         if conversion == "to_base":
-            def __decorate_to_base(function):
+            def _decorate_to_base(function):
                 @functools.wraps(function)
                 def dec(*args, **kwargs):
                     return np.array(function(*args, **kwargs) * self.code_to_base_value(quantity),
                                     dtype=self._base_units.get_dtype(quantity))
                 return dec
-            return __decorate_to_base
+            return _decorate_to_base
         elif conversion == "to_code":
-            def __decorate_to_code(function):
+            def _decorate_to_code(function):
                 @functools.wraps(function)
                 def dec(*args, **kwargs):
                     return np.array(function(*args, **kwargs) * self.base_to_code_value(quantity),
                                     dtype=self._base_units.get_dtype(quantity))
                 return dec
-            return __decorate_to_code
+            return _decorate_to_code
         else:
             raise ValueError()

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -215,6 +215,24 @@ class UnitConverter:
         """
         self._base_registry = base_registry
         self._code_registry = code_registry
+        self._check_quantities()
+        self._check_dimensionality()
+
+    def _check_quantities(self):
+        base_quant = list(self._base_registry.unit_dict.keys())
+        for quant in self._code_registry.unit_dict.keys():
+            if quant not in base_quant:
+                raise ValueError("quantity {} is not defined in the base registry".format(quant))
+
+    def _check_dimensionality(self):
+        for quant in self._code_registry.unit_dict.keys():
+            if not self._base_registry[quant].dimensionality == self._code_registry[quant].dimensionality:
+                raise pint.DimensionalityError(self._base_registry[quant], self._code_registry[quant],
+                                               extra_msg="\n Dimensional inequality: Quantity {} has dimensionality {} "
+                                                         "in the base registry but {} in the code "
+                                                         "registry".format(quant,
+                                                                           self._base_registry[quant].dimensionality,
+                                                                           self._code_registry[quant].dimensionality))
 
     def code_to_base_pint(self, quantity):
         """

--- a/pyiron_base/generic/units.py
+++ b/pyiron_base/generic/units.py
@@ -63,7 +63,8 @@ class PyironUnitRegistry:
     @property
     def dtype_dict(self):
         """
-        A dictionary of the names of the different physical quantities to the corresponding datatype in which they are to be stored
+        A dictionary of the names of the different physical quantities to the corresponding datatype in which they are
+        to be stored
 
         Returns:
             dict
@@ -104,7 +105,7 @@ class PyironUnitRegistry:
             quantity (str): Physical quantity associated with the labels
 
         Raises:
-            ValueError: If quantity is not yet added with :method:`.add_quantity()`
+            KeyError: If quantity is not yet added with :method:`.add_quantity()`
 
         Note: `quantity` should already be a key of unit_dict
 
@@ -113,7 +114,7 @@ class PyironUnitRegistry:
             if quantity in self.unit_dict.keys():
                 self._quantity_dict[label] = quantity
             else:
-                raise ValueError("Quantity {} is not defined. Use `add_quantity` to register the unit of this label")
+                raise KeyError("Quantity {} is not defined. Use `add_quantity` to register the unit of this label")
 
     def __getitem__(self, item):
         """
@@ -124,13 +125,16 @@ class PyironUnitRegistry:
 
         Returns:
             pint.unit.Unit/pint.quantity.Quantity: The corresponding `pint` unit/quantity
+
+        Raises:
+            KeyError: If quantity is not yet added with :method:`.add_quantity()` or :method:`.add_labels()`
         """
         if item in self._unit_dict.keys():
             return self._unit_dict[item]
         elif item in self._quantity_dict.keys():
             return self._unit_dict[self._quantity_dict[item]]
         else:
-            raise ValueError("Quantity/label '{}' not registered in this unit registry".format(item))
+            raise KeyError("Quantity/label '{}' not registered in this unit registry".format(item))
 
     def get_dtype(self, quantity):
         """
@@ -143,14 +147,14 @@ class PyironUnitRegistry:
             type: Corresponding data type
 
         Raises:
-            ValueError:
+            KeyError: If quantity is not yet added with :method:`.add_quantity()` or :method:`.add_labels()`
         """
         if quantity in self._unit_dict.keys():
             return self._dtype_dict[quantity]
         elif quantity in self._quantity_dict.keys():
             return self._dtype_dict[self._quantity_dict[quantity]]
         else:
-            raise ValueError("Quantity/label '{}' not registered in this unit registry".format(quantity))
+            raise KeyError("Quantity/label '{}' not registered in this unit registry".format(quantity))
 
 
 class UnitConverter:

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -2,7 +2,8 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from pyiron_base.generic.units import UnitsBase, UnitConverter
+import numpy as np
+from pyiron_base.generic.units import PyironUnitRegistry, UnitConverter
 import unittest
 import pint
 
@@ -12,27 +13,54 @@ pint_registry = pint.UnitRegistry()
 class TestUnits(unittest.TestCase):
 
     def test_units(self):
-        base_units = UnitsBase()
+        base_units = PyironUnitRegistry()
         base_units.add_quantity(quantity="energy", unit=pint_registry.eV)
-        code_units = UnitsBase()
+        self.assertRaises(ValueError, base_units.add_quantity, quantity="energy", unit="eV")
+        dim_less_q = pint_registry.Quantity
+        base_units.add_quantity(quantity="dimensionless_integer_quantity", unit=dim_less_q(1), data_type=int)
+        code_units = PyironUnitRegistry()
         # Define unit kJ/mol
         code_units.add_quantity(quantity="energy",
                                 unit=1e3 * pint_registry.cal / (pint_registry.mol * pint_registry.N_A))
         code_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
+        # Raise Error for undefined quantity
+        self.assertRaises(ValueError, code_units.add_labels, labels=["mean_forces"], quantity="force")
         self.assertTrue(code_units["energy"], code_units["energy_tot"])
         self.assertTrue(code_units["energy"], code_units["energy_pot"])
         # Define converter
-        converter = UnitConverter(base_units=base_units, code_units=code_units)
-        self.assertAlmostEqual(round(converter.code_to_base_value("energy"), 3), 0.043)
-        self.assertAlmostEqual(converter.code_to_base_value("energy") * converter.base_to_code_value("energy"), 1e3)
+        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
+        self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy"), 3), 0.043)
+        # Raise error if quantity not defined in any of the unit registries
+        self.assertRaises(ValueError, unit_converter.code_to_base_value, "dimensionless_integer_quantity")
+        self.assertRaises(ValueError, code_units.get_dtype, "dimensionless_integer_quantity")
+        # Define dimensionless quantity in the code units registry
+        code_units.add_quantity(quantity="dimensionless_integer_quantity", unit=dim_less_q(1), data_type=int)
+        self.assertIsInstance(code_units.get_dtype("dimensionless_integer_quantity"), int.__class__)
+        self.assertIsInstance(code_units.get_dtype("energy_tot"), float.__class__)
+        self.assertAlmostEqual(unit_converter.code_to_base_value("dimensionless_integer_quantity"), 1)
+        self.assertAlmostEqual(unit_converter.code_to_base_value("energy")
+                               * unit_converter.base_to_code_value("energy"), 1e3)
+
+        # Use decorator to convert units
+        @unit_converter(quantity="energy", conversion="code_to_base")
+        def return_ones_base():
+            return np.ones(10)
+
+        @unit_converter(quantity="energy", conversion="base_to_code")
+        def return_ones_code():
+            return np.ones(10)
+
+        self.assertTrue(np.allclose(return_ones_base(), np.ones(10) * 0.0433641))
+        self.assertTrue(np.allclose(return_ones_base() * return_ones_code(), np.ones(10) * 1e3))
+        self.assertRaises(ValueError, unit_converter, quantity="energy", conversion="gibberish")
         # Define dimensionally incorrect units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre ** 2)
-        converter = UnitConverter(base_units=base_units, code_units=code_units)
+        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
         # Check if dimensionality error raised
-        self.assertRaises(pint.DimensionalityError, converter.code_to_base_value, "energy")
-        # Try wacky units
+        self.assertRaises(pint.DimensionalityError, unit_converter.code_to_base_value, "energy")
+        # Try SI units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre)
-        converter = UnitConverter(base_units=base_units, code_units=code_units)
-        self.assertAlmostEqual(round(converter.code_to_base_value("energy") / 1e18, 3), 6.242)
+        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
+        self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy") / 1e18, 3), 6.242)

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -2,7 +2,11 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
+from contextlib import redirect_stdout
+import doctest
+from io import StringIO
 import numpy as np
+import pyiron_base
 from pyiron_base.generic.units import PyironUnitRegistry, UnitConverter
 import unittest
 import pint
@@ -81,3 +85,25 @@ class TestUnits(unittest.TestCase):
         # Raise error if quantity not defined in base class
         code_units.add_quantity(quantity="force", unit=pint_registry.N)
         self.assertRaises(ValueError, UnitConverter, base_registry=base_units, code_registry=code_units)
+
+    def test_docstrings(self):
+        # Fails if docstrings fail
+        # Capturing output adapted from https://stackoverflow.com/a/22434594/12332968
+        with StringIO() as buf, redirect_stdout(buf):
+            result = doctest.testmod(pyiron_base.generic.units)
+            output = buf.getvalue()
+        self.failIf(result.failed > 0, msg=output)
+
+# from contextlib import redirect_stdout
+# import doctest
+# from io import StringIO
+
+# class TestWithDocstrings(unittest.TestCase, ABC):
+#
+#     def test_docstrings(self, module):
+#         # Fails if docstrings fail
+#         # Capturing output adapted from https://stackoverflow.com/a/22434594/12332968
+#         with StringIO() as buf, redirect_stdout(buf):
+#             result = doctest.testmod(module)
+#             output = buf.getvalue()
+#         self.failIf(result.failed > 0, msg=output)

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -71,11 +71,13 @@ class TestUnits(unittest.TestCase):
         # Define dimensionally incorrect units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre ** 2)
-        unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         # Check if dimensionality error raised
-        self.assertRaises(pint.DimensionalityError, unit_converter.code_to_base_value, "energy")
+        self.assertRaises(pint.DimensionalityError, UnitConverter, base_registry=base_units, code_registry=code_units)
         # Try SI units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre)
         unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy") / 1e18, 3), 6.242)
+        # Raise error if quantity not defined in base class
+        code_units.add_quantity(quantity="force", unit=pint_registry.N)
+        self.assertRaises(ValueError, UnitConverter, base_registry=base_units, code_registry=code_units)

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -21,7 +21,7 @@ class TestUnits(unittest.TestCase):
         code_units = PyironUnitRegistry()
         # Define unit kJ/mol
         code_units.add_quantity(quantity="energy",
-                                unit=1e3 * pint_registry.cal / (pint_registry.mol * pint_registry.N_A))
+                                unit=pint_registry.kilocal / (pint_registry.mol * pint_registry.N_A))
         code_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
         # Raise Error for undefined quantity
         self.assertRaises(ValueError, code_units.add_labels, labels=["mean_forces"], quantity="force")
@@ -39,7 +39,7 @@ class TestUnits(unittest.TestCase):
         self.assertIsInstance(code_units.get_dtype("energy_tot"), float.__class__)
         self.assertAlmostEqual(unit_converter.code_to_base_value("dimensionless_integer_quantity"), 1)
         self.assertAlmostEqual(unit_converter.code_to_base_value("energy")
-                               * unit_converter.base_to_code_value("energy"), 1e3)
+                               * unit_converter.base_to_code_value("energy"), 1)
 
         # Use decorator to convert units
         @unit_converter(quantity="energy", conversion="code_to_base")
@@ -50,8 +50,18 @@ class TestUnits(unittest.TestCase):
         def return_ones_code():
             return np.ones(10)
 
+        @unit_converter(quantity="energy", conversion="base_units")
+        def return_ones_ev():
+            return np.ones(10)
+
+        @unit_converter(quantity="energy", conversion="code_units")
+        def return_ones_kj_mol():
+            return np.ones(10)
+        print(return_ones_ev())
+        self.assertEqual(1 * return_ones_kj_mol().units, 1 * code_units["energy"])
+        self.assertEqual(1 * return_ones_ev().units, 1 * base_units["energy"])
         self.assertTrue(np.allclose(return_ones_base(), np.ones(10) * 0.0433641))
-        self.assertTrue(np.allclose(return_ones_base() * return_ones_code(), np.ones(10) * 1e3))
+        self.assertTrue(np.allclose(return_ones_base() * return_ones_code(), np.ones(10) * 1))
         self.assertRaises(ValueError, unit_converter, quantity="energy", conversion="gibberish")
         # Define dimensionally incorrect units
         code_units.add_quantity(quantity="energy",

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -18,6 +18,11 @@ class TestUnits(unittest.TestCase):
         self.assertRaises(ValueError, base_units.add_quantity, quantity="energy", unit="eV")
         dim_less_q = pint_registry.Quantity
         base_units.add_quantity(quantity="dimensionless_integer_quantity", unit=dim_less_q(1), data_type=int)
+        self.assertIsInstance(base_units.quantity_dict, dict)
+        self.assertIsInstance(base_units.unit_dict, dict)
+        self.assertEqual(base_units.unit_dict["energy"], pint_registry.eV)
+        self.assertIsInstance(base_units.dtype_dict, dict)
+        self.assertIsInstance(base_units.dtype_dict["energy"], float.__class__)
         code_units = PyironUnitRegistry()
         # Define unit kJ/mol
         code_units.add_quantity(quantity="energy",

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -2,19 +2,20 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from contextlib import redirect_stdout
-import doctest
-from io import StringIO
 import numpy as np
+from pyiron_base._tests import TestWithDocstrings
 import pyiron_base
 from pyiron_base.generic.units import PyironUnitRegistry, UnitConverter
-import unittest
 import pint
 
 pint_registry = pint.UnitRegistry()
 
 
-class TestUnits(unittest.TestCase):
+class TestUnits(TestWithDocstrings):
+
+    @property
+    def docstring_module(self):
+        return pyiron_base.generic.units
 
     def test_units(self):
         base_units = PyironUnitRegistry()
@@ -85,25 +86,3 @@ class TestUnits(unittest.TestCase):
         # Raise error if quantity not defined in base class
         code_units.add_quantity(quantity="force", unit=pint_registry.N)
         self.assertRaises(ValueError, UnitConverter, base_registry=base_units, code_registry=code_units)
-
-    def test_docstrings(self):
-        # Fails if docstrings fail
-        # Capturing output adapted from https://stackoverflow.com/a/22434594/12332968
-        with StringIO() as buf, redirect_stdout(buf):
-            result = doctest.testmod(pyiron_base.generic.units)
-            output = buf.getvalue()
-        self.failIf(result.failed > 0, msg=output)
-
-# from contextlib import redirect_stdout
-# import doctest
-# from io import StringIO
-
-# class TestWithDocstrings(unittest.TestCase, ABC):
-#
-#     def test_docstrings(self, module):
-#         # Fails if docstrings fail
-#         # Capturing output adapted from https://stackoverflow.com/a/22434594/12332968
-#         with StringIO() as buf, redirect_stdout(buf):
-#             result = doctest.testmod(module)
-#             output = buf.getvalue()
-#         self.failIf(result.failed > 0, msg=output)

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -24,15 +24,15 @@ class TestUnits(unittest.TestCase):
                                 unit=pint_registry.kilocal / (pint_registry.mol * pint_registry.N_A))
         code_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
         # Raise Error for undefined quantity
-        self.assertRaises(ValueError, code_units.add_labels, labels=["mean_forces"], quantity="force")
+        self.assertRaises(KeyError, code_units.add_labels, labels=["mean_forces"], quantity="force")
         self.assertTrue(code_units["energy"], code_units["energy_tot"])
         self.assertTrue(code_units["energy"], code_units["energy_pot"])
         # Define converter
         unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy"), 3), 0.043)
         # Raise error if quantity not defined in any of the unit registries
-        self.assertRaises(ValueError, unit_converter.code_to_base_value, "dimensionless_integer_quantity")
-        self.assertRaises(ValueError, code_units.get_dtype, "dimensionless_integer_quantity")
+        self.assertRaises(KeyError, unit_converter.code_to_base_value, "dimensionless_integer_quantity")
+        self.assertRaises(KeyError, code_units.get_dtype, "dimensionless_integer_quantity")
         # Define dimensionless quantity in the code units registry
         code_units.add_quantity(quantity="dimensionless_integer_quantity", unit=dim_less_q(1), data_type=int)
         self.assertIsInstance(code_units.get_dtype("dimensionless_integer_quantity"), int.__class__)
@@ -50,11 +50,11 @@ class TestUnits(unittest.TestCase):
         def return_ones_code():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="base_registry")
+        @unit_converter(quantity="energy", conversion="base_units")
         def return_ones_ev():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="code_registry")
+        @unit_converter(quantity="energy", conversion="code_units")
         def return_ones_kj_mol():
             return np.ones(10)
 

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -28,7 +28,7 @@ class TestUnits(unittest.TestCase):
         self.assertTrue(code_units["energy"], code_units["energy_tot"])
         self.assertTrue(code_units["energy"], code_units["energy_pot"])
         # Define converter
-        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
+        unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy"), 3), 0.043)
         # Raise error if quantity not defined in any of the unit registries
         self.assertRaises(ValueError, unit_converter.code_to_base_value, "dimensionless_integer_quantity")
@@ -50,14 +50,14 @@ class TestUnits(unittest.TestCase):
         def return_ones_code():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="base_units")
+        @unit_converter(quantity="energy", conversion="base_registry")
         def return_ones_ev():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="code_units")
+        @unit_converter(quantity="energy", conversion="code_registry")
         def return_ones_kj_mol():
             return np.ones(10)
-        print(return_ones_ev())
+
         self.assertEqual(1 * return_ones_kj_mol().units, 1 * code_units["energy"])
         self.assertEqual(1 * return_ones_ev().units, 1 * base_units["energy"])
         self.assertTrue(np.allclose(return_ones_base(), np.ones(10) * 0.0433641))
@@ -66,11 +66,11 @@ class TestUnits(unittest.TestCase):
         # Define dimensionally incorrect units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre ** 2)
-        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
+        unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         # Check if dimensionality error raised
         self.assertRaises(pint.DimensionalityError, unit_converter.code_to_base_value, "energy")
         # Try SI units
         code_units.add_quantity(quantity="energy",
                                 unit=pint_registry.N * pint_registry.metre)
-        unit_converter = UnitConverter(base_units=base_units, code_units=code_units)
+        unit_converter = UnitConverter(base_registry=base_units, code_registry=code_units)
         self.assertAlmostEqual(round(unit_converter.code_to_base_value("energy") / 1e18, 3), 6.242)

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -47,19 +47,19 @@ class TestUnits(unittest.TestCase):
                                * unit_converter.base_to_code_value("energy"), 1)
 
         # Use decorator to convert units
-        @unit_converter(quantity="energy", conversion="code_to_base")
+        @unit_converter.code_to_base(quantity="energy")
         def return_ones_base():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="base_to_code")
+        @unit_converter.base_to_code(quantity="energy")
         def return_ones_code():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="base_units")
+        @unit_converter.base_units(quantity="energy")
         def return_ones_ev():
             return np.ones(10)
 
-        @unit_converter(quantity="energy", conversion="code_units")
+        @unit_converter.code_units(quantity="energy")
         def return_ones_kj_mol():
             return np.ones(10)
 

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base.generic.units import UnitsBase, UnitConverter
+import unittest
+import pint
+
+pint_registry = pint.UnitRegistry()
+
+
+class TestUnits(unittest.TestCase):
+
+    def test_units(self):
+        base_units = UnitsBase()
+        base_units.add_quantity(quantity="energy", unit=pint_registry.eV)
+        code_units = UnitsBase()
+        # Define unit kJ/mol
+        code_units.add_quantity(quantity="energy",
+                                unit=1e3 * pint_registry.cal / (pint_registry.mol * pint_registry.N_A))
+        code_units.add_labels(labels=["energy_tot", "energy_pot"], quantity="energy")
+        self.assertTrue(code_units["energy"], code_units["energy_tot"])
+        self.assertTrue(code_units["energy"], code_units["energy_pot"])
+        # Define converter
+        converter = UnitConverter(base_units=base_units, code_units=code_units)
+        self.assertAlmostEqual(round(converter.code_to_base_value("energy"), 3), 0.043)
+        self.assertAlmostEqual(converter.code_to_base_value("energy") * converter.base_to_code_value("energy"), 1e3)
+        # Define dimensionally incorrect units
+        code_units.add_quantity(quantity="energy",
+                                unit=pint_registry.N * pint_registry.metre ** 2)
+        converter = UnitConverter(base_units=base_units, code_units=code_units)
+        # Check if dimensionality error raised
+        self.assertRaises(pint.DimensionalityError, converter.code_to_base_value, "energy")
+        # Try wacky units
+        code_units.add_quantity(quantity="energy",
+                                unit=pint_registry.N * pint_registry.metre)
+        converter = UnitConverter(base_units=base_units, code_units=code_units)
+        self.assertAlmostEqual(round(converter.code_to_base_value("energy") / 1e18, 3), 6.242)


### PR DESCRIPTION
Leveraging the capabilities of [pint](https://pint.readthedocs.io/en/stable/index.html) to handle units for different simulation codes as well as modelling length and timescales. 