### PR TITLE
Reference job file size increase fix (issue #411)

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -655,7 +655,7 @@ class JobCore(HasGroups):
         h5_dict["groups"] += self._list_ext_childs()
         return h5_dict
 
-    def copy(self):
+    def copy_self(self):
         """
         Copy the JobCore object which links to the HDF5 file
 
@@ -707,7 +707,7 @@ class JobCore(HasGroups):
 
         # Create a new job by copying the current python object, move the content
         # of the HDF5 file and then attach the new HDF5 link to the new python object.
-        new_job_core = self.copy()
+        new_job_core = self.copy_self()
         new_job_core._name = new_job_name
         new_job_core._hdf5 = hdf5_project
         new_job_core._master_id = self._master_id

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -655,7 +655,7 @@ class JobCore(HasGroups):
         h5_dict["groups"] += self._list_ext_childs()
         return h5_dict
 
-    def copy(self):
+    def copy_self(self):
         """
         Copy the JobCore object which links to the HDF5 file
 
@@ -707,11 +707,7 @@ class JobCore(HasGroups):
 
         # Create a new job by copying the current python object, move the content
         # of the HDF5 file and then attach the new HDF5 link to the new python object.
-        if isinstance(project, JobCore):
-            new_job_core = self.copy()
-        else:
-            new_job_core = copy.copy(self)
-            new_job_core.reset_job_id()
+        new_job_core = self.copy_self()
         new_job_core._name = new_job_name
         new_job_core._hdf5 = hdf5_project
         new_job_core._master_id = self._master_id

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -655,7 +655,7 @@ class JobCore(HasGroups):
         h5_dict["groups"] += self._list_ext_childs()
         return h5_dict
 
-    def copy_self(self):
+    def copy(self):
         """
         Copy the JobCore object which links to the HDF5 file
 
@@ -707,7 +707,11 @@ class JobCore(HasGroups):
 
         # Create a new job by copying the current python object, move the content
         # of the HDF5 file and then attach the new HDF5 link to the new python object.
-        new_job_core = self.copy_self()
+        if isinstance(project, JobCore):
+            new_job_core = self.copy()
+        else:
+            new_job_core = copy.copy(self)
+            new_job_core.reset_job_id()
         new_job_core._name = new_job_name
         new_job_core._hdf5 = hdf5_project
         new_job_core._master_id = self._master_id

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -894,7 +894,7 @@ class JobCore(HasGroups):
         """
         try:
             return self._hdf5[item]
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         name_lst = item.split("/")

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -894,7 +894,7 @@ class JobCore(HasGroups):
         """
         try:
             return self._hdf5[item]
-        except (ValueError, TypeError):
+        except ValueError:
             pass
 
         name_lst = item.split("/")

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -663,6 +663,7 @@ class JobCore(HasGroups):
             JobCore: New FileHDFio object pointing to the same HDF5 file
         """
         copied_self = copy.copy(self)
+        copied_self.reset_job_id()
         return copied_self
 
     def _internal_copy_to(self, project=None, new_job_name=None, new_database_entry=True,
@@ -893,7 +894,7 @@ class JobCore(HasGroups):
         """
         try:
             return self._hdf5[item]
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         name_lst = item.split("/")

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -663,7 +663,6 @@ class JobCore(HasGroups):
             JobCore: New FileHDFio object pointing to the same HDF5 file
         """
         copied_self = copy.copy(self)
-        copied_self.reset_job_id()
         return copied_self
 
     def _internal_copy_to(self, project=None, new_job_name=None, new_database_entry=True,

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -170,6 +170,7 @@ class GenericJob(JobCore):
         self._python_only_job = False
         self.interactive_cache = None
         self.error = GenericError(job=self)
+        self._copy_exists = False
 
         for sig in intercepted_signals:
             signal.signal(sig, self.signal_intercept)
@@ -472,8 +473,10 @@ class GenericJob(JobCore):
                           copy_files=True, delete_existing_job=False):
         # Store all job arguments in the HDF5 file
         delete_file_after_copy = _job_store_before_copy(
-            job=self
+            job=self,
+            copy_exists=self._copy_exists
         )
+        self._copy_exists = True
 
         # Call the copy_to() function defined in the JobCore
         new_job_core, file_project, hdf5_project, reloaded = super(GenericJob, self)._internal_copy_to(

--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -379,12 +379,13 @@ def _job_remove_folder(job):
         shutil.rmtree(working_directory)
 
 
-def _job_store_before_copy(job):
+def _job_store_before_copy(job, copy_exists=False):
     """
     Store job in HDF5 file for copying
 
     Args:
         job (GenericJob): job object to copy
+        copy_exists (bool): if a copy of the job has already been made
 
     Returns:
         bool: [True/False] if the HDF5 file of the job exists already
@@ -393,7 +394,8 @@ def _job_store_before_copy(job):
         delete_file_after_copy = True
     else:
         delete_file_after_copy = False
-    job.to_hdf()
+    if not copy_exists:
+        job.to_hdf()
     return delete_file_after_copy
 
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -559,13 +559,12 @@ class GenericMaster(GenericJob):
                 return self.project.inspect(child_id)["/".join(name_lst[1:])]
             else:
                 return self.project.load(child_id, convert_to_object=True)
-        elif self._job_name_lst is not None:
-            if item_obj in self._job_name_lst:
-                child = self._load_job_from_cache(job_name=item_obj)
-                if len(name_lst) == 1:
-                    return child
-                else:
-                    return child["/".join(name_lst[1:])]
+        elif (self._job_name_lst is not None) and (item_obj in self._job_name_lst):
+            child = self._load_job_from_cache(job_name=item_obj)
+            if len(name_lst) == 1:
+                return child
+            else:
+                return child["/".join(name_lst[1:])]
         else:
             return super(GenericMaster, self).__getitem__(item)
 

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -9,6 +9,7 @@ import inspect
 import textwrap
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
+import sys
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -448,8 +449,20 @@ class GenericMaster(GenericJob):
         Returns:
 
         """
-        item_from_get_item = self.__getitem__(item=item)
-        if item_from_get_item is not None:
+        exception = False
+        sys.setrecursionlimit(100)
+        # NOTE: Manually set the recursion limit, since ipython 7.18.1 apparently doesn't catch RecursionError
+        # exceptions, on windows 10 systems like the one I'm testing on and is still an open issue here:
+        # https://github.com/ipython/ipython/issues/12197#
+        # Setting recursion limit lower than 100 raises 'recursion depth is too low'. Setting it too high crashes
+        # the kernel.
+        try:
+            item_from_get_item = self.__getitem__(item=item)
+        except RecursionError:
+            item_from_get_item = None
+            exception = True
+        sys.setrecursionlimit(1000)  # set recursion limit back to the default value
+        if (item_from_get_item is not None) or exception:
             return item_from_get_item
         else:
             raise AttributeError("{} tried to find child job {}, but getattr failed to find the item.".format(
@@ -546,7 +559,7 @@ class GenericMaster(GenericJob):
                 return self.project.inspect(child_id)["/".join(name_lst[1:])]
             else:
                 return self.project.load(child_id, convert_to_object=True)
-        elif item_obj in self._job_name_lst:
+        elif (self._job_name_lst is not None) and (item_obj in self._job_name_lst):
             child = self._load_job_from_cache(job_name=item_obj)
             if len(name_lst) == 1:
                 return child

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -9,7 +9,6 @@ import inspect
 import textwrap
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
-import sys
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -449,20 +448,8 @@ class GenericMaster(GenericJob):
         Returns:
 
         """
-        exception = False
-        sys.setrecursionlimit(100)
-        # NOTE: Manually set the recursion limit, since ipython 7.18.1 apparently doesn't catch RecursionError
-        # exceptions, on windows 10 systems like the one I'm testing on and is still an open issue here:
-        # https://github.com/ipython/ipython/issues/12197#
-        # Setting recursion limit lower than 100 raises 'recursion depth is too low'. Setting it too high crashes
-        # the kernel.
-        try:
-            item_from_get_item = self.__getitem__(item=item)
-        except RecursionError:
-            item_from_get_item = None
-            exception = True
-        sys.setrecursionlimit(1000)  # set recursion limit back to the default value
-        if (item_from_get_item is not None) or exception:
+        item_from_get_item = self.__getitem__(item=item)
+        if item_from_get_item is not None:
             return item_from_get_item
         else:
             raise AttributeError("{} tried to find child job {}, but getattr failed to find the item.".format(
@@ -559,7 +546,7 @@ class GenericMaster(GenericJob):
                 return self.project.inspect(child_id)["/".join(name_lst[1:])]
             else:
                 return self.project.load(child_id, convert_to_object=True)
-        elif (self._job_name_lst is not None) and (item_obj in self._job_name_lst):
+        elif item_obj in self._job_name_lst:
             child = self._load_job_from_cache(job_name=item_obj)
             if len(name_lst) == 1:
                 return child


### PR DESCRIPTION
There were a couple of things that were actually causing the file size explosion in issue #411:

1. Line 710 in `job/core.py` was not calling the `copy` method defined on line 658. I renamed the method to `copy_self`.
2. `to_hdf` was being called on the reference job every time a new copy of it was made. I added a hidden flag in the `JobCore` class called `_copy_exists` to record if an object of this class has previously been copied or not.

This PR should fix #411.