### PR TITLE
Creator registration

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -34,7 +34,7 @@ from pyiron_base.generic.object import HasDatabase, HasStorage, PyironObject
 from pyiron_base.database.performance import get_database_statistics
 
 from pyiron_base.toolkit import Toolkit, BaseTools
-Project.register_creator('base', BaseTools)
+Project.register_tools('base', BaseTools)
 
 # optional API of the pyiron_base module
 try:

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -18,12 +18,13 @@ from pyiron_base.job.interactivewrapper import InteractiveWrapper
 from pyiron_base.job.jobstatus import JobStatus, job_status_successful_lst, job_status_finished_lst, job_status_lst
 from pyiron_base.job.jobtype import JOB_CLASS_DICT, JobType, JobTypeChoice
 from pyiron_base.job.template import TemplateJob, PythonTemplateJob
+from pyiron_base.job.factory import JobFactoryCore
 from pyiron_base.master.generic import GenericMaster, get_function_from_string
 from pyiron_base.master.list import ListMaster
 from pyiron_base.master.parallel import ParallelMaster, JobGenerator
 from pyiron_base.master.serial import SerialMasterBase
 from pyiron_base.master.flexible import FlexibleMaster
-from pyiron_base.project.generic import Project, Creator, CreatorCore
+from pyiron_base.project.generic import Project, Creator
 from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
 from pyiron_base.server.queuestatus import validate_que_request
 from pyiron_base.settings.generic import Settings
@@ -31,6 +32,9 @@ from pyiron_base.settings.install import install_dialog
 from pyiron_base.table.datamining import PyironTable, TableJob
 from pyiron_base.generic.object import HasDatabase, HasStorage, PyironObject
 from pyiron_base.database.performance import get_database_statistics
+
+from pyiron_base.toolkit import Toolkit, BaseTools
+Project.register_creator('base', BaseTools)
 
 # optional API of the pyiron_base module
 try:

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -23,7 +23,7 @@ from pyiron_base.master.list import ListMaster
 from pyiron_base.master.parallel import ParallelMaster, JobGenerator
 from pyiron_base.master.serial import SerialMasterBase
 from pyiron_base.master.flexible import FlexibleMaster
-from pyiron_base.project.generic import Project, Creator
+from pyiron_base.project.generic import Project, Creator, CreatorCore
 from pyiron_base.pyio.parser import Logstatus, extract_data_from_file
 from pyiron_base.server.queuestatus import validate_que_request
 from pyiron_base.settings.generic import Settings

--- a/pyiron_base/job/factory.py
+++ b/pyiron_base/job/factory.py
@@ -72,7 +72,7 @@ class JobFactoryCore(PyironFactory, ABC):
 
 class JobFactory(JobFactoryCore):
     @property
-    def _job_class_dict(self):
+    def _job_class_dict(self) -> dict:
         return {
             "FlexibleMaster": FlexibleMaster,
             "ScriptJob": ScriptJob,

--- a/pyiron_base/job/factory.py
+++ b/pyiron_base/job/factory.py
@@ -5,9 +5,12 @@
 Factories for creating jobs, which may already exist in the database/storage.
 """
 
+from pyiron_base.project.generic import Project
 from pyiron_base.generic.factory import PyironFactory
 from abc import ABC, abstractmethod
 from pyiron_base.job.jobtype import JobType
+from pyiron_base.job.generic import GenericJob
+from typing import Type
 
 from pyiron_base.master.flexible import FlexibleMaster
 from pyiron_base.job.script import ScriptJob
@@ -28,7 +31,7 @@ __date__ = "Sep 7, 2021"
 
 
 class JobFactoryCore(PyironFactory, ABC):
-    def __init__(self, project):
+    def __init__(self, project: Project):
         self._project = project
 
     def __dir__(self):
@@ -39,7 +42,7 @@ class JobFactoryCore(PyironFactory, ABC):
 
     def __getattr__(self, name):
         if name in self._job_class_dict.keys():
-            def wrapper(job_name, delete_existing_job=False):
+            def wrapper(job_name, delete_existing_job=False) -> Type[GenericJob]:
                 """
                 Create a job.
 

--- a/pyiron_base/job/factory.py
+++ b/pyiron_base/job/factory.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Factories for creating jobs, which may already exist in the database/storage.
+"""
+
+from pyiron_base.generic.factory import PyironFactory
+from abc import ABC, abstractmethod
+from pyiron_base.job.jobtype import JobType
+
+from pyiron_base.master.flexible import FlexibleMaster
+from pyiron_base.job.script import ScriptJob
+from pyiron_base.master.serial import SerialMasterBase
+from pyiron_base.table.datamining import TableJob
+from pyiron_base.generic.hdfio import ProjectHDFio
+
+__author__ = "Liam Huber, Jan Janssen"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "production"
+__date__ = "Sep 7, 2021"
+
+
+class JobFactoryCore(PyironFactory, ABC):
+    def __init__(self, project):
+        self._project = project
+
+    def __dir__(self):
+        """
+        Enable autocompletion by overwriting the __dir__() function.
+        """
+        return list(self._job_class_dict.keys())
+
+    def __getattr__(self, name):
+        if name in self._job_class_dict.keys():
+            def wrapper(job_name, delete_existing_job=False):
+                """
+                Create a job.
+
+                Args:
+                    job_name (str): name of the job
+                    delete_existing_job (bool): delete an existing job - default false
+
+                Returns:
+                    GenericJob: job object depending on the job_type selected
+                """
+                return JobType(
+                    class_name=self._job_class_dict[name],  # Pass the class directly, JobType can handle that
+                    project=ProjectHDFio(project=self._project.copy(), file_name=job_name),
+                    job_name=job_name,
+                    job_class_dict=self._job_class_dict,
+                    delete_existing_job=delete_existing_job
+                )
+            return wrapper
+        else:
+            raise AttributeError("no job class named '{}' defined".format(name))
+
+    @property
+    @abstractmethod
+    def _job_class_dict(self):
+        pass
+
+
+class JobFactory(JobFactoryCore):
+    @property
+    def _job_class_dict(self):
+        return {
+            "FlexibleMaster": FlexibleMaster,
+            "ScriptJob": ScriptJob,
+            "SerialMasterBase": SerialMasterBase,
+            "TableJob": TableJob
+        }

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -48,8 +48,6 @@ from pyiron_base.server.queuestatus import (
 from pyiron_base.job.external import Notebook
 from pyiron_base.project.data import ProjectData
 from pyiron_base.archiving import import_archive, export_archive
-from abc import ABC
-from typing import Type
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -63,17 +61,6 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 s = Settings()
-
-
-class CreatorCore(ABC):
-    def __init__(self, project):
-        self._project = project
-
-
-class BaseCreator(CreatorCore):
-    def __init__(self, project):
-        super().__init__(project)
-        # TODO: Attach a job factory
 
 
 class Project(ProjectPath, HasGroups):
@@ -135,7 +122,6 @@ class Project(ProjectPath, HasGroups):
         self._inspect_mode = False
         self._data = None
         self._creator = Creator(project=self)
-        self._base = BaseCreator(project=self)
 
         if not s.database_is_disabled:
             s.open_connection()
@@ -1528,13 +1514,13 @@ class Project(ProjectPath, HasGroups):
         )
 
     @classmethod
-    def register_creator(cls, name: str, creator: Type[CreatorCore]):
+    def register_creator(cls, name: str, creator):
         """
         Add a new creator to the project class.
 
         Example)
-        >>> from pyiron_base import Project, CreatorCore
-        >>> class MyCreator(CreatorCore):
+        >>> from pyiron_base import Project, Toolkit
+        >>> class MyCreator(Toolkit):
         >>>     @property
         >>>     def foo(self):
         >>>         return 'foo'
@@ -1550,7 +1536,7 @@ class Project(ProjectPath, HasGroups):
 
         Args:
             name (str): The name for the newly registered property.
-            creator (CreatorCore): The creator to register.
+            creator (Toolkit): The creator to register.
         """
         setattr(cls, name, property(lambda self: creator(self)))
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1539,6 +1539,10 @@ class Project(ProjectPath, HasGroups):
             name (str): The name for the newly registered property.
             tools (Toolkit): The tools to register.
         """
+        if hasattr(cls, name):
+            raise AttributeError(
+                f'{cls.__name__} already has an attribute {name}. Please use a new name for registration.'
+            )
         setattr(cls, name, property(lambda self: tools(self)))
 
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1514,20 +1514,20 @@ class Project(ProjectPath, HasGroups):
         )
 
     @classmethod
-    def register_tools(cls, name: str, creator):
+    def register_tools(cls, name: str, tools):
         """
         Add a new creator to the project class.
 
         Example)
         >>> from pyiron_base import Project, Toolkit
-        >>> class MyCreator(Toolkit):
+        >>> class MyTools(Toolkit):
         >>>     @property
         >>>     def foo(self):
         >>>         return 'foo'
         >>>
-        >>> Project.register_tools('my_creator', MyCreator)
+        >>> Project.register_tools('my_tools', MyTools)
         >>> pr = Project('scratch')
-        >>> print(pr.my_creator.foo)
+        >>> print(pr.my_tools.foo)
         'foo'
 
         The intent is then that pyiron submodules (e.g. `pyiron_atomistics`) define a new creator and in their
@@ -1536,9 +1536,9 @@ class Project(ProjectPath, HasGroups):
 
         Args:
             name (str): The name for the newly registered property.
-            creator (Toolkit): The creator to register.
+            tools (Toolkit): The tools to register.
         """
-        setattr(cls, name, property(lambda self: creator(self)))
+        setattr(cls, name, property(lambda self: tools(self)))
 
 
 class Maintenance:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1567,6 +1567,29 @@ class Creator:
         self._job_factory = JobFactory(project=project)
         self._project = project
 
+    @classmethod
+    def register(cls, name, registrant):
+        """
+        Instantiate a new object as a property of the creator. The new object should take a `Project` instance as the
+        only initialization argument.
+
+        E.g. in the `__init__` file for a new pyiron module you may have:
+        >>> class Foo:
+        >>>     def __init__(self, project):
+        >>>         self._project = project
+        >>>
+        >>> from pyiron_base import Creator
+        >>> Creator.register('my_new_foo', Foo)
+
+        Of course you shouldn't also define the class itself in `__init__.py` but rather somewhere in your codebase, it
+        just shows up here to make the example complete.
+
+        Args:
+            name (str): The name for the newly registered property.
+            registrant (class): The class to register, which must take an instance of `Project` as its only argument.
+        """
+        setattr(cls, name, property(lambda self: registrant(self._project)))
+
     @property
     def job(self):
         return self._job_factory

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1519,6 +1519,7 @@ class Project(ProjectPath, HasGroups):
         Add a new creator to the project class.
 
         Example)
+        
         >>> from pyiron_base import Project, Toolkit
         >>> class MyCreator(Toolkit):
         >>>     @property

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1522,9 +1522,9 @@ class Project(ProjectPath, HasGroups):
         
         >>> from pyiron_base import Project, Toolkit
         >>> class MyTools(Toolkit):
-        >>>     @property
-        >>>     def foo(self):
-        >>>         return 'foo'
+        ...     @property
+        ...     def foo(self):
+        ...         return 'foo'
         >>>
         >>> Project.register_tools('my_tools', MyTools)
         >>> pr = Project('scratch')

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1514,7 +1514,7 @@ class Project(ProjectPath, HasGroups):
         )
 
     @classmethod
-    def register_creator(cls, name: str, creator):
+    def register_tools(cls, name: str, creator):
         """
         Add a new creator to the project class.
 
@@ -1525,7 +1525,7 @@ class Project(ProjectPath, HasGroups):
         >>>     def foo(self):
         >>>         return 'foo'
         >>>
-        >>> Project.register_creator('my_creator', MyCreator)
+        >>> Project.register_tools('my_creator', MyCreator)
         >>> pr = Project('scratch')
         >>> print(pr.my_creator.foo)
         'foo'

--- a/pyiron_base/toolkit.py
+++ b/pyiron_base/toolkit.py
@@ -1,0 +1,18 @@
+from abc import ABC
+
+from pyiron_base.job.factory import JobFactory
+
+
+class Toolkit(ABC):
+    def __init__(self, project):
+        self._project = project
+
+
+class BaseTools(Toolkit):
+    def __init__(self, project):
+        super().__init__(project)
+        self._job = JobFactory(project)
+
+    @property
+    def job(self):
+        return self._job

--- a/pyiron_base/toolkit.py
+++ b/pyiron_base/toolkit.py
@@ -31,5 +31,5 @@ class BaseTools(Toolkit):
         self._job = JobFactory(project)
 
     @property
-    def job(self):
+    def job(self) -> JobFactory:
         return self._job

--- a/pyiron_base/toolkit.py
+++ b/pyiron_base/toolkit.py
@@ -1,6 +1,23 @@
-from abc import ABC
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Builtin tools that come with pyiron base.
+"""
 
+from abc import ABC
 from pyiron_base.job.factory import JobFactory
+
+__author__ = "Liam Huber"
+__copyright__ = (
+    "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "production"
+__date__ = "Sep 7, 2021"
 
 
 class Toolkit(ABC):

--- a/tests/job/test_factory.py
+++ b/tests/job/test_factory.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base._tests import TestWithCleanProject
+from pyiron_base.job.factory import JobFactory
+
+
+class TestJobFactory(TestWithCleanProject):
+    def setUp(self) -> None:
+        super().setUp()
+        self.factory = JobFactory(self.project)
+
+    def test_core(self):
+        job = self.factory.ScriptJob('foo')
+
+        job.status.aborted = True
+        self.assertLogs(self.factory.ScriptJob('foo'), level='WARNING')  # Job aborted warning
+
+        job.input.foo = 'foo'
+        job = self.factory.ScriptJob('foo', delete_existing_job=True)
+        with self.assertRaises(Exception):
+            job.input.foo  # Shouldn't exist after deleting existing job
+
+    def test_base(self):
+        self.assertGreater(len(self.factory._job_class_dict), 0)

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -6,7 +6,8 @@ import unittest
 from os.path import dirname, join, abspath
 from os import remove
 from pyiron_base.project.generic import Project
-from pyiron_base._tests import PyironTestCase
+from pyiron_base._tests import PyironTestCase, TestWithProject
+from pyiron_base.toolkit import BaseTools
 
 
 class TestProjectData(PyironTestCase):
@@ -54,6 +55,18 @@ class TestProjectData(PyironTestCase):
                 pass
         except:
             self.fail("Iterating over empty project with set status flag should not raise exception.")
+
+
+class TestToolRegistration(TestWithProject):
+    def setUp(self) -> None:
+        self.tools = BaseTools(self.project)
+
+    def test_registration(self):
+        self.project.register_tools('foo', self.tools)
+        with self.assertRaises(AttributeError):
+            self.project.register_tools('foo', self.tools)  # Name taken
+        with self.assertRaises(AttributeError):
+            self.project.register_tools('load', self.tools)  # Already another method
 
 
 if __name__ == '__main__':

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base._tests import TestWithProject
+from pyiron_base.toolkit import BaseTools
+
+
+class TestToolkit(TestWithProject):
+    def setUp(self):
+        super().setUp()
+        self.tools = BaseTools(self.project)
+
+    def test_job(self):
+        self.tools.job.ScriptJob('foo')
+        with self.assertRaises(AttributeError):
+            self.tools.job.NotAJobAtAll('bar')


### PR DESCRIPTION
Instead of having new pyiron submodules subclass `Project` and always worry about which child of `Project` we currently have, to simply on-the-fly enhance the existing `Project` by registering new methods with it. 

This was originally suggested by @freyso [here](https://github.com/pyiron/pyiron_base/pull/385) and has since been discussed at one of the meetings ([minutes](https://github.com/orgs/pyiron/teams/pyiron/discussions/79)) and is an official [issue](https://github.com/pyiron/pyiron_atomistics/issues/323) from @niklassiemer. I made a first crack at it and got a good response from @JNmpi and @muh-hassani in the tech dev meeting ([minutes](https://github.com/orgs/pyiron/teams/development/discussions/48)), so this is an expanded attack at that idea.

The
```python
from pyiron_base import Project
pr = Project('scratch')
pr.base.job.ScriptJob('foo')

import pyiron_atomistics
job = pr.atomistics.job.Lammps('bar')  # Note we did not need to reinstantiate pr
job.structure = pr.atomistics.structure.bulk('Al')
```

A use case can be seen over in [pyiron_atomistics#347](https://github.com/pyiron/pyiron_atomistics/pull/347).

Pros:
- Drastically reduces use of strings in controlling the code behaviour
- Hopefully no more need to subclass of `Project` for every submodule (which right now is so we can re-instantiate the right class?)
- Submodule init files get a lot simpler
- Development in this direction can run fully in parallel to the existing routines

Cons:
- More typing maybe (i.e. with keyboard)? As it is now we lose the verb `create` which makes me sad, but I'm trying to minimize keystrokes a little
- Potentially harder to find things, e.g. "do I want `pr.atomistics.job.Foo` or `pr.continuum.job.Foo`?"
  - I am definitely still open to rearranging things, e.g. `pr.atomistics.job.Lammps` --> `pr.create.job.atomistics.Lammps`
- **Not yet tested for remote jobs.** As long as your remote python environment has imported (or imports on seeing the loading job type) all the same pyiron modules as you use in your notebook, it's fine...but I haven't tested this
  - I know we already have some solution for this, as I *already* make custom job classes that wouldn't work if I hadn't added bespoke modules to my `PYTHONPATH` in my `.bashrc`, I am just ignorant of *how* exactly we work this magic

TODO:
- ~~Attach job factories to these creators~~
- ~~Unit tests~~
- ~~Finish adding type-hinting~~
- Make sure it works for jobs run on a queue

Not TODO:
- Move stuff around to new modules (e.g. a new `pyiron_base.creators` module or similar)
  - Exact location can be adjusted if/when we're happy with everything in principle, as avoiding circular imports means some of it is a pain in the butt and I want to handle it separately.
