### PR TITLE
Revert "Bump h5py from 3.3.0 to 3.4.0"

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - future =0.18.2
 - gitpython =3.1.18
 - h5io =0.1.2
-- h5py =3.4.0
+- h5py =3.3.0
 - numpy =1.21.2
 - pandas =1.3.2
 - pathlib2 =2.3.6

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'future==0.18.2',
         'gitpython==3.1.18',
         'h5io==0.1.2',
-        'h5py==3.4.0',
+        'h5py==3.3.0',
         'numpy==1.21.2',
         'pandas==1.3.2',
         'pathlib2==2.3.6',


### PR DESCRIPTION
Reverts pyiron/pyiron_base#422 since https://github.com/pyiron/pyiron_atomistics/pull/333 is failing right now