### PR TITLE
Smooth storage

### DIFF
--- a/pyiron_base/generic/object.py
+++ b/pyiron_base/generic/object.py
@@ -44,8 +44,6 @@ class HasStorage(HasHDF, ABC):
     def _from_hdf(self, hdf: ProjectHDFio, version: str=None):
         self.storage.from_hdf(hdf=hdf)
 
-    def _get_hdf_group_name(self):
-        return ""
 
 
 class HasDatabase(ABC):

--- a/pyiron_base/generic/object.py
+++ b/pyiron_base/generic/object.py
@@ -8,6 +8,8 @@ The core class in pyiron, linking python to the database to file storage.
 
 from abc import ABC
 from pyiron_base import DataContainer
+from pyiron_base.interfaces.has_hdf import HasHDF
+from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.settings.generic import Settings
 
 __author__ = "Liam Huber"
@@ -24,7 +26,7 @@ __date__ = "Mar 23, 2021"
 s = Settings()
 
 
-class HasStorage(ABC):
+class HasStorage(HasHDF, ABC):
     """
     A base class for objects that use HDF5 data serialization via the `DataContainer` class.
     """
@@ -33,32 +35,17 @@ class HasStorage(ABC):
         self._storage = DataContainer(table_name='storage')
 
     @property
-    def storage(self):
+    def storage(self) -> DataContainer:
         return self._storage
 
-    def to_hdf(self, hdf, group_name=None):
-        """
-        Serialize everything in the `storage` field to HDF5.
+    def _to_hdf(self, hdf: ProjectHDFio):
+        self.storage.to_hdf(hdf=hdf)
 
-        Args:
-            hdf (ProjectHDFio): HDF5 group object.
-            group_name (str, optional): HDF5 subgroup name.
-        """
-        if group_name is not None:
-            hdf = hdf.create_group(group_name)
-        self._storage.to_hdf(hdf=hdf)
+    def _from_hdf(self, hdf: ProjectHDFio, version: str=None):
+        self.storage.from_hdf(hdf=hdf)
 
-    def from_hdf(self, hdf, group_name=None):
-        """
-        Restore the everything in the `storage` field from an HDF5 file.
-
-        Args:
-            hdf (ProjectHDFio): HDF5 group object.
-            group_name (str, optional): HDF5 subgroup name.
-        """
-        if group_name is not None:
-            hdf = hdf.create_group(group_name)
-        self._storage.from_hdf(hdf=hdf)
+    def _get_hdf_group_name(self):
+        return "storage"
 
 
 class HasDatabase(ABC):

--- a/pyiron_base/generic/object.py
+++ b/pyiron_base/generic/object.py
@@ -7,7 +7,7 @@ The core class in pyiron, linking python to the database to file storage.
 """
 
 from abc import ABC
-from pyiron_base import DataContainer
+from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.settings.generic import Settings

--- a/pyiron_base/generic/object.py
+++ b/pyiron_base/generic/object.py
@@ -45,7 +45,7 @@ class HasStorage(HasHDF, ABC):
         self.storage.from_hdf(hdf=hdf)
 
     def _get_hdf_group_name(self):
-        return "storage"
+        return ""
 
 
 class HasDatabase(ABC):

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -139,7 +139,7 @@ class HasHDF(ABC):
         """
         return {}
 
-    def _type_to_hdf(self, hdf: ProjectHDFio):
+    def _store_type_to_hdf(self, hdf: ProjectHDFio):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
         hdf["OBJECT"] = hdf["NAME"]  # unused alias
@@ -177,7 +177,7 @@ class HasHDF(ABC):
             if len(hdf.list_dirs()) > 0 and group_name is None:
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
-            self._type_to_hdf(hdf)
+            self._store_type_to_hdf(hdf)
 
     def rewrite_hdf(self, hdf: ProjectHDFio, group_name: str=None):
         """

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -18,6 +18,7 @@ __email__ = "poul@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2021"
 
+
 class _WithHDF:
     __slots__ = ("_hdf", "_group_name")
 
@@ -34,6 +35,7 @@ class _WithHDF:
     def __exit__(self, *args):
         if self._group_name is not None:
             self._hdf.close()
+
 
 class HasHDF(ABC):
     """
@@ -140,7 +142,7 @@ class HasHDF(ABC):
     def _type_to_hdf(self, hdf: ProjectHDFio):
         hdf["NAME"] = self.__class__.__name__
         hdf["TYPE"] = str(type(self))
-        hdf["OBJECT"] = hdf["NAME"] # unused alias
+        hdf["OBJECT"] = hdf["NAME"]  # unused alias
         if hasattr(self, "__version__"):
             hdf["VERSION"] = self.__version__
         hdf["HDF_VERSION"] = self.__hdf_version__

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -24,23 +24,21 @@ class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
         HasStorage.__init__(self)
-        self._storage.create_group('input')
-        self._storage.create_group('output')
+        self.storage.create_group('input')
+        self.storage.create_group('output')
 
     @property
     def input(self):
-        return self._storage.input
+        return self.storage.input
 
     @property
     def output(self):
-        return self._storage.output
+        return self.storage.output
 
     def to_hdf(self, hdf=None, group_name=None):
-        GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)
         HasStorage.to_hdf(self, hdf=self.project_hdf5)
 
     def from_hdf(self, hdf=None, group_name=None):
-        GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)
         HasStorage.from_hdf(self, hdf=self.project_hdf5)
 
 


### PR DESCRIPTION
Rebase `HasStorage` to be a child of `HasHDF`. This way all children of `HaveStorage` handle the complete storage workflow: they can themselves get serialized and deserialized, and they have a spot for slapping any permanent data that should belong to them.

@pmrv it was all super easy, but I was a bit uncomfortable with this snippet:
```python
class HasStorage...

    def _get_hdf_group_name(self):
        return ""
```

Basically it means that `TYPE` etc will get stored at the base level of whatever is passed as `hdf` to the `HasStorage` child class, while `storage` is the sister to these and holds all the data _belonging_ to that object. This works beautifully, e.g. over in `TemplateJob` and in what I'm doing over in the `schroedinger` branch of `pyiron_continuum`, but do you foresee any side effects?