### PR TITLE
Extract all database responsibilities from Settings

### DIFF
--- a/pyiron_base/cli/reloadfile.py
+++ b/pyiron_base/cli/reloadfile.py
@@ -5,10 +5,10 @@ import os
 import h5py
 import shutil
 from pyiron_base import Project
-from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 
 
-s = Settings()
+dbm = DatabaseManager()
 
 
 def register(parser):
@@ -29,7 +29,7 @@ def main(args):
     file = os.path.basename(project_path)
     job_name = os.path.splitext(file)[0]
 
-    db_project_path = s.top_path(project_path)
+    db_project_path = dbm.top_path(project_path)
     project = os.path.dirname(project_path)
     db_project = (project + "/")
     if db_project_path is not None:

--- a/pyiron_base/database/manager.py
+++ b/pyiron_base/database/manager.py
@@ -160,13 +160,6 @@ class DatabaseManager(metaclass=Singleton):
             self._database.conn.close()
             self._database = None
 
-    @property
-    def project_check_enabled(self):
-        if self.database_is_disabled:
-            return False
-        else:
-            return s.configuration["project_check_enabled"]
-
     def top_path(self, full_path):
         """
         Validated that the full_path is a sub directory of one of the pyrion environments loaded.

--- a/pyiron_base/database/manager.py
+++ b/pyiron_base/database/manager.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+A class for mediating connections to (pseudo)database tables.
+"""
+
+from pyiron_base.generic.util import Singleton
+from pyiron_base.settings.generic import Settings
+from pyiron_base.database.generic import DatabaseAccess
+import os
+
+s = Settings()
+
+__author__ = "Jan Janssen, Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH"
+    " - Computational Materials Design (CM) Department"
+)
+__version__ = "0.0"
+__maintainer__ = "Liam Huber"
+__email__ = "huber@mpie.de"
+__status__ = "development"
+__date__ = "Sep 24, 2021"
+
+
+class DatabaseManager(metaclass=Singleton):
+    def __init__(self):
+        self._database = None
+        self._use_local_database = False
+        self._database_is_disabled = s.configuration["disable_database"]
+
+    @property
+    def database(self):
+        return self._database
+
+    @property
+    def using_local_database(self):
+        return self._use_local_database
+
+    @property
+    def database_is_disabled(self):
+        return self._database_is_disabled
+
+    @property
+    def project_check_enabled(self):
+        if self.database_is_disabled:
+            return False
+        else:
+            return s.configuration["project_check_enabled"]
+
+    @property
+    def connection_timeout(self):
+        """
+        Get the connection timeout in seconds.  Zero means close the database after every connection.
+
+        Returns:
+            int: timeout in seconds
+        """
+        return s.configuration["connection_timeout"]
+
+    @connection_timeout.setter
+    def connection_timeout(self, val):
+        s.configuration["connection_timeout"] = val
+
+    def open_connection(self):
+        """
+        Internal function to open the connection to the database. Only after this function is called the database is
+        accessable.
+        """
+        if self._database is None and not self.database_is_disabled:
+            self._database = DatabaseAccess(
+                s.configuration["sql_connection_string"],
+                s.configuration["sql_table_name"],
+                timeout=s.configuration["connection_timeout"]
+            )
+
+    def switch_to_local_database(self, file_name="pyiron.db", cwd=None):
+        """
+        Swtich to an local SQLite based database.
+
+        Args:
+            file_name (str): SQLite database file name
+            cwd (str/None): directory where the SQLite database file is located in
+        """
+        if self.using_local_database:
+            s.logger.log("Database is already in local mode or disabled!")
+        else:
+            if cwd is None and not os.path.isabs(file_name):
+                file_name = os.path.join(os.path.abspath(os.path.curdir), file_name)
+            elif cwd is not None:
+                file_name = os.path.join(cwd, file_name)
+            self.close_connection()
+            self.open_local_sqlite_connection(connection_string="sqlite:///" + file_name)
+
+    def open_local_sqlite_connection(self, connection_string):
+        self._database = DatabaseAccess(connection_string, s.configuration["sql_table_name"])
+        self._use_local_database = True
+        self._database_is_disabled = False
+
+    def switch_to_central_database(self):
+        """
+        Switch to central database
+        """
+        if self._use_local_database:
+            self.close_connection()
+            self._database_is_disabled = s.configuration["disable_database"]
+            if self.database_is_disabled:
+                self._database = None
+            else:
+                self._database = DatabaseAccess(
+                    s.configuration["sql_connection_string"],
+                    s.configuration["sql_table_name"],
+                )
+
+            self._use_local_database = False
+        else:
+            s.logger.log("Database is already in central mode or disabled!")
+
+    def switch_to_viewer_mode(self):
+        """
+        Switch from user mode to viewer mode - if viewer_mode is enable pyiron has read only access to the database.
+        """
+        if s.configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
+            if self._database.viewer_mode:
+                s.logger.log("Database is already in viewer mode!")
+            else:
+                self.close_connection()
+                self._database = DatabaseAccess(
+                    s.configuration["sql_view_connection_string"],
+                    s.configuration["sql_view_table_name"],
+                )
+                self._database.viewer_mode = True
+
+        else:
+            print("Viewer Mode is not available on this pyiron installation.")
+
+    def switch_to_user_mode(self):
+        """
+        Switch from viewer mode to user mode - if viewer_mode is enable pyiron has read only access to the database.
+        """
+        if s.configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
+            if self._database.viewer_mode:
+                self.close_connection()
+                self._database = DatabaseAccess(
+                    s.configuration["sql_connection_string"],
+                    s.configuration["sql_table_name"],
+                )
+                self._database.viewer_mode = True
+            else:
+                s.logger.log("Database is already in user mode!")
+        else:
+            print("Viewer Mode is not available on this pyiron installation.")
+
+    def close_connection(self):
+        """
+        Internal function to close the connection to the database.
+        """
+        if self._database is not None:
+            self._database.conn.close()
+            self._database = None
+
+    @property
+    def project_check_enabled(self):
+        if self.database_is_disabled:
+            return False
+        else:
+            return s.configuration["project_check_enabled"]
+
+    def top_path(self, full_path):
+        """
+        Validated that the full_path is a sub directory of one of the pyrion environments loaded.
+
+        Args:
+            full_path (str): path
+
+        Returns:
+            str: path
+        """
+        if full_path[-1] != "/":
+            full_path += "/"
+
+        if not self.project_check_enabled:
+            return None
+
+        for path in s.configuration["project_paths"]:
+            if path in full_path:
+                return path
+        raise ValueError(
+            "the current path {0} is not included in the .pyiron configuration. {1}".format(
+                full_path, s.configuration["project_paths"]
+            )
+        )

--- a/pyiron_base/database/manager.py
+++ b/pyiron_base/database/manager.py
@@ -2,7 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 """
-A class for mediating connections to (pseudo)database tables.
+A class for mediating connections to SQL databases.
 """
 
 from pyiron_base.generic.util import Singleton

--- a/pyiron_base/generic/object.py
+++ b/pyiron_base/generic/object.py
@@ -10,7 +10,7 @@ from abc import ABC
 from pyiron_base.generic.datacontainer import DataContainer
 from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.generic.hdfio import ProjectHDFio
-from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 
 __author__ = "Liam Huber"
 __copyright__ = (
@@ -23,7 +23,7 @@ __email__ = "huber@mpie.de"
 __status__ = "development"
 __date__ = "Mar 23, 2021"
 
-s = Settings()
+dbm = DatabaseManager()
 
 
 class HasStorage(HasHDF, ABC):
@@ -45,7 +45,6 @@ class HasStorage(HasHDF, ABC):
         self.storage.from_hdf(hdf=hdf)
 
 
-
 class HasDatabase(ABC):
     """
     A base class for objects that are registered in pyiron's database
@@ -54,9 +53,9 @@ class HasDatabase(ABC):
     """
 
     def __init__(self, *args, **kwargs):
-        if not s.database_is_disabled:
-            s.open_connection()
-            self._database = s.database
+        if not dbm.database_is_disabled:
+            dbm.open_connection()
+            self._database = dbm.database
         else:
             raise NotImplementedError("WIP. For now only allowed with a database")
 

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -13,6 +13,7 @@ import posixpath
 import multiprocessing
 from pyiron_base.job.wrapper import JobWrapper
 from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.job.executable import Executable
 from pyiron_base.job.jobstatus import JobStatus
 from pyiron_base.job.core import JobCore
@@ -39,6 +40,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 s = Settings()
+dbm = DatabaseManager()
 
 intercepted_signals = [
     signal.SIGINT,
@@ -749,7 +751,7 @@ class GenericJob(JobCore):
                 with open(error_file, "w") as f:
                     f.write(e.output)
                 if self.server.run_mode.non_modal:
-                    s.close_connection()
+                    dbm.close_connection()
                 raise RuntimeError("Job aborted")
             else:
                 job_crashed = True
@@ -773,7 +775,7 @@ class GenericJob(JobCore):
             transfer_back=True,
             delete_remote=s.queue_adapter.ssh_delete_file_on_remote
         )
-        if s.database_is_disabled:
+        if dbm.database_is_disabled:
             self.project.db.update()
         else:
             ft = FileTable(project=self.project_hdf5.path + "_hdf5/")
@@ -869,7 +871,7 @@ class GenericJob(JobCore):
         The run if non modal function is called by run to execute the simulation in the background. For this we use
         multiprocessing.Process()
         """
-        if not s.using_local_database:
+        if not dbm.using_local_database:
             p = multiprocessing.Process(
                 target=multiprocess_wrapper,
                 args=(self.job_id, self.project_hdf5.working_directory, False, None),
@@ -927,7 +929,7 @@ class GenericJob(JobCore):
                 file=self.project_hdf5.file_name,
                 transfer_back=False
             )
-        elif s.database_is_disabled:
+        elif dbm.database_is_disabled:
             command = "python -m pyiron_base.cli wrapper -p " \
                       + self.working_directory \
                       + " -f " + self.project_hdf5.file_name + self.project_hdf5.h5_path

--- a/pyiron_base/job/wrapper.py
+++ b/pyiron_base/job/wrapper.py
@@ -9,6 +9,7 @@ import os
 import logging
 from pyiron_base.project.generic import Project
 from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.database.filetable import get_hamilton_from_file, get_hamilton_version_from_file, \
     get_job_status_from_file
 
@@ -24,6 +25,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 s = Settings()
+dbm = DatabaseManager()
 
 
 class JobWrapper(object):
@@ -44,12 +46,12 @@ class JobWrapper(object):
         self.working_directory = working_directory
         self._remote_flag = submit_on_remote
         if connection_string is not None:
-            s.open_local_sqlite_connection(connection_string=connection_string)
+            dbm.open_local_sqlite_connection(connection_string=connection_string)
         pr = Project(path=os.path.join(working_directory, '..', '..'))
         if job_id is not None:
             self.job = pr.load(int(job_id))
         else:
-            projectpath = s.top_path(hdf5_file)
+            projectpath = dbm.top_path(hdf5_file)
             if projectpath is None:
                 project = os.path.dirname(hdf5_file)
             else:
@@ -129,9 +131,9 @@ def job_wrapper_function(working_directory, job_id=None, file_path=None, submit_
 
     # always close the database connection in calculations on the cluster to avoid high number of concurrent
     # connections.
-    s.close_connection()
-    s.connection_timeout = 0
-    s.open_connection()
+    dbm.close_connection()
+    dbm.connection_timeout = 0
+    dbm.open_connection()
 
     if job_id is not None:
         job = JobWrapper(

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -17,6 +17,7 @@ from pyiron_base.master.submissionstatus import SubmissionStatus
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.jobstatus import JobStatus
 from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.job.wrapper import job_wrapper_function
 from pyiron_base.generic.util import deprecate
 
@@ -32,6 +33,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 s = Settings()
+dbm = DatabaseManager()
 
 
 class ParallelMaster(GenericMaster):
@@ -609,7 +611,7 @@ class ParallelMaster(GenericMaster):
             job.save()
             job.project_hdf5.create_working_directory()
             job.write_input()
-            if s.database_is_disabled or (s.queue_adapter is not None and s.queue_adapter.remote_flag):
+            if dbm.database_is_disabled or (s.queue_adapter is not None and s.queue_adapter.remote_flag):
                 job_lst.append(
                     (
                         job.project.path,
@@ -630,7 +632,7 @@ class ParallelMaster(GenericMaster):
                     )
                 )
         pool.starmap(job_wrapper_function, job_lst)
-        if s.database_is_disabled:
+        if dbm.database_is_disabled:
             self.project.db.update()
         self.status.collect = True
         self.run()  # self.run_if_collect()

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -18,6 +18,7 @@ from warnings import warn
 from pyiron_base.project.path import ProjectPath
 from pyiron_base.database.filetable import FileTable
 from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.settings.publications import list_publications
 from pyiron_base.database.performance import get_database_statistics
 from pyiron_base.database.jobtable import (
@@ -62,6 +63,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 s = Settings()
+dbm = DatabaseManager()
 
 
 class Project(ProjectPath, HasGroups):
@@ -124,9 +126,9 @@ class Project(ProjectPath, HasGroups):
         self._data = None
         self._creator = Creator(project=self)
 
-        if not s.database_is_disabled:
-            s.open_connection()
-            self.db = s.database
+        if not dbm.database_is_disabled:
+            dbm.open_connection()
+            self.db = dbm.database
         else:
             self.db = FileTable(project=path)
         self.job_type = JobTypeChoice()
@@ -1132,18 +1134,18 @@ class Project(ProjectPath, HasGroups):
         Switch from user mode to viewer mode - if viewer_mode is enable pyiron has read only access to the database.
         """
         if not isinstance(self.db, FileTable):
-            s.switch_to_viewer_mode()
-            s.open_connection()
-            self.db = s.database
+            dbm.switch_to_viewer_mode()
+            dbm.open_connection()
+            self.db = dbm.database
 
     def switch_to_user_mode(self):
         """
         Switch from viewer mode to user mode - if viewer_mode is enable pyiron has read only access to the database.
         """
         if not isinstance(self.db, FileTable):
-            s.switch_to_user_mode()
-            s.open_connection()
-            self.db = s.database
+            dbm.switch_to_user_mode()
+            dbm.open_connection()
+            self.db = dbm.database
 
     def switch_to_local_database(self, file_name="pyiron.db", cwd=None):
         """
@@ -1155,21 +1157,21 @@ class Project(ProjectPath, HasGroups):
         """
         if cwd is None:
             cwd = self.path
-        if not s.project_check_enabled:
-            s.switch_to_local_database(file_name=file_name, cwd=cwd)
+        if not dbm.project_check_enabled:
+            dbm.switch_to_local_database(file_name=file_name, cwd=cwd)
             super(Project, self).__init__(path=self.path)
         else:
-            s.switch_to_local_database(file_name=file_name, cwd=cwd)
-        self.db = s.database
+            dbm.switch_to_local_database(file_name=file_name, cwd=cwd)
+        self.db = dbm.database
 
     def switch_to_central_database(self):
         """
         Switch from local mode to central mode - if local_mode is enable pyiron is using a local database.
         """
-        s.switch_to_central_database()
-        if not s.database_is_disabled:
-            s.open_connection()
-            self.db = s.database
+        dbm.switch_to_central_database()
+        if not dbm.database_is_disabled:
+            dbm.open_connection()
+            self.db = dbm.database
         else:
             self.db = FileTable(project=self.path)
             super(Project, self).__init__(path=self.path)

--- a/pyiron_base/project/path.py
+++ b/pyiron_base/project/path.py
@@ -8,7 +8,7 @@ Classes for representing the file system path in pyiron
 from copy import copy
 import os
 import posixpath
-from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 
 __author__ = "Jan Janssen, Joerg Neugebauer"
 __copyright__ = (
@@ -407,7 +407,7 @@ class ProjectPath(GenericPath):
         Returns:
             str, str: root_path, project_path
         """
-        root = Settings().top_path(full_path)
+        root = DatabaseManager().top_path(full_path)
         if root is not None:
             pr_path = posixpath.relpath(full_path, root)
             return root, pr_path

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -8,6 +8,7 @@ Set of functions to interact with the queuing system directly from within pyiron
 import pandas
 import time
 from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.generic.util import static_isinstance
 from pyiron_base.job.jobstatus import job_status_finished_lst
 
@@ -25,6 +26,7 @@ __date__ = "Sep 1, 2017"
 QUEUE_SCRIPT_PREFIX = "pi_"
 
 s = Settings()
+dbm = DatabaseManager()
 
 
 def queue_table(job_ids=[], project_only=True, full_table=False):
@@ -191,7 +193,7 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
         else:
             finished = False
             for _ in range(max_iterations):
-                if s.database_is_disabled:
+                if dbm.database_is_disabled:
                     job.project.db.update()
                 job.refresh_job_status()
                 if job.status.string in job_status_finished_lst:

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -9,7 +9,6 @@ import os
 import importlib
 from configparser import ConfigParser
 from pyiron_base.settings.logger import setup_logger
-from pyiron_base.database.generic import DatabaseAccess
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -78,13 +77,11 @@ class Settings(metaclass=Singleton):
         self._update_configuration(config)
 
         # Build the SQLalchemy connection strings
-        self._database_is_disabled = self._configuration["disable_database"]
-        if not self.database_is_disabled:
+        if not self._configuration["disable_database"]:
             self._configuration = self.convert_database_config(
                 config=self._configuration
             )
-        self._database = None
-        self._use_local_database = False
+
         self._queue_adapter = None
         self._queue_adapter = self._init_queue_adapter(
             resource_path_lst=self._configuration["resource_paths"]
@@ -92,6 +89,10 @@ class Settings(metaclass=Singleton):
         self.logger = setup_logger()
         self._publication_lst = {}
         self.publication_add(self.publication)
+
+    @property
+    def configuration(self):
+        return self._configuration
 
     def _update_configuration(self, config):
         environment = os.environ
@@ -129,27 +130,8 @@ class Settings(metaclass=Singleton):
         ]
 
     @property
-    def using_local_database(self):
-        return self._use_local_database
-
-    @property
-    def database(self):
-        return self._database
-
-    @property
     def queue_adapter(self):
         return self._queue_adapter
-
-    @property
-    def project_check_enabled(self):
-        if self.database_is_disabled:
-            return False
-        else:
-            return self._configuration["project_check_enabled"]
-
-    @property
-    def database_is_disabled(self):
-        return self._database_is_disabled
 
     @property
     def publication_lst(self):
@@ -197,143 +179,6 @@ class Settings(metaclass=Singleton):
             list: path of paths
         """
         return self._configuration["resource_paths"]
-
-    @property
-    def connection_timeout(self):
-        """
-        Get the connection timeout in seconds.  Zero means close the database after every connection.
-
-        Returns:
-            int: timeout in seconds
-        """
-        return self._configuration["connection_timeout"]
-
-    @connection_timeout.setter
-    def connection_timeout(self, val):
-        self._configuration["connection_timeout"] = val
-
-    def open_connection(self):
-        """
-        Internal function to open the connection to the database. Only after this function is called the database is
-        accessable.
-        """
-        if self._database is None and not self.database_is_disabled:
-            self._database = DatabaseAccess(
-                self._configuration["sql_connection_string"],
-                self._configuration["sql_table_name"],
-                timeout=self._configuration["connection_timeout"]
-            )
-
-    def switch_to_local_database(self, file_name="pyiron.db", cwd=None):
-        """
-        Swtich to an local SQLite based database.
-
-        Args:
-            file_name (str): SQLite database file name
-            cwd (str/None): directory where the SQLite database file is located in
-        """
-        if self._use_local_database:
-            self.logger.log("Database is already in local mode or disabled!")
-        else:
-            if cwd is None and not os.path.isabs(file_name):
-                file_name = os.path.join(os.path.abspath(os.path.curdir), file_name)
-            elif cwd is not None:
-                file_name = os.path.join(cwd, file_name)
-            self.close_connection()
-            self.open_local_sqlite_connection(connection_string="sqlite:///" + file_name)
-
-    def open_local_sqlite_connection(self, connection_string):
-        self._database = DatabaseAccess(connection_string, self._configuration["sql_table_name"])
-        self._use_local_database = True
-        if self.database_is_disabled:
-            self._database_is_disabled = False
-
-    def switch_to_central_database(self):
-        """
-        Switch to central database
-        """
-        if self._use_local_database:
-            self.close_connection()
-            self._database_is_disabled = self._configuration["disable_database"]
-            if self.database_is_disabled:
-                self._database = None
-            else:
-                self._database = DatabaseAccess(
-                    self._configuration["sql_connection_string"],
-                    self._configuration["sql_table_name"],
-                )
-
-            self._use_local_database = False
-        else:
-            self.logger.log("Database is already in central mode or disabled!")
-
-    def switch_to_viewer_mode(self):
-        """
-        Switch from user mode to viewer mode - if viewer_mode is enable pyiron has read only access to the database.
-        """
-        if self._configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
-            if self._database.viewer_mode:
-                self.logger.log("Database is already in viewer mode!")
-            else:
-                self.close_connection()
-                self._database = DatabaseAccess(
-                    self._configuration["sql_view_connection_string"],
-                    self._configuration["sql_view_table_name"],
-                )
-                self._database.viewer_mode = True
-
-        else:
-            print("Viewer Mode is not available on this pyiron installation.")
-
-    def switch_to_user_mode(self):
-        """
-        Switch from viewer mode to user mode - if viewer_mode is enable pyiron has read only access to the database.
-        """
-        if self._configuration["sql_view_connection_string"] is not None and not self.database_is_disabled:
-            if self._database.viewer_mode:
-                self.close_connection()
-                self._database = DatabaseAccess(
-                    self._configuration["sql_connection_string"],
-                    self._configuration["sql_table_name"],
-                )
-                self._database.viewer_mode = True
-            else:
-                self.logger.log("Database is already in user mode!")
-        else:
-            print("Viewer Mode is not available on this pyiron installation.")
-
-    def close_connection(self):
-        """
-        Internal function to close the connection to the database.
-        """
-        if hasattr(self, "_database") and self._database is not None:
-            self._database.conn.close()
-            self._database = None
-
-    def top_path(self, full_path):
-        """
-        Validated that the full_path is a sub directory of one of the pyrion environments loaded.
-
-        Args:
-            full_path (str): path
-
-        Returns:
-            str: path
-        """
-        if full_path[-1] != "/":
-            full_path += "/"
-
-        if not self.project_check_enabled:
-            return None
-
-        for path in self._configuration["project_paths"]:
-            if path in full_path:
-                return path
-        raise ValueError(
-            "the current path {0} is not included in the .pyiron configuration. {1}".format(
-                full_path, self._configuration["project_paths"]
-            )
-        )
 
     # private functions
     @staticmethod

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 """
 The settings file provides the attributes of the configuration as properties.
+
+The settings object is additionally responsible for the queue adapter, the logger, and the publications list.
 """
 
 import os
@@ -76,7 +78,7 @@ class Settings(metaclass=Singleton):
         }
         self._update_configuration(config)
 
-        # Build the SQLalchemy connection strings
+        # Build the SQLalchemy connection strings from config data
         if not self._configuration["disable_database"]:
             self._configuration = self.convert_database_config(
                 config=self._configuration

--- a/pyiron_base/settings/update.py
+++ b/pyiron_base/settings/update.py
@@ -6,7 +6,7 @@
 Functions to update existing pyiron installations - mainly modify the database columns. 
 """
 
-from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -26,9 +26,9 @@ def database():
     database columns. This is only possible if no other pyiron session is accessing the database. Therefore the script
     might take some time to be executed successfully.
     """
-    s = Settings()
-    s.open_connection()
-    db = s.database
+    dbm = DatabaseManager()
+    dbm.open_connection()
+    db = dbm.database
     try:
         if "projectPath".lower() not in db.get_table_headings(db.table_name):
             print("add missing column: " + "projectPath")

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -2,12 +2,12 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from pyiron_base._tests import PyironTestCase
+from pyiron_base._tests import TestWithProject
 from pyiron_base.database.manager import DatabaseManager
 from pyiron_base.settings.generic import Settings
 
 
-class TestDatabaseManager(PyironTestCase):
+class TestDatabaseManager(TestWithProject):
 
     @classmethod
     def setUpClass(cls):
@@ -22,3 +22,8 @@ class TestDatabaseManager(PyironTestCase):
         self.assertNotEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
                             msg="But after that it should be independent from the settings")
         self.dbm._database_is_disabled = False  # Re-enable it at the end of the test
+
+    def test_file_top_path(self):
+        self.assertTrue(
+            self.dbm.top_path(self.project_path + "/test") in self.project_path
+        )

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base._tests import PyironTestCase
+from pyiron_base.database.manager import DatabaseManager
+from pyiron_base.settings.generic import Settings
+
+
+class TestDatabaseManager(PyironTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dbm = DatabaseManager()
+        cls.s = Settings()
+
+    def test_database_is_disabled(self):
+        self.assertEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
+                         msg="Database manager should be initialized by settings.")
+        self.dbm._database_is_disabled = True
+        self.assertNotEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
+                            msg="But after that it should be independent from the settings")

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -21,3 +21,4 @@ class TestDatabaseManager(PyironTestCase):
         self.dbm._database_is_disabled = True
         self.assertNotEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
                             msg="But after that it should be independent from the settings")
+        self.dbm._database_is_disabled = False  # Re-enable it at the end of the test

--- a/tests/settings/test_generic_file_config.py
+++ b/tests/settings/test_generic_file_config.py
@@ -5,6 +5,8 @@
 from pyiron_base.settings.generic import Settings
 import os
 from pyiron_base._tests import PyironTestCase
+from pyiron_base.settings.generic import Settings
+from pyiron_base.database.manager import DatabaseManager
 
 
 class TestConfigSettingsStatic(PyironTestCase):
@@ -15,7 +17,8 @@ class TestConfigSettingsStatic(PyironTestCase):
             os.path.join(os.path.dirname(os.path.abspath(__file__)), "../static")
         ).replace("\\", "/")
         cls.project_path = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
-        cls.file_config = Settings()
+        cls.s = Settings()
+        cls.dbm = DatabaseManager()
 
     # def test_file_db_connection_name(self):
     #     self.assertEqual(self.file_config.db_connection_name, 'DEFAULT')
@@ -35,7 +38,7 @@ class TestConfigSettingsStatic(PyironTestCase):
 
     def test_file_top_path(self):
         self.assertTrue(
-            self.file_config.top_path(self.project_path + "/test") in self.project_path
+            self.dbm.top_path(self.project_path + "/test") in self.project_path
         )
 
     # def test_file_resource_paths(self):
@@ -50,4 +53,4 @@ class TestConfigSettingsStatic(PyironTestCase):
     #     )
 
     def test_file_login_user(self):
-        self.assertEqual(self.file_config.login_user, "pyiron")
+        self.assertEqual(self.s.login_user, "pyiron")

--- a/tests/settings/test_generic_file_config.py
+++ b/tests/settings/test_generic_file_config.py
@@ -2,7 +2,6 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from pyiron_base.settings.generic import Settings
 import os
 from pyiron_base._tests import PyironTestCase
 from pyiron_base.settings.generic import Settings

--- a/tests/settings/test_generic_file_config.py
+++ b/tests/settings/test_generic_file_config.py
@@ -35,11 +35,6 @@ class TestConfigSettingsStatic(PyironTestCase):
     # def test_file_db_name(self):
     #     self.assertEqual(self.file_config.db_name, 'DEFAULT')
 
-    def test_file_top_path(self):
-        self.assertTrue(
-            self.dbm.top_path(self.project_path + "/test") in self.project_path
-        )
-
     # def test_file_resource_paths(self):
     #     self.assertTrue(
     #         any(


### PR DESCRIPTION
And move them to a new class `pyiron_base.database.manager.DatabaseManager`.

Cons: Another global singleton floating around.

Pros: More streamlined responsibility for `Settings`; necessary step towards a more universal database interaction (i.e. treating `DatabaseAccess` and `FileTable` on the same footing from the perspective of a job)