### PR TITLE
Update template job to use ~~DataContainer~~ HasStorage

### DIFF
--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -47,7 +47,7 @@ class TemplateJob(GenericJob):
             hdf=hdf,
             group_name=group_name
         )
-        self._data.from_hdf(hdf=hdf, group_name=group_name)
+        self._data.from_hdf(hdf=self.project_hdf5, group_name=None)
 
 
 class PythonTemplateJob(TemplateJob):

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -40,7 +40,7 @@ class TemplateJob(GenericJob):
             hdf=hdf,
             group_name=group_name
         )
-        self._data.to_hdf(hdf=hdf, group_name=group_name)
+        self._data.to_hdf(hdf=self.project_hdf5, group_name=None)
 
     def from_hdf(self, hdf=None, group_name=None):
         super().from_hdf(

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -6,7 +6,7 @@ Template class to define jobs
 """
 
 from pyiron_base.job.generic import GenericJob
-from pyiron_base.generic.parameters import GenericParameters
+from pyiron_base.generic.datacontainer import DataContainer
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -23,23 +23,31 @@ __date__ = "May 15, 2020"
 class TemplateJob(GenericJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
-        self.input = GenericParameters(table_name="input")
+        self._data = DataContainer(table_name="data")
+        self._data.create_group('input')
+        self._data.create_group('output')
+
+    @property
+    def input(self):
+        return self._data.input
+
+    @property
+    def output(self):
+        return self._data.output
 
     def to_hdf(self, hdf=None, group_name=None):
         super().to_hdf(
             hdf=hdf,
             group_name=group_name
         )
-        with self.project_hdf5.open("input") as h5in:
-            self.input.to_hdf(h5in)
+        self._data.to_hdf(hdf=hdf, group_name=group_name)
 
     def from_hdf(self, hdf=None, group_name=None):
         super().from_hdf(
             hdf=hdf,
             group_name=group_name
         )
-        with self.project_hdf5.open("input") as h5in:
-            self.input.from_hdf(h5in)
+        self._data.from_hdf(hdf=hdf, group_name=group_name)
 
 
 class PythonTemplateJob(TemplateJob):

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -6,7 +6,7 @@ Template class to define jobs
 """
 
 from pyiron_base.job.generic import GenericJob
-from pyiron_base.generic.datacontainer import DataContainer
+from pyiron_base.generic.object import HasStorage
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -20,34 +20,20 @@ __status__ = "development"
 __date__ = "May 15, 2020"
 
 
-class TemplateJob(GenericJob):
+class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
-        super().__init__(project, job_name)
-        self._data = DataContainer(table_name="data")
-        self._data.create_group('input')
-        self._data.create_group('output')
+        GenericJob.__init__(self, project, job_name)
+        HasStorage.__init__(self)
+        self._storage.create_group('input')
+        self._storage.create_group('output')
 
     @property
     def input(self):
-        return self._data.input
+        return self._storage.input
 
     @property
     def output(self):
-        return self._data.output
-
-    def to_hdf(self, hdf=None, group_name=None):
-        super().to_hdf(
-            hdf=hdf,
-            group_name=group_name
-        )
-        self._data.to_hdf(hdf=self.project_hdf5, group_name=None)
-
-    def from_hdf(self, hdf=None, group_name=None):
-        super().from_hdf(
-            hdf=hdf,
-            group_name=group_name
-        )
-        self._data.from_hdf(hdf=self.project_hdf5, group_name=None)
+        return self._storage.output
 
 
 class PythonTemplateJob(TemplateJob):


### PR DESCRIPTION
@JNmpi here it is. I noticed also that this job type is not available to create, but is only accessible with `from pyiron_base import TemplateJob`. My gut feeling is that this is mostly a parent class and not actually instantiated, so it's OK that it doesn't show up on the creation list?

@jan-janssen sorry to pester you for review, but the only place this might have an impact is over in pyiron_experimental for [pystem](https://github.com/pyiron/pyiron_experimental/blob/master/pyiron_experimental/pystemjob.py), [temmeta](https://github.com/pyiron/pyiron_experimental/blob/master/pyiron_experimental/temmetajob.py), and [matchseries](https://github.com/pyiron/pyiron_experimental/blob/master/pyiron_experimental/matchseries.py). For the first two I can already see there's not going to be an impact, but matchseries is more complicated and it has no tests. Since you're the sole contributor there I'd appreciate if you'd quickly look over and/or set up a test.