### PR TITLE
Fix template job saving and loading

### DIFF
--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -37,11 +37,11 @@ class TemplateJob(GenericJob, HasStorage):
 
     def to_hdf(self, hdf=None, group_name=None):
         GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)
-        HasStorage.to_hdf(self, hdf=self.project_hdf5, group_name='storage')
+        HasStorage.to_hdf(self, hdf=self.project_hdf5, group_name='')
 
     def from_hdf(self, hdf=None, group_name=None):
         GenericJob.from_hdf(self, hdf=hdf, group_name=group_name)
-        HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name='storage')
+        HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name='')
 
 
 class PythonTemplateJob(TemplateJob):

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -36,10 +36,12 @@ class TemplateJob(GenericJob, HasStorage):
         return self.storage.output
 
     def to_hdf(self, hdf=None, group_name=None):
-        HasStorage.to_hdf(self, hdf=self.project_hdf5)
+        GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)
+        HasStorage.to_hdf(self, hdf=self.project_hdf5, group_name='storage')
 
     def from_hdf(self, hdf=None, group_name=None):
-        HasStorage.from_hdf(self, hdf=self.project_hdf5)
+        GenericJob.from_hdf(self, hdf=hdf, group_name=group_name)
+        HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name='storage')
 
 
 class PythonTemplateJob(TemplateJob):


### PR DESCRIPTION
Resolves #443 

I don't like it though, since now `GenericJob.to_hdf` populates `['input']` and fills `['TYPE', ...]`. Then in `['storage']` we also have another group `['input']` with our real input and `['TYPE', ...]` get reproduced.