### PR TITLE
Customized TestCase for pyiron

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -52,7 +52,7 @@ class PyironTestCase(unittest.TestCase, ABC):
         self.failIf(result.failed > 0, msg=output)
 
 
-class TestWithProject(PyironTestCase):
+class TestWithProject(PyironTestCase, ABC):
     """
     Tests that start and remove a project for their suite.
     """

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -72,7 +72,7 @@ class TestWithProject(PyironTestCase):
             pass
 
 
-class TestWithCleanProject(TestWithProject):
+class TestWithCleanProject(TestWithProject, ABC):
     """
     Tests that start and remove a project for their suite, and remove jobs from the project for each test.
     """

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -27,36 +27,7 @@ __status__ = "development"
 __date__ = "Mar 23, 2021"
 
 
-class TestWithProject(unittest.TestCase, ABC):
-    """
-    Tests that start and remove a project for their suite.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.project_path = getfile(cls)[:-3].replace("\\", "/")
-        cls.file_location, cls.project_name = split(cls.project_path)
-        cls.project = Project(cls.project_path)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.project.remove(enable=True)
-        try:
-            remove(join(cls.file_location, "pyiron.log"))
-        except FileNotFoundError:
-            pass
-
-
-class TestWithCleanProject(TestWithProject, ABC):
-    """
-    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
-    """
-
-    def tearDown(self):
-        self.project.remove_jobs_silently(recursive=True)
-
-
-class TestWithDocstrings(unittest.TestCase, ABC):
+class PyironTestCase(unittest.TestCase, ABC):
 
     """
     Tests that also include testing the docstrings in the specified modules
@@ -79,3 +50,32 @@ class TestWithDocstrings(unittest.TestCase, ABC):
             result = doctest.testmod(self.docstring_module)
             output = buf.getvalue()
         self.failIf(result.failed > 0, msg=output)
+
+
+class TestWithProject(PyironTestCase):
+    """
+    Tests that start and remove a project for their suite.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project_path = getfile(cls)[:-3].replace("\\", "/")
+        cls.file_location, cls.project_name = split(cls.project_path)
+        cls.project = Project(cls.project_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.remove(enable=True)
+        try:
+            remove(join(cls.file_location, "pyiron.log"))
+        except FileNotFoundError:
+            pass
+
+
+class TestWithCleanProject(TestWithProject):
+    """
+    Tests that start and remove a project for their suite, and remove jobs from the project for each test.
+    """
+
+    def tearDown(self):
+        self.project.remove_jobs_silently(recursive=True)

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -21,7 +21,7 @@ class ToyJob(PythonTemplateJob):
         self.status.finished = True
 
 
-class TestPack(unittest.TestCase):
+class TestPack(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -7,6 +7,8 @@ from pandas._testing import assert_frame_equal
 from filecmp import dircmp
 from pyiron_base import PythonTemplateJob
 from shutil import rmtree
+from pyiron_base._tests import PyironTestCase
+
 
 class ToyJob(PythonTemplateJob):
     def __init__(self, project, job_name):

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -6,6 +6,7 @@ from pandas._testing import assert_frame_equal
 from filecmp import dircmp
 from pyiron_base import PythonTemplateJob
 from shutil import rmtree
+from pyiron_base._tests import PyironTestCase
 
 
 class ToyJob(PythonTemplateJob):
@@ -19,6 +20,7 @@ class ToyJob(PythonTemplateJob):
         with self.project_hdf5.open("output/generic") as h5out:
             h5out["energy_tot"] = self.input["input_energy"]
         self.status.finished = True
+
 
 class TestUnpacking(PyironTestCase):
     @classmethod

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -20,7 +20,7 @@ class ToyJob(PythonTemplateJob):
             h5out["energy_tot"] = self.input["input_energy"]
         self.status.finished = True
 
-class TestUnpacking(unittest.TestCase):
+class TestUnpacking(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         # this is used to create a folder/a compressed file, are not path

--- a/tests/database/test_database_access.py
+++ b/tests/database/test_database_access.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from random import choice
 from string import ascii_uppercase
 from pyiron_base.database.generic import DatabaseAccess
+from pyiron_base._tests import PyironTestCase
 
 
 class TestDatabaseAccess(PyironTestCase):

--- a/tests/database/test_database_access.py
+++ b/tests/database/test_database_access.py
@@ -18,7 +18,7 @@ from string import ascii_uppercase
 from pyiron_base.database.generic import DatabaseAccess
 
 
-class TestDatabaseAccess(unittest.TestCase):
+class TestDatabaseAccess(PyironTestCase):
     """
     Standard Unittest of the DatabaseAccess class
     """

--- a/tests/database/test_database_file.py
+++ b/tests/database/test_database_file.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from pyiron_base.database.filetable import FileTable
 
 
-class TestDatabaseAccess(unittest.TestCase):
+class TestDatabaseAccess(PyironTestCase):
     """
     Standard Unittest of the DatabaseAccess class
     """

--- a/tests/database/test_database_file.py
+++ b/tests/database/test_database_file.py
@@ -14,6 +14,7 @@ import unittest
 import os
 from datetime import datetime
 from pyiron_base.database.filetable import FileTable
+from pyiron_base._tests import PyironTestCase
 
 
 class TestDatabaseAccess(PyironTestCase):

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -1,7 +1,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 import pyiron_base
-from pyiron_base._tests import TestWithCleanProject
+from pyiron_base._tests import TestWithCleanProject, PyironTestCase
 from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.generic.hdfstub import HDFStub
 from pyiron_base.generic.inputlist import InputList

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -1,5 +1,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
+import pyiron_base
 from pyiron_base._tests import TestWithCleanProject
 from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.generic.hdfstub import HDFStub
@@ -19,6 +20,10 @@ class Sub(DataContainer):
 
 
 class TestDataContainer(TestWithCleanProject):
+
+    @property
+    def docstring_module(self):
+        return pyiron_base.generic.datacontainer
 
     @classmethod
     def setUpClass(cls):
@@ -507,7 +512,8 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(not isinstance(ll._store[0], HDFStub),
                         "Loaded value not stored back into container!")
 
-class TestInputList(unittest.TestCase):
+
+class TestInputList(PyironTestCase):
 
     def test_deprecation_warning(self):
         """Instantiating an InputList should raise a warning."""

--- a/tests/generic/test_factory.py
+++ b/tests/generic/test_factory.py
@@ -4,6 +4,7 @@
 
 import unittest
 from pyiron_base.generic.factory import PyironFactory
+from pyiron_base._tests import PyironTestCase
 
 
 class TestFactories(PyironTestCase):

--- a/tests/generic/test_factory.py
+++ b/tests/generic/test_factory.py
@@ -6,7 +6,7 @@ import unittest
 from pyiron_base.generic.factory import PyironFactory
 
 
-class TestFactories(unittest.TestCase):
+class TestFactories(PyironTestCase):
     def test_pyiron_factory(self):
         factory = PyironFactory()
         factory.foo = "foo"

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -7,6 +7,7 @@ import sys
 from io import StringIO
 import numpy as np
 from pyiron_base.generic.hdfio import FileHDFio
+from pyiron_base._tests import PyironTestCase
 import unittest
 
 

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -10,7 +10,7 @@ from pyiron_base.generic.hdfio import FileHDFio
 import unittest
 
 
-class TestFileHDFio(unittest.TestCase):
+class TestFileHDFio(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")

--- a/tests/generic/test_filedata.py
+++ b/tests/generic/test_filedata.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pyiron_base import FileHDFio, ProjectHDFio
 from pyiron_base.generic.filedata import FileData, load_file
 from pyiron_base.project.generic import Project
+from pyiron_base._tests import PyironTestCase
 
 
 class TestLoadFile(PyironTestCase):

--- a/tests/generic/test_filedata.py
+++ b/tests/generic/test_filedata.py
@@ -10,7 +10,7 @@ from pyiron_base.generic.filedata import FileData, load_file
 from pyiron_base.project.generic import Project
 
 
-class TestLoadFile(unittest.TestCase):
+class TestLoadFile(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
@@ -85,7 +85,7 @@ class TestLoadFile(unittest.TestCase):
         self.assertEqual(json_dict, {'x': [0, 1]})
 
 
-class TestFileData(unittest.TestCase):
+class TestFileData(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")

--- a/tests/generic/test_fileio.py
+++ b/tests/generic/test_fileio.py
@@ -3,7 +3,8 @@
 
 from pyiron_base.generic.fileio import read, write
 import os
-import unittest
+from pyiron_base._tests import PyironTestCase
+
 
 class TestFileIO(PyironTestCase):
 

--- a/tests/generic/test_fileio.py
+++ b/tests/generic/test_fileio.py
@@ -5,7 +5,7 @@ from pyiron_base.generic.fileio import read, write
 import os
 import unittest
 
-class TestFileIO(unittest.TestCase):
+class TestFileIO(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/generic/test_genericParameters.py
+++ b/tests/generic/test_genericParameters.py
@@ -8,10 +8,12 @@ import os
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.project.generic import Project
+from pyiron_base._tests import PyironTestCase
 import unittest
 
 
-class TestGenericParameters(unittest.TestCase):
+class TestGenericParameters(PyironTestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.generic_parameters_empty = GenericParameters(table_name="empty")

--- a/tests/generic/test_units.py
+++ b/tests/generic/test_units.py
@@ -3,7 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
-from pyiron_base._tests import TestWithDocstrings
+from pyiron_base._tests import PyironTestCase
 import pyiron_base
 from pyiron_base.generic.units import PyironUnitRegistry, UnitConverter
 import pint
@@ -11,7 +11,7 @@ import pint
 pint_registry = pint.UnitRegistry()
 
 
-class TestUnits(TestWithDocstrings):
+class TestUnits(PyironTestCase):
 
     @property
     def docstring_module(self):

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -7,6 +7,7 @@ import warnings
 from pyiron_base.generic.util import static_isinstance
 from pyiron_base.generic.util import deprecate, deprecate_soon
 from pyiron_base.generic.util import ImportAlarm
+from pyiron_base._tests import PyironTestCase
 
 
 class TestJobType(PyironTestCase):
@@ -119,6 +120,7 @@ class TestDeprecator(PyironTestCase):
             food(baz=True)
         self.assertEqual(len(w), 2, "Not all warnings preserved.")
 
+
 class TestImportAlarm(PyironTestCase):
 
     def setUp(self):
@@ -174,6 +176,7 @@ class TestImportAlarm(PyironTestCase):
         with self.assertRaises(ZeroDivisionError, msg="Context manager should swallow unrelated exceptions"), \
              ImportAlarm("Unrelated"):
             print(1/0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/generic/test_util.py
+++ b/tests/generic/test_util.py
@@ -9,7 +9,7 @@ from pyiron_base.generic.util import deprecate, deprecate_soon
 from pyiron_base.generic.util import ImportAlarm
 
 
-class TestJobType(unittest.TestCase):
+class TestJobType(PyironTestCase):
     def test_static_isinstance(self):
         self.assertTrue(
             static_isinstance(
@@ -27,7 +27,7 @@ class TestJobType(unittest.TestCase):
         self.assertRaises(TypeError, static_isinstance, list(), 1)
 
 
-class TestDeprecator(unittest.TestCase):
+class TestDeprecator(PyironTestCase):
     def test_deprecate(self):
         """Function decorated with `deprecate` should raise a warning."""
         @deprecate
@@ -119,7 +119,7 @@ class TestDeprecator(unittest.TestCase):
             food(baz=True)
         self.assertEqual(len(w), 2, "Not all warnings preserved.")
 
-class TestImportAlarm(unittest.TestCase):
+class TestImportAlarm(PyironTestCase):
 
     def setUp(self):
         self.import_alarm = ImportAlarm()

--- a/tests/job/test_childids.py
+++ b/tests/job/test_childids.py
@@ -7,7 +7,7 @@ import unittest
 from pyiron_base.project.generic import Project
 
 
-class TestChildids(unittest.TestCase):
+class TestChildids(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/job/test_childids.py
+++ b/tests/job/test_childids.py
@@ -3,8 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
-import unittest
 from pyiron_base.project.generic import Project
+from pyiron_base._tests import PyironTestCase
 
 
 class TestChildids(PyironTestCase):

--- a/tests/job/test_databaseproperties.py
+++ b/tests/job/test_databaseproperties.py
@@ -9,7 +9,7 @@ from pyiron_base.project.generic import Project
 from pyiron_base.job.core import DatabaseProperties
 
 
-class TestDatabaseProperties(unittest.TestCase):
+class TestDatabaseProperties(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.database_entry = {
@@ -75,7 +75,7 @@ class TestDatabaseProperties(unittest.TestCase):
             _ = DatabaseProperties().job
 
 
-class DatabasePropertyIntegration(unittest.TestCase):
+class DatabasePropertyIntegration(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/job/test_databaseproperties.py
+++ b/tests/job/test_databaseproperties.py
@@ -7,6 +7,7 @@ import datetime
 import os
 from pyiron_base.project.generic import Project
 from pyiron_base.job.core import DatabaseProperties
+from pyiron_base._tests import PyironTestCase
 
 
 class TestDatabaseProperties(PyironTestCase):

--- a/tests/job/test_executable.py
+++ b/tests/job/test_executable.py
@@ -4,7 +4,7 @@
 
 import unittest
 
-# class TestExecutable(unittest.TestCase):
+# class TestExecutable(PyironTestCase):
 #     def setUp(self):
 #         self.exe_no_existing = Executable(codename='GenericJob', path_binary_codes=['../../../../static/bin_cmmc'],
 #                                           overwrite_nt_flag=True)

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -7,7 +7,7 @@ import os
 from pyiron_base.project.generic import Project
 
 
-class DatabasePropertyIntegration(unittest.TestCase):
+class DatabasePropertyIntegration(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -5,6 +5,7 @@
 import unittest
 import os
 from pyiron_base.project.generic import Project
+from pyiron_base._tests import PyironTestCase
 
 
 class DatabasePropertyIntegration(PyironTestCase):

--- a/tests/job/test_interactivewrapper.py
+++ b/tests/job/test_interactivewrapper.py
@@ -3,9 +3,9 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
-import unittest
 from pyiron_base.project.generic import Project
 from pyiron_base.job.interactivewrapper import InteractiveWrapper
+from pyiron_base._tests import PyironTestCase
 
 class TestInteractiveWrapper(PyironTestCase):
 

--- a/tests/job/test_interactivewrapper.py
+++ b/tests/job/test_interactivewrapper.py
@@ -7,7 +7,7 @@ import unittest
 from pyiron_base.project.generic import Project
 from pyiron_base.job.interactivewrapper import InteractiveWrapper
 
-class TestInteractiveWrapper(unittest.TestCase):
+class TestInteractiveWrapper(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/job/test_jobStatus.py
+++ b/tests/job/test_jobStatus.py
@@ -10,7 +10,7 @@ from pyiron_base.job.jobstatus import JobStatus
 import unittest
 
 
-class TestJobStatus(unittest.TestCase):
+class TestJobStatus(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.jobstatus = JobStatus()
@@ -273,7 +273,7 @@ class TestJobStatus(unittest.TestCase):
         self.assertEqual(finished_status, str(self.jobstatus_database))
 
 
-class JobStatusIntegration(unittest.TestCase):
+class JobStatusIntegration(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/job/test_jobStatus.py
+++ b/tests/job/test_jobStatus.py
@@ -8,6 +8,7 @@ from pyiron_base.project.generic import Project
 from pyiron_base.database.generic import DatabaseAccess
 from pyiron_base.job.jobstatus import JobStatus
 import unittest
+from pyiron_base._tests import PyironTestCase
 
 
 class TestJobStatus(PyironTestCase):

--- a/tests/job/test_jobtypechoice.py
+++ b/tests/job/test_jobtypechoice.py
@@ -7,7 +7,7 @@ from pyiron_base.job.jobtype import JobTypeChoice, JobFactory
 from pyiron_base import JOB_CLASS_DICT
 
 
-class TestJobTypeChoice(unittest.TestCase):
+class TestJobTypeChoice(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -50,7 +50,7 @@ class TestJobTypeChoice(unittest.TestCase):
                       "JobTypeChoice")
 
 
-class TestJobCreator(unittest.TestCase):
+class TestJobCreator(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/tests/job/test_jobtypechoice.py
+++ b/tests/job/test_jobtypechoice.py
@@ -2,9 +2,9 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import unittest
 from pyiron_base.job.jobtype import JobTypeChoice, JobFactory
 from pyiron_base import JOB_CLASS_DICT
+from pyiron_base._tests import PyironTestCase
 
 
 class TestJobTypeChoice(PyironTestCase):

--- a/tests/master/test_GenericMaster.py
+++ b/tests/master/test_GenericMaster.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import unittest
 import os
 from pyiron_base.project.generic import Project
 from pyiron_base.job.generic import GenericJob

--- a/tests/master/test_GenericMaster.py
+++ b/tests/master/test_GenericMaster.py
@@ -7,6 +7,7 @@ import os
 from pyiron_base.project.generic import Project
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.master.generic import GenericMaster
+from pyiron_base._tests import PyironTestCase
 
 
 class TestGenericJob(PyironTestCase):

--- a/tests/master/test_GenericMaster.py
+++ b/tests/master/test_GenericMaster.py
@@ -9,7 +9,7 @@ from pyiron_base.job.generic import GenericJob
 from pyiron_base.master.generic import GenericMaster
 
 
-class TestGenericJob(unittest.TestCase):
+class TestGenericJob(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/master/test_SerialMasterBase.py
+++ b/tests/master/test_SerialMasterBase.py
@@ -6,6 +6,8 @@ import unittest
 import os
 from pyiron_base.project.generic import Project
 from pyiron_base.master.serial import SerialMasterBase
+from pyiron_base._tests import PyironTestCase
+
 
 class TestGenericJob(PyironTestCase):
     @classmethod

--- a/tests/master/test_SerialMasterBase.py
+++ b/tests/master/test_SerialMasterBase.py
@@ -7,7 +7,7 @@ import os
 from pyiron_base.project.generic import Project
 from pyiron_base.master.serial import SerialMasterBase
 
-class TestGenericJob(unittest.TestCase):
+class TestGenericJob(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/master/test_parallelmaster.py
+++ b/tests/master/test_parallelmaster.py
@@ -29,7 +29,7 @@ class TestMaster(ParallelMaster):
         super().__init__(job_name, project)
         self._job_generator = TestGenerator(self)
 
-class TestParallelMaster(unittest.TestCase):
+class TestParallelMaster(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/master/test_parallelmaster.py
+++ b/tests/master/test_parallelmaster.py
@@ -6,6 +6,8 @@ import unittest
 import os
 from pyiron_base.project.generic import Project
 from pyiron_base import JobGenerator, ParallelMaster
+from pyiron_base._tests import PyironTestCase
+
 
 class TestGenerator(JobGenerator):
 

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -7,6 +7,7 @@ from os.path import dirname, join, abspath
 from os import remove
 from pyiron_base.project.generic import Project
 from pyiron_base.project.data import ProjectData
+from pyiron_base._tests import PyironTestCase
 
 
 class TestProjectData(PyironTestCase):

--- a/tests/project/test_data.py
+++ b/tests/project/test_data.py
@@ -9,7 +9,7 @@ from pyiron_base.project.generic import Project
 from pyiron_base.project.data import ProjectData
 
 
-class TestProjectData(unittest.TestCase):
+class TestProjectData(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -8,7 +8,7 @@ from pyiron_base.project.generic import Project
 from pyiron_base.project.path import GenericPath
 
 
-class TestGenericPath(unittest.TestCase):
+class TestGenericPath(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
@@ -26,7 +26,7 @@ class TestGenericPath(unittest.TestCase):
         self.assertEqual(self.path_project.path, self.current_dir + "/project/path/")
 
 
-class TestProject(unittest.TestCase):
+class TestProject(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -7,7 +7,6 @@ import unittest
 from pyiron_base.project.generic import Project
 from pyiron_base.project.path import GenericPath
 from pyiron_base._tests import PyironTestCase
-from pyiron_base._tests import PyironTestCase
 
 
 class TestGenericPath(PyironTestCase):

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -4,9 +4,8 @@
 
 import os
 import unittest
-from pyiron_base.project.generic import Project
 from pyiron_base.project.path import GenericPath
-from pyiron_base._tests import PyironTestCase
+from pyiron_base._tests import PyironTestCase, TestWithCleanProject
 
 
 class TestGenericPath(PyironTestCase):
@@ -27,14 +26,16 @@ class TestGenericPath(PyironTestCase):
         self.assertEqual(self.path_project.path, self.current_dir + "/project/path/")
 
 
-class TestProject(PyironTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
-        cls.project = Project(os.path.join(cls.current_dir, "sub_folder"))
+class TestProject(TestWithCleanProject):
 
-    def tearDown(self):
-        self.project.remove(enable=True)
+    # @classmethod
+    # def setUpClass(cls):
+    #     cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
+    #     cls.project = Project(os.path.join(cls.current_dir, "sub_folder"))
+    #
+    # @classmethod
+    # def tearDownClass(cls):
+    #     cls.project.remove(enable=True)
 
     def test_repr(self):
         self.assertEqual([], self.project.list_groups())
@@ -46,8 +47,8 @@ class TestProject(PyironTestCase):
             sorted(
                 [
                     directory
-                    for directory in os.listdir(self.current_dir)
-                    if not os.path.isfile(os.path.join(self.current_dir, directory))
+                    for directory in os.listdir(self.file_location)
+                    if not os.path.isfile(os.path.join(self.file_location, directory))
                 ]
             ),
             pr_down_one.list_groups(),
@@ -56,9 +57,9 @@ class TestProject(PyironTestCase):
             sorted(
                 [
                     directory
-                    for directory in os.listdir(os.path.join(self.current_dir, ".."))
+                    for directory in os.listdir(os.path.join(self.file_location, ".."))
                     if not os.path.isfile(
-                        os.path.join(self.current_dir, "..", directory)
+                        os.path.join(self.file_location, "..", directory)
                     )
                 ]
             ),

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -4,8 +4,9 @@
 
 import os
 import unittest
+from pyiron_base.project.generic import Project
 from pyiron_base.project.path import GenericPath
-from pyiron_base._tests import PyironTestCase, TestWithCleanProject
+from pyiron_base._tests import PyironTestCase
 
 
 class TestGenericPath(PyironTestCase):
@@ -26,16 +27,16 @@ class TestGenericPath(PyironTestCase):
         self.assertEqual(self.path_project.path, self.current_dir + "/project/path/")
 
 
-class TestProject(TestWithCleanProject):
+class TestProject(PyironTestCase):
 
-    # @classmethod
-    # def setUpClass(cls):
-    #     cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
-    #     cls.project = Project(os.path.join(cls.current_dir, "sub_folder"))
-    #
-    # @classmethod
-    # def tearDownClass(cls):
-    #     cls.project.remove(enable=True)
+    @classmethod
+    def setUpClass(cls):
+        cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
+        cls.project = Project(os.path.join(cls.current_dir, "sub_folder"))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.project.remove(enable=True)
 
     def test_repr(self):
         self.assertEqual([], self.project.list_groups())
@@ -47,8 +48,8 @@ class TestProject(TestWithCleanProject):
             sorted(
                 [
                     directory
-                    for directory in os.listdir(self.file_location)
-                    if not os.path.isfile(os.path.join(self.file_location, directory))
+                    for directory in os.listdir(self.current_dir)
+                    if not os.path.isfile(os.path.join(self.current_dir, directory))
                 ]
             ),
             pr_down_one.list_groups(),
@@ -57,9 +58,9 @@ class TestProject(TestWithCleanProject):
             sorted(
                 [
                     directory
-                    for directory in os.listdir(os.path.join(self.file_location, ".."))
+                    for directory in os.listdir(os.path.join(self.current_dir, ".."))
                     if not os.path.isfile(
-                        os.path.join(self.file_location, "..", directory)
+                        os.path.join(self.current_dir, "..", directory)
                     )
                 ]
             ),

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -6,6 +6,8 @@ import os
 import unittest
 from pyiron_base.project.generic import Project
 from pyiron_base.project.path import GenericPath
+from pyiron_base._tests import PyironTestCase
+from pyiron_base._tests import PyironTestCase
 
 
 class TestGenericPath(PyironTestCase):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -6,6 +6,7 @@ import unittest
 from os.path import dirname, join, abspath
 from os import remove
 from pyiron_base.project.generic import Project
+from pyiron_base._tests import PyironTestCase
 
 
 class TestProjectData(PyironTestCase):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -8,7 +8,7 @@ from os import remove
 from pyiron_base.project.generic import Project
 
 
-class TestProjectData(unittest.TestCase):
+class TestProjectData(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = dirname(abspath(__file__)).replace("\\", "/")

--- a/tests/project/test_projectPath.py
+++ b/tests/project/test_projectPath.py
@@ -5,6 +5,7 @@
 import os
 import unittest
 from pyiron_base.project.path import ProjectPath
+from pyiron_base._tests import PyironTestCase
 
 
 class TestProjectPath(PyironTestCase):

--- a/tests/project/test_projectPath.py
+++ b/tests/project/test_projectPath.py
@@ -7,7 +7,7 @@ import unittest
 from pyiron_base.project.path import ProjectPath
 
 
-class TestProjectPath(unittest.TestCase):
+class TestProjectPath(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         if os.name == "nt":

--- a/tests/server/test_runmode.py
+++ b/tests/server/test_runmode.py
@@ -6,7 +6,7 @@ import unittest
 from pyiron_base.server.runmode import Runmode
 
 
-class TestRunmode(unittest.TestCase):
+class TestRunmode(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.run_mode_default = Runmode()

--- a/tests/server/test_runmode.py
+++ b/tests/server/test_runmode.py
@@ -4,6 +4,7 @@
 
 import unittest
 from pyiron_base.server.runmode import Runmode
+from pyiron_base._tests import PyironTestCase
 
 
 class TestRunmode(PyironTestCase):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -4,6 +4,7 @@
 
 import unittest
 from pyiron_base.server.generic import Server
+from pyiron_base._tests import PyironTestCase
 
 
 class TestRunmode(PyironTestCase):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -6,7 +6,7 @@ import unittest
 from pyiron_base.server.generic import Server
 
 
-class TestRunmode(unittest.TestCase):
+class TestRunmode(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.server = Server()

--- a/tests/server/test_submissionStatus.py
+++ b/tests/server/test_submissionStatus.py
@@ -5,8 +5,8 @@
 from datetime import datetime
 from pyiron_base.database.generic import DatabaseAccess
 from pyiron_base.master.submissionstatus import SubmissionStatus
-import unittest
 import os
+from pyiron_base._tests import PyironTestCase
 
 
 class TestSubmissionStatus(PyironTestCase):

--- a/tests/server/test_submissionStatus.py
+++ b/tests/server/test_submissionStatus.py
@@ -9,7 +9,7 @@ import unittest
 import os
 
 
-class TestSubmissionStatus(unittest.TestCase):
+class TestSubmissionStatus(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.sub_status = SubmissionStatus()

--- a/tests/settings/test_generic_file_config.py
+++ b/tests/settings/test_generic_file_config.py
@@ -5,6 +5,7 @@
 from pyiron_base.settings.generic import Settings
 import os
 import unittest
+from pyiron_base._tests import PyironTestCase
 
 
 class TestConfigSettingsStatic(PyironTestCase):

--- a/tests/settings/test_generic_file_config.py
+++ b/tests/settings/test_generic_file_config.py
@@ -7,7 +7,7 @@ import os
 import unittest
 
 
-class TestConfigSettingsStatic(unittest.TestCase):
+class TestConfigSettingsStatic(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.resource_path = os.path.abspath(

--- a/tests/settings/test_generic_test_config.py
+++ b/tests/settings/test_generic_test_config.py
@@ -8,7 +8,7 @@ import unittest
 from pyiron_base.settings.generic import Settings
 
 
-class TestConfigSettingsStatic(unittest.TestCase):
+class TestConfigSettingsStatic(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.resource_path = (

--- a/tests/settings/test_generic_test_config.py
+++ b/tests/settings/test_generic_test_config.py
@@ -6,6 +6,7 @@ from pathlib2 import Path
 import os
 import unittest
 from pyiron_base.settings.generic import Settings
+from pyiron_base._tests import PyironTestCase
 
 
 class TestConfigSettingsStatic(PyironTestCase):

--- a/tests/settings/test_install.py
+++ b/tests/settings/test_install.py
@@ -6,6 +6,7 @@ import os
 import shutil
 from pyiron_base.settings.install import install_pyiron
 import unittest
+from pyiron_base._tests import PyironTestCase
 
 
 class TestInstall(PyironTestCase):

--- a/tests/settings/test_install.py
+++ b/tests/settings/test_install.py
@@ -8,7 +8,7 @@ from pyiron_base.settings.install import install_pyiron
 import unittest
 
 
-class TestInstall(unittest.TestCase):
+class TestInstall(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This PR includes the following changes

- Creating a generic `PyironTestCase` for all unittesting within pyiron which includes generic functions that can be used for all test modules
- Inheriting all test modules from this particular module
- Automatic testing of the docstrings of the `DataContainer` module