### PR TITLE
Exploit table

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -13,13 +13,8 @@ import time
 import os
 from datetime import datetime
 from sqlalchemy import (
-    Column,
     create_engine,
-    DateTime,
-    Float,
-    Integer,
     MetaData,
-    String,
     Table,
     text,
     and_,
@@ -30,6 +25,7 @@ from sqlalchemy.sql import select
 from sqlalchemy.exc import OperationalError, DatabaseError
 from threading import Thread, Lock
 from queue import SimpleQueue, Empty as QueueEmpty
+from pyiron_base.database.tables import simulation_table
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -204,27 +200,7 @@ class DatabaseAccess(object):
 
         self._chem_formula_lim_length = 50
         self.__reload_db()
-        self.simulation_table = Table(
-            str(table_name),
-            self.metadata,
-            Column("id", Integer, primary_key=True, autoincrement=True),
-            Column("parentid", Integer),
-            Column("masterid", Integer),
-            Column("projectpath", String(50)),
-            Column("project", String(255)),
-            Column("job", String(50)),
-            Column("subjob", String(255)),
-            Column("chemicalformula", String(self._chem_formula_lim_length)),
-            Column("status", String(20)),
-            Column("hamilton", String(20)),
-            Column("hamversion", String(50)),
-            Column("username", String(20)),
-            Column("computer", String(100)),
-            Column("timestart", DateTime),
-            Column("timestop", DateTime),
-            Column("totalcputime", Float),
-            extend_existing=True,
-        )
+        self.simulation_table = simulation_table(str(table_name), self.metadata)
         self.metadata.create_all()
         self._viewer_mode = False
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -25,7 +25,7 @@ from sqlalchemy.sql import select
 from sqlalchemy.exc import OperationalError, DatabaseError
 from threading import Thread, Lock
 from queue import SimpleQueue, Empty as QueueEmpty
-from pyiron_base.database.tables import simulation_table
+from pyiron_base.database.tables import HistoricalTable
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -200,7 +200,7 @@ class DatabaseAccess(object):
 
         self._chem_formula_lim_length = 50
         self.__reload_db()
-        self.simulation_table = simulation_table(str(table_name), self.metadata)
+        self.simulation_table = HistoricalTable(str(table_name), self.metadata)
         self.metadata.create_all()
         self._viewer_mode = False
 

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -103,6 +103,7 @@ class HistoricalTable(TableManager):
             "timestart": datetime.now(),
             "masterid": obj.master_id,
             "parentid": obj.parent_id,
+            "chemicalformula": obj.chemical_formula
         }
         return self._check_chem_formula_length(par_dict)
 
@@ -113,7 +114,7 @@ class HistoricalTable(TableManager):
         par_dict(dict): dictionary of the parameter
         limit(int): the limit for the length of checmical formular
         """
-        key_limited = 'ChemicalFormula'
+        key_limited = 'chemicalformula'
         if key_limited in par_dict.keys() and \
                 par_dict[key_limited] is not None and \
                 len(par_dict[key_limited]) > self.table.columns.chemicalformula.type.length:

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -86,7 +86,7 @@ class TableManager(ABC):
 class HistoricalTable(TableManager):
     """The historical table."""
     def __init__(self, table_name, metadata, extend_existing=True):
-        super(HistoricalTable, self).__init__(table_name, metadata, extend_existing=True)
+        super().__init__(table_name, metadata, extend_existing=extend_existing)
         self._char_limit.update({'projectpath': 50, 'project': 255, 'job': 50, 'subjob': 250,
                                  'chemicalformula': 50, 'status': 20, 'hamilton': 50, 'hamversion': 50,
                                  'username': 20, 'computer': 100})

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -5,6 +5,7 @@
 Classes defining the shape of pyiron's database tables.
 """
 
+from abc import ABC, abstractmethod
 from sqlalchemy import (
     Column,
     DateTime,
@@ -12,7 +13,12 @@ from sqlalchemy import (
     Integer,
     String,
     Table,
+    MetaData
 )
+from typing import Type
+# from pyiron_base.job.generic import GenericJob
+from datetime import datetime
+
 
 __author__ = "Murat Han Celik, Liam Huber"
 __copyright__ = (
@@ -26,10 +32,42 @@ __status__ = "development"
 __date__ = "Sep, 2021"
 
 
-class HistoricalTable(Table):
+class TableManager(ABC):
+    """
+    A parent class for pyiron database tables.
+    """
+
+    def __init__(self, table_name, metadata, extend_existing=True):
+        self._table = self._create_table(table_name, metadata, extend_existing=extend_existing)
+
+    def add(self, obj, settings):
+        """Add data from an object to the database table."""
+        par_dict = self._object_to_entry(obj, settings)
+        par_dict = dict(
+            (key.lower(), value) for key, value in par_dict.items()
+        )
+        return self._table.insert(par_dict)
+
+    @property
+    def table(self) -> Table:
+        return self._table
+
+    @abstractmethod
+    def _create_table(self, table_name: str, metadata: MetaData, extend_existing: bool=True) -> Table:
+        """Initialize a `Table` with all the columns you want."""
+        pass
+
+    @abstractmethod
+    def _object_to_entry(self, obj, settings) -> dict:
+        """Parse an object into a database entry."""
+        pass
+
+
+class HistoricalTable(TableManager):
     """The historical table."""
-    def _init(self, table_name, metadata, *args, extend_existing=True, **kwargs):
-        super()._init(
+
+    def _create_table(self, table_name, metadata, extend_existing=True):
+        return Table(
             table_name,
             metadata,
             Column("id", Integer, primary_key=True, autoincrement=True),
@@ -50,3 +88,34 @@ class HistoricalTable(Table):
             Column("totalcputime", Float),
             extend_existing=extend_existing
         )
+
+    def _object_to_entry(self, obj, settings) -> dict:  # : Type[GenericJob] circular import issues
+        par_dict = {
+            "username": settings.login_user,
+            "projectpath": obj.project_hdf5.root_path,
+            "project": obj.project_hdf5.project_path,
+            "job": obj.job_name,
+            "subjob": obj.project_hdf5.h5_path,
+            "hamversion": obj.version,
+            "hamilton": obj.__name__,
+            "status": obj.status.string,
+            "computer": obj._db_server_entry(),
+            "timestart": datetime.now(),
+            "masterid": obj.master_id,
+            "parentid": obj.parent_id,
+        }
+        return self._check_chem_formula_length(par_dict)
+
+    def _check_chem_formula_length(self, par_dict):
+        """
+        performs a check whether the length of chemical formula exceeds the defined limit
+        args:
+        par_dict(dict): dictionary of the parameter
+        limit(int): the limit for the length of checmical formular
+        """
+        key_limited = 'ChemicalFormula'
+        if key_limited in par_dict.keys() and \
+                par_dict[key_limited] is not None and \
+                len(par_dict[key_limited]) > self.table.columns.chemicalformula.type.length:
+            par_dict[key_limited] = "OVERFLOW_ERROR"
+        return par_dict

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -26,26 +26,27 @@ __status__ = "development"
 __date__ = "Sep, 2021"
 
 
-def simulation_table(table_name, metadata, extend_existing=True):
+class HistoricalTable(Table):
     """The historical table."""
-    return Table(
-        table_name,
-        metadata,
-        Column("id", Integer, primary_key=True, autoincrement=True),
-        Column("parentid", Integer),
-        Column("masterid", Integer),
-        Column("projectpath", String(50)),
-        Column("project", String(255)),
-        Column("job", String(50)),
-        Column("subjob", String(255)),
-        Column("chemicalformula", String(30)),
-        Column("status", String(20)),
-        Column("hamilton", String(20)),
-        Column("hamversion", String(50)),
-        Column("username", String(20)),
-        Column("computer", String(100)),
-        Column("timestart", DateTime),
-        Column("timestop", DateTime),
-        Column("totalcputime", Float),
-        extend_existing=extend_existing
-    )
+    def _init(self, table_name, metadata, *args, extend_existing=True, **kwargs):
+        super()._init(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True, autoincrement=True),
+            Column("parentid", Integer),
+            Column("masterid", Integer),
+            Column("projectpath", String(50)),
+            Column("project", String(255)),
+            Column("job", String(50)),
+            Column("subjob", String(255)),
+            Column("chemicalformula", String(30)),
+            Column("status", String(20)),
+            Column("hamilton", String(20)),
+            Column("hamversion", String(50)),
+            Column("username", String(20)),
+            Column("computer", String(100)),
+            Column("timestart", DateTime),
+            Column("timestop", DateTime),
+            Column("totalcputime", Float),
+            extend_existing=extend_existing
+        )

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -1,0 +1,51 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Classes defining the shape of pyiron's database tables.
+"""
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    String,
+    Table,
+)
+
+__author__ = "Murat Han Celik, Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH"
+    " - Computational Materials Design (CM) Department"
+)
+__version__ = "0.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "development"
+__date__ = "Sep, 2021"
+
+
+def simulation_table(table_name, metadata, extend_existing=True):
+    """The historical table."""
+    return Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("parentid", Integer),
+        Column("masterid", Integer),
+        Column("projectpath", String(50)),
+        Column("project", String(255)),
+        Column("job", String(50)),
+        Column("subjob", String(255)),
+        Column("chemicalformula", String(30)),
+        Column("status", String(20)),
+        Column("hamilton", String(20)),
+        Column("hamversion", String(50)),
+        Column("username", String(20)),
+        Column("computer", String(100)),
+        Column("timestart", DateTime),
+        Column("timestop", DateTime),
+        Column("totalcputime", Float),
+        extend_existing=extend_existing
+    )

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -90,7 +90,7 @@ class HistoricalTable(TableManager):
         self._char_limit.update({'projectpath': 50, 'project': 255, 'job': 50, 'subjob': 250,
                                  'chemicalformula': 50, 'status': 20, 'hamilton': 50, 'hamversion': 50,
                                  'username': 20, 'computer': 100})
-        self._sensitive_keys = ['projectpath', 'project', 'job', 'subjob', 'hamilton',
+        self._restrictively_limited_size_keys = ['projectpath', 'project', 'job', 'subjob', 'hamilton',
                                 'hamversion', 'username', 'computer']
 
     def _create_table(self, table_name, metadata, extend_existing=True):
@@ -142,8 +142,8 @@ class HistoricalTable(TableManager):
         for key in par_dict.keys():
             if par_dict[key] is not None and \
                     len(par_dict[key]) > self._char_limit[key.lower()]:
-                if key.lower() not in self._sensitive_keys:
+                if key.lower() not in self._restrictively_limited_size_keys:
                     par_dict[key] = "OVERFLOW_ERROR"
                 else:
-                    raise TooLongDBEntry(key=key, limit=self._char_limit['key.lower()'], val=par_dict[key])
+                    raise TooLongDBEntry(key=key, limit=self._char_limit[key.lower()], val=par_dict[key])
         return par_dict

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -52,8 +52,9 @@ class TableManager(ABC):
     """
 
     def __init__(self, table_name, metadata, extend_existing=True):
-        self._table = self._create_table(table_name, metadata, extend_existing=extend_existing)
         self._char_limit = {}
+        self._update_char_limit()
+        self._table = self._create_table(table_name, metadata, extend_existing=extend_existing)
 
     def add(self, obj, settings):
         """Add data from an object to the database table."""
@@ -66,6 +67,15 @@ class TableManager(ABC):
     @property
     def table(self) -> Table:
         return self._table
+
+    @abstractmethod
+    def _update_char_limit(self) -> dict:
+        pass
+
+    @property
+    @abstractmethod
+    def _restrictively_limited_size_keys(self):
+        pass
 
     @abstractmethod
     def _create_table(self, table_name: str, metadata: MetaData, extend_existing: bool=True) -> Table:
@@ -87,11 +97,15 @@ class HistoricalTable(TableManager):
     """The historical table."""
     def __init__(self, table_name, metadata, extend_existing=True):
         super().__init__(table_name, metadata, extend_existing=extend_existing)
+
+    def _update_char_limit(self):
         self._char_limit.update({'projectpath': 50, 'project': 255, 'job': 50, 'subjob': 250,
                                  'chemicalformula': 50, 'status': 20, 'hamilton': 50, 'hamversion': 50,
                                  'username': 20, 'computer': 100})
-        self._restrictively_limited_size_keys = ['projectpath', 'project', 'job', 'subjob', 'hamilton',
-                                'hamversion', 'username', 'computer']
+
+    @property
+    def _restrictively_limited_size_keys(self):
+        return ['projectpath', 'project', 'job', 'subjob', 'hamilton', 'hamversion', 'username', 'computer']
 
     def _create_table(self, table_name, metadata, extend_existing=True):
         return Table(

--- a/pyiron_base/database/tables.py
+++ b/pyiron_base/database/tables.py
@@ -141,7 +141,7 @@ class HistoricalTable(TableManager):
         """
         for key in par_dict.keys():
             if par_dict[key] is not None and \
-                    len(par_dict[key]) > self._char_limit['key.lower()']:
+                    len(par_dict[key]) > self._char_limit[key.lower()]:
                 if key.lower() not in self._sensitive_keys:
                     par_dict[key] = "OVERFLOW_ERROR"
                 else:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1158,7 +1158,6 @@ class GenericJob(JobCore):
         """
         self.to_hdf()
         job_id = self.project.db.add(self, s, self.project.db.historical)
-        # job_id = self.project.db.add_item_dict(self.db_entry())
         self._job_id = job_id
         self.refresh_job_status()
         if self._check_if_input_should_be_written():
@@ -1184,29 +1183,10 @@ class GenericJob(JobCore):
         """
         return True
 
-    def db_entry(self):
-        """
-        Generate the initial database entry for the current GenericJob
-
-        Returns:
-            (dict): database dictionary {"username", "projectpath", "project", "job", "subjob", "hamversion",
-                                         "hamilton", "status", "computer", "timestart", "masterid", "parentid"}
-        """
-        db_dict = {
-            "username": s.login_user,
-            "projectpath": self.project_hdf5.root_path,
-            "project": self.project_hdf5.project_path,
-            "job": self.job_name,
-            "subjob": self.project_hdf5.h5_path,
-            "hamversion": self.version,
-            "hamilton": self.__name__,
-            "status": self.status.string,
-            "computer": self._db_server_entry(),
-            "timestart": datetime.now(),
-            "masterid": self.master_id,
-            "parentid": self.parent_id,
-        }
-        return db_dict
+    @property
+    def chemical_formula(self):
+        """A necessary evil since atomistic properties are deeply buried in our database"""
+        return None
 
     def restart(self, job_name=None, job_type=None):
         """

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1157,7 +1157,8 @@ class GenericJob(JobCore):
             (int): Job ID stored in the database
         """
         self.to_hdf()
-        job_id = self.project.db.add_item_dict(self.db_entry())
+        job_id = self.project.db.add(self, s, self.project.db.historical)
+        # job_id = self.project.db.add_item_dict(self.db_entry())
         self._job_id = job_id
         self.refresh_job_status()
         if self._check_if_input_should_be_written():

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -6,26 +6,18 @@ import unittest
 import os
 from pyiron_base.job.generic import GenericJob
 from pyiron_base._tests import TestWithCleanProject
+from pyiron_base.settings.generic import Settings
+
+s = Settings()
 
 
 class TestGenericJob(TestWithCleanProject):
-    def test_db_entry(self):
-        ham = self.project.create.job.ScriptJob("job_single_debug")
-        db_entry = ham.db_entry()
-        self.assertEqual(db_entry["project"], ham.project_hdf5.project_path)
-        self.assertEqual(db_entry["hamilton"], "Script")
-        self.assertEqual(db_entry["hamversion"], ham.version)
-        self.assertEqual(db_entry["status"], ham.status.string)
-        self.assertEqual(db_entry["job"], ham.job_name)
-        ham.save()
-        ham.remove()
-
     def test_reload_empty_job(self):
         job_empty = self.project.create_job(
             job_type=GenericJob,
             job_name="empty_reload"
         )
-        job_id = job_empty.project.db.add_item_dict(job_empty.db_entry())
+        job_id = job_empty.project.db.add(job_empty, s, job_empty.project.db.historical)
         job_empty_inspect = self.project.inspect(job_id)
         self.assertEqual(len(job_empty_inspect.list_nodes()), 0)
         self.assertTrue(job_empty_inspect.project_hdf5.is_empty)


### PR DESCRIPTION
The idea is to increase encapsulation of our database tables by decoupling the details of the table from the more generic database access. 

I still leave in place all the old infrastructure, but now `GenericJob.save` exploits the new saving mechanism -- this still needs tests and then all the old stuff needs to be removed. I am happy to work on that, but can't do it now.

A couple issues I still don't like:
- `Settings` are passed from the job all the way to the table
- The job still talks to database access like `self.project.db.add(self, s, self.project.db.historical)`, but it would read much nicer to just have `self.project.db.historical.add(self, s)`, but I didn't figure out how to do this without passing too much responsibility from `DatabaseAccess` over to `HistoricalTable`...maybe it's just ok how it is...

Things I love:
- Column definition is handled in *one place*, not separately in `GenericJob.db_entry` *and* `DatabaseAccess`
- Encapsulation gives extensibility -- we have a template for adding more tables/breaking the historical one down into a table for objects and a table for jobs
- `DatabaseAccess` can be cleaner and not worry about crap like checking if the 'chemicalformula' is too long, which should clearly outside its responsibility. (Ok, this point is kind of just encapsulation again)