### PR TITLE
Support Pandas DataFrame in the DataContainer

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -779,9 +779,9 @@ class DataContainer(MutableMapping, HasGroups):
             for g in hdf.list_groups():
                 hdf_pointer = hdf[g]
                 if hasattr(hdf_pointer, "to_to_object"):
-                    items.append( (*normalize_key(g), hdf_pointer.to_object()))
+                    items.append( (*normalize_key(g), hdf_pointer.to_object() if not self._lazy else HDFStub(hdf, g)))
                 else:
-                    items.append((*normalize_key(g), pandas.read_hdf(hdf_pointer.file_name, hdf_pointer.h5_path)))
+                    items.append((*normalize_key(g), pandas.read_hdf(hdf_pointer.file_name, hdf_pointer.h5_path) if not self._lazy else HDFStub(hdf, g)))
             for _, k, v in sorted(items, key=lambda x: x[0]):
                 self[k] = v
 

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -779,9 +779,9 @@ class DataContainer(MutableMapping, HasGroups):
             for g in hdf.list_groups():
                 hdf_pointer = hdf[g]
                 if hasattr(hdf_pointer, "to_to_object"):
-                    items.append( (*normalize_key(g), hdf[g].to_object()))
+                    items.append( (*normalize_key(g), hdf_pointer.to_object()))
                 else:
-                    items.append((*normalize_key(g), pandas.read_hdf(hdf.file_name, hdf.h5_path + "/" + g)))
+                    items.append((*normalize_key(g), pandas.read_hdf(hdf_pointer.file_name, hdf_pointer.h5_path)))
             for _, k, v in sorted(items, key=lambda x: x[0]):
                 self[k] = v
 


### PR DESCRIPTION
This is primarily used for Scriptjobs to submit the current state of a dataset for analysis.