### PR TITLE
Add a Hdf mixin that takes care of type info + general boilerplate

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -15,7 +15,8 @@ import pandas
 
 from pyiron_base.generic.fileio import read, write
 from pyiron_base.generic.hdfstub import HDFStub
-from pyiron_base.interfaces.has_groups import HasGroups, HasHDF
+from pyiron_base.interfaces.has_groups import HasGroups
+from pyiron_base.interfaces.has_hdf import HasHDF
 
 __author__ = "Marvin Poul"
 __copyright__ = (

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -15,7 +15,7 @@ import pandas
 
 from pyiron_base.generic.fileio import read, write
 from pyiron_base.generic.hdfstub import HDFStub
-from pyiron_base.interfaces.has_groups import HasGroups
+from pyiron_base.interfaces.has_groups import HasGroups, HasHDF
 
 __author__ = "Marvin Poul"
 __copyright__ = (
@@ -50,7 +50,7 @@ def _normalize(key):
 
     return key
 
-class DataContainer(MutableMapping, HasGroups):
+class DataContainer(MutableMapping, HasGroups, HasHDF):
     """
     Mutable sequence with optional keys.
 
@@ -677,30 +677,10 @@ class DataContainer(MutableMapping, HasGroups):
         """
         return copy.deepcopy(self)
 
-    def to_hdf(self, hdf, group_name=None):
-        """
-        Store the DataContainer in an HDF5 file.  If ``group_name`` or
-        *self.table_name* are not `None`, create a sub group in hdf prior to
-        writing if not save directly to hdf.  group_name overrides
-        self.table_name if both are not None.
+    def _get_hdf_group_name(self):
+        return self.table_name
 
-        Args:
-            hdf (ProjectHDFio): HDF5 group object
-            group_name (str, optional): HDF5 subgroup name, overrides
-                self.table_name
-        """
-
-        group_name = group_name or self.table_name
-        if group_name:
-            hdf = hdf.create_group(group_name)
-        elif len(hdf.list_dirs()) > 0:
-            raise ValueError(
-                    "HDF group must be empty when neither table_name nor "
-                    "group_name are set."
-            )
-
-
-        self._type_to_hdf(hdf)
+    def _to_hdf(self, hdf):
         hdf["READ_ONLY"] = self.read_only
         for i, (k, v) in enumerate(self.items()):
             if isinstance(k, str) and "__index_" in k:
@@ -720,38 +700,7 @@ class DataContainer(MutableMapping, HasGroups):
                     raise TypeError("Error saving {} (key {}): DataContainer doesn't support saving elements "
                                     "of type \"{}\" to HDF!".format(v, k, type(v))) from None
 
-    def _type_to_hdf(self, hdf):
-        """
-        Internal helper function to save type and version in hdf root
-
-        Args:
-            hdf (ProjectHDFio): HDF5 group object
-        """
-        hdf["NAME"] = self.__class__.__name__
-        hdf["TYPE"] = str(type(self))
-        hdf["VERSION"] = self.__version__
-        hdf["HDF_VERSION"] = self.__hdf_version__
-        hdf["OBJECT"] = "DataContainer"
-
-    def from_hdf(self, hdf, group_name=None):
-        """
-        Restore the DataContainer from an HDF5 file.  If group_name or
-        self.table_name are not None, open a sub group in hdf prior to reading
-        if not read directly from hdf.  group_name overrides self.table_name if
-        both are not None.
-
-        Args:
-            hdf (ProjectHDFio): HDF5 group object
-            group_name (str, optional): HDF5 subgroup name, overrides
-                self.table_name
-        """
-
-        group_name = group_name or self.table_name
-        if group_name:
-            hdf = hdf.open(group_name)
-
-        version = hdf.get("HDF_VERSION", "0.1.0")
-
+    def _from_hdf(self, hdf, version=None):
         self.clear()
 
         if version == "0.1.0":

--- a/pyiron_base/generic/has_hdf.py
+++ b/pyiron_base/generic/has_hdf.py
@@ -24,7 +24,7 @@ class HasHDF(ABC):
     __hdf_version__ = "0.1.0"
 
     @abstractmethod
-    def _from_hdf(hdf):
+    def _from_hdf(hdf, version=None):
         pass
 
     @abstractmethod
@@ -39,7 +39,8 @@ class HasHDF(ABC):
 
     def from_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:
-            self._from_hdf(hdf)
+            version = hdf.get("HDF_VERSION", "0.1.0")
+            self._from_hdf(hdf, version=version)
 
     def to_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:

--- a/pyiron_base/generic/has_hdf.py
+++ b/pyiron_base/generic/has_hdf.py
@@ -25,6 +25,10 @@ class HasHDF(ABC):
         pass
 
     @abstractmethod
+    def _type_to_hdf(hdf):
+        pass
+
+    @abstractmethod
     def _to_hdf(hdf):
         pass
 
@@ -34,6 +38,7 @@ class HasHDF(ABC):
 
     def to_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:
+            self._type_to_hdf(hdf)
             self._to_hdf(hdf)
 
     def rewrite_hdf(self, hdf, group_name=None):

--- a/pyiron_base/generic/has_hdf.py
+++ b/pyiron_base/generic/has_hdf.py
@@ -20,17 +20,22 @@ class WithHDF:
 
 class HasHDF(ABC):
 
+    __version__ = "0.1.0"
+    __hdf_version__ = "0.1.0"
+
     @abstractmethod
     def _from_hdf(hdf):
         pass
 
     @abstractmethod
-    def _type_to_hdf(hdf):
-        pass
-
-    @abstractmethod
     def _to_hdf(hdf):
         pass
+
+    def _type_to_hdf(hdf):
+        hdf["NAME"] = self.__class__.__name__
+        hdf["TYPE"] = str(type(self))
+        hdf["VERSION"] = self.__version__
+        hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:

--- a/pyiron_base/generic/has_hdf.py
+++ b/pyiron_base/generic/has_hdf.py
@@ -1,0 +1,43 @@
+
+from abc import ABC, abstractmethod
+
+class WithHDF:
+
+    def __init__(self, hdf, group_name=None):
+        self._hdf = hdf
+        self._group_name = group_name
+
+    def __enter__(self):
+        if self._group_name is not None:
+            self._hdf = self._hdf.open(self._group_name)
+
+        return self._hdf
+
+    def __exit__(self, *args):
+        if self._group_name is not None:
+            self._hdf.close()
+
+class HasHDF(ABC):
+
+    @abstractmethod
+    def _from_hdf(hdf):
+        pass
+
+    @abstractmethod
+    def _to_hdf(hdf):
+        pass
+
+    def from_hdf(self, hdf, group_name=None):
+        with WithHDF(hdf, group_name) as hdf:
+            self._from_hdf(hdf)
+
+    def to_hdf(self, hdf, group_name=None):
+        with WithHDF(hdf, group_name) as hdf:
+            self._to_hdf(hdf)
+
+    def rewrite_hdf(self, hdf, group_name=None):
+        with WithHDF(hdf, group_name) as hdf:
+            obj = self.__class__()
+            obj.from_hdf(hdf)
+            hdf.remove(...)
+            obj.to_hdf(hdf)

--- a/pyiron_base/generic/has_hdf.py
+++ b/pyiron_base/generic/has_hdf.py
@@ -2,6 +2,7 @@
 from abc import ABC, abstractmethod
 
 class WithHDF:
+    __slots__ = ("_hdf", "_group_name")
 
     def __init__(self, hdf, group_name=None):
         self._hdf = hdf

--- a/pyiron_base/generic/hdfstub.py
+++ b/pyiron_base/generic/hdfstub.py
@@ -60,11 +60,14 @@ class HDFStub:
         """
         Create new stub.
 
+        The given hdf object is copied, so that calls to its :meth:`ProjectHDFio.open` and :meth:`.ProjectHDFio.close`
+        between this initialization and later calls to :meth:.load` do not change the location this stub is pointing at.
+
         Args:
             hdf (:class:`.ProjectHDFio`): hdf object to load from
             group_name (str): node or group name to load from the hdf object
         """
-        self._hdf = hdf
+        self._hdf = hdf.copy()
         self._group_name = group_name
 
     @classmethod

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -42,12 +42,13 @@ class HasHDF(ABC):
         hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf, group_name=None):
-        group_name = group_name or self._get_group_name()
+        group_name = group_name or self._get_hdf_group_name()
         with WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)
 
     def to_hdf(self, hdf, group_name=None):
+        group_name = group_name or self._get_hdf_group_name()
         with WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
                 raise ValueError("HDF group must be empty when group_name is not set.")

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -35,7 +35,6 @@ class _WithHDF:
 
 class HasHDF(ABC):
 
-    __version__ = "0.1.0"
     __hdf_version__ = "0.1.0"
 
     @abstractmethod

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -38,6 +38,7 @@ class HasHDF(ABC):
     def _type_to_hdf(self, hdf):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
+        hdf["OBJECT"] = hdf["NAME"] # unused alias
         hdf["VERSION"] = self.__version__
         hdf["HDF_VERSION"] = self.__hdf_version__
 

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -71,13 +71,13 @@ class HasHDF(ABC):
         hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf, group_name=None):
-        group_name = group_name or self._get_hdf_group_name()
+        group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)
 
     def to_hdf(self, hdf, group_name=None):
-        group_name = group_name or self._get_hdf_group_name()
+        group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
                 raise ValueError("HDF group must be empty when group_name is not set.")

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -1,4 +1,3 @@
-
 from abc import ABC, abstractmethod
 
 class WithHDF:
@@ -54,8 +53,8 @@ class HasHDF(ABC):
         with WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
                 raise ValueError("HDF group must be empty when group_name is not set.")
-            self._type_to_hdf(hdf)
             self._to_hdf(hdf)
+            self._type_to_hdf(hdf)
 
     def rewrite_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-class WithHDF:
+class _WithHDF:
     __slots__ = ("_hdf", "_group_name")
 
     def __init__(self, hdf, group_name=None):
@@ -44,20 +44,20 @@ class HasHDF(ABC):
 
     def from_hdf(self, hdf, group_name=None):
         group_name = group_name or self._get_hdf_group_name()
-        with WithHDF(hdf, group_name) as hdf:
+        with _WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)
 
     def to_hdf(self, hdf, group_name=None):
         group_name = group_name or self._get_hdf_group_name()
-        with WithHDF(hdf, group_name) as hdf:
+        with _WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
             self._type_to_hdf(hdf)
 
     def rewrite_hdf(self, hdf, group_name=None):
-        with WithHDF(hdf, group_name) as hdf:
+        with _WithHDF(hdf, group_name) as hdf:
             obj = hdf.to_object()
             hdf.remove_group()
             obj.to_hdf(hdf)

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -121,7 +121,7 @@ class HasHDF(ABC):
         pass
 
     @classmethod
-    def from_hdf_args(cls, hdf: ProjectHDFio):
+    def from_hdf_args(cls, hdf: ProjectHDFio) -> dict:
         """
         Read arguments for instance creation from HDF5 file.
 
@@ -142,12 +142,30 @@ class HasHDF(ABC):
         hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf: ProjectHDFio, group_name: str=None):
+        """
+        Read object to HDF.
+
+        If group_name is given descend into subgroup in hdf first.
+
+        Args:
+            hdf (:class:`.ProjectHDFio`): HDF group to read from
+            group_name (str, optional): name of subgroup
+        """
         group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)
 
     def to_hdf(self, hdf: ProjectHDFio, group_name: str=None):
+        """
+        Write object to HDF.
+
+        If group_name is given create a subgroup in hdf first.
+
+        Args:
+            hdf (:class:`.ProjectHDFio`): HDF group to write to
+            group_name (str, optional): name of subgroup
+        """
         group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
@@ -156,6 +174,15 @@ class HasHDF(ABC):
             self._type_to_hdf(hdf)
 
     def rewrite_hdf(self, hdf: ProjectHDFio, group_name: str=None):
+        """
+        Update the HDF representation.
+
+        If an object is read from an older format, this will remove the old data and rewrite it in the newest format.
+
+        Args:
+            hdf (:class:`.ProjectHDFio`): HDF group to read/write
+            group_name (str, optional): name of subgroup
+        """
         with _WithHDF(hdf, group_name) as hdf:
             obj = hdf.to_object()
             hdf.remove_group()

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -34,6 +34,19 @@ class HasHDF(ABC):
     def _get_hdf_group_name(self):
         pass
 
+    @classmethod
+    def from_hdf_args(cls, hdf):
+        """
+        Read arguments for instance creation from HDF5 file.
+
+        Args:
+            hdf (ProjectHDFio): HDF5 group object
+
+        Returns:
+            dict: arguments that can be **kwarg-passed to cls().
+        """
+        return {}
+
     def _type_to_hdf(self, hdf):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -32,7 +32,7 @@ class HasHDF(ABC):
         pass
 
     @abstractmethod
-    def _get_group_name(self):
+    def _get_hdf_group_name(self):
         pass
 
     def _type_to_hdf(self, hdf):

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 """Interface for classes to serialize to HDF5."""
 
+from pyiron_base.generic.hdfio import ProjectHDFio
+
 from abc import ABC, abstractmethod
 
 __author__ = "Marvin Poul"
@@ -34,23 +36,26 @@ class _WithHDF:
             self._hdf.close()
 
 class HasHDF(ABC):
+    """
+    Mixin class for objects that can write themselves to HDF.
+    """
 
     __hdf_version__ = "0.1.0"
 
     @abstractmethod
-    def _from_hdf(self, hdf, version=None):
+    def _from_hdf(self, hdf: ProjectHDFio, version: str=None):
         pass
 
     @abstractmethod
-    def _to_hdf(self, hdf):
+    def _to_hdf(self, hdf: ProjectHDFio):
         pass
 
     @abstractmethod
-    def _get_hdf_group_name(self):
+    def _get_hdf_group_name(self) -> str:
         pass
 
     @classmethod
-    def from_hdf_args(cls, hdf):
+    def from_hdf_args(cls, hdf: ProjectHDFio):
         """
         Read arguments for instance creation from HDF5 file.
 
@@ -62,7 +67,7 @@ class HasHDF(ABC):
         """
         return {}
 
-    def _type_to_hdf(self, hdf):
+    def _type_to_hdf(self, hdf: ProjectHDFio):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
         hdf["OBJECT"] = hdf["NAME"] # unused alias
@@ -70,13 +75,13 @@ class HasHDF(ABC):
             hdf["VERSION"] = self.__version__
         hdf["HDF_VERSION"] = self.__hdf_version__
 
-    def from_hdf(self, hdf, group_name=None):
+    def from_hdf(self, hdf: ProjectHDFio, group_name: str=None):
         group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)
 
-    def to_hdf(self, hdf, group_name=None):
+    def to_hdf(self, hdf: ProjectHDFio, group_name: str=None):
         group_name = group_name if group_name is not None else self._get_hdf_group_name()
         with _WithHDF(hdf, group_name) as hdf:
             if len(hdf.list_dirs()) > 0 and group_name is None:
@@ -84,7 +89,7 @@ class HasHDF(ABC):
             self._to_hdf(hdf)
             self._type_to_hdf(hdf)
 
-    def rewrite_hdf(self, hdf, group_name=None):
+    def rewrite_hdf(self, hdf: ProjectHDFio, group_name: str=None):
         with _WithHDF(hdf, group_name) as hdf:
             obj = hdf.to_object()
             hdf.remove_group()

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -1,4 +1,20 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""Interface for classes to serialize to HDF5."""
+
 from abc import ABC, abstractmethod
+
+__author__ = "Marvin Poul"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Marvin Poul"
+__email__ = "poul@mpie.de"
+__status__ = "production"
+__date__ = "Sep 1, 2021"
 
 class _WithHDF:
     __slots__ = ("_hdf", "_group_name")

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -52,6 +52,10 @@ class HasHDF(ABC):
     subclass.  When loading an object with :class:`ProjectHDFio.to_object` this method is called internally, used to
     create an instance on which then :meth:`.from_hdf` is called.
 
+    Subclasses may specify an :attr:`__hdf_version__` to signal changes in the layout of the data in HDF.
+    :meth:`.from_hdf` will read this value and pass it verbatim to the subclasses :meth:`._from_hdf`.  No semantics are
+    imposed on this value, but it is usually a three digit version number.
+
     Here's a toy class that enables writting `list`s to HDF.
 
     >>> class HDFList(list, HasHDF):
@@ -177,7 +181,7 @@ class HasHDF(ABC):
         """
         Update the HDF representation.
 
-        If an object is read from an older format, this will remove the old data and rewrite it in the newest format.
+        If an object is read from an older layout, this will remove the old data and rewrite it in the newest layout.
 
         Args:
             hdf (:class:`.ProjectHDFio`): HDF group to read/write

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -24,20 +24,25 @@ class HasHDF(ABC):
     __hdf_version__ = "0.1.0"
 
     @abstractmethod
-    def _from_hdf(hdf, version=None):
+    def _from_hdf(self, hdf, version=None):
         pass
 
     @abstractmethod
-    def _to_hdf(hdf):
+    def _to_hdf(self, hdf):
         pass
 
-    def _type_to_hdf(hdf):
+    @abstractmethod
+    def _get_group_name(self):
+        pass
+
+    def _type_to_hdf(self, hdf):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
         hdf["VERSION"] = self.__version__
         hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf, group_name=None):
+        group_name = group_name or self._get_group_name()
         with WithHDF(hdf, group_name) as hdf:
             version = hdf.get("HDF_VERSION", "0.1.0")
             self._from_hdf(hdf, version=version)

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -39,7 +39,8 @@ class HasHDF(ABC):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
         hdf["OBJECT"] = hdf["NAME"] # unused alias
-        hdf["VERSION"] = self.__version__
+        if hasattr(self, "__version__"):
+            hdf["VERSION"] = self.__version__
         hdf["HDF_VERSION"] = self.__hdf_version__
 
     def from_hdf(self, hdf, group_name=None):

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -59,7 +59,6 @@ class HasHDF(ABC):
 
     def rewrite_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:
-            obj = self.__class__()
-            obj.from_hdf(hdf)
-            hdf.remove(...)
+            obj = hdf.to_object()
+            hdf.remove_group()
             obj.to_hdf(hdf)

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -49,6 +49,8 @@ class HasHDF(ABC):
 
     def to_hdf(self, hdf, group_name=None):
         with WithHDF(hdf, group_name) as hdf:
+            if len(hdf.list_dirs()) > 0 and group_name is None:
+                raise ValueError("HDF group must be empty when group_name is not set.")
             self._type_to_hdf(hdf)
             self._to_hdf(hdf)
 

--- a/tests/interfaces/test_hashdf.py
+++ b/tests/interfaces/test_hashdf.py
@@ -1,0 +1,8 @@
+import pyiron_base.interfaces.has_hdf
+from pyiron_base._tests import PyironTestCase
+
+class TestHasHDF(PyironTestCase):
+
+    @property
+    def docstring_module(self):
+        return pyiron_base.interfaces.has_hdf


### PR DESCRIPTION
It came up a few times that `DataContainer` was subclassed because of the HDF functionality, but wasn't otherwise very suitable, e.g. [here](https://github.com/pyiron/pyiron_contrib/pull/205) and [here](https://github.com/pyiron/pyiron_contrib/pull/228) and generally we have objects that write themselves to HDF but are not based on a general data structure like `DataContainer`.  I've had this sketch for a while now that should make it easier to implement this kind of classes.

As a demonstration I've derived `DataContainer` from this new mixin, but generally it should be easy to move old classes to this format (expect `GenericParameters` which handles HDF in a slightly different way).

Test + docs will follow after discussion whether we find this useful. 