### PR TITLE
Remove JobCore.load_object and clean up around it

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -541,14 +541,11 @@ class JobCore(HasGroups):
             convert_to_object=False
         )
 
-    def load_object(self, convert_to_object=True, project=None):
+    def load_object(self, project=None):
         """
         Load object to convert a JobPath to an GenericJob object.
 
         Args:
-            convert_to_object (bool): convert the object to an pyiron object or only access the HDF5 file - default=True
-                                      accessing only the HDF5 file is about an order of magnitude faster, but only
-                                      provides limited functionality. Compare the GenericJob object to JobCore object.
             project (ProjectHDFio): ProjectHDFio to load the object with - optional
 
         Returns:
@@ -556,11 +553,9 @@ class JobCore(HasGroups):
         """
         if not project:
             project = self.project_hdf5.copy()
-        if convert_to_object:
-            with project.open("..") as job_dir:
-                job_dir._mode = "a"
-                return self.to_object(project=job_dir, job_name=self._name)
-        return self
+        with project.open("..") as job_dir:
+            job_dir._mode = "a"
+            return self.to_object(project=job_dir, job_name=self._name)
 
     def is_master_id(self, job_id):
         """

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -541,7 +541,7 @@ class JobCore(HasGroups):
             convert_to_object=False
         )
 
-    def load_object(self, project=None):
+    def load_object(self):
         """
         Load object to convert a JobPath to an GenericJob object.
 
@@ -551,9 +551,7 @@ class JobCore(HasGroups):
         Returns:
             GenericJob, JobPath: depending on convert_to_object
         """
-        if not project:
-            project = self.project_hdf5.copy()
-        with project.open("..") as job_dir:
+        with self.project_hdf5.open("..") as job_dir:
             job_dir._mode = "a"
             return self.to_object(project=job_dir, job_name=self._name)
 

--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -541,20 +541,6 @@ class JobCore(HasGroups):
             convert_to_object=False
         )
 
-    def load_object(self):
-        """
-        Load object to convert a JobPath to an GenericJob object.
-
-        Args:
-            project (ProjectHDFio): ProjectHDFio to load the object with - optional
-
-        Returns:
-            GenericJob, JobPath: depending on convert_to_object
-        """
-        with self.project_hdf5.open("..") as job_dir:
-            job_dir._mode = "a"
-            return self.to_object(project=job_dir, job_name=self._name)
-
     def is_master_id(self, job_id):
         """
         Check if the job ID job_id is the master ID for any child job

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -783,8 +783,6 @@ class Project(ProjectPath, HasGroups):
             job = jobpath(db=self.db, job_id=job_id, user=self.user)
             if convert_to_object:
                 job = job.load_object()
-            job._job_id = job_id
-            if convert_to_object:
                 job.reset_job_id(job_id=job_id)
                 job.set_input_to_read_only()
             return job
@@ -792,7 +790,6 @@ class Project(ProjectPath, HasGroups):
             job = jobpath(db=self.db, db_entry=db_entry)
             if convert_to_object:
                 job = job.load_object()
-            if convert_to_object:
                 job.set_input_to_read_only()
             return job
         else:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -782,7 +782,7 @@ class Project(ProjectPath, HasGroups):
         if job_id:
             job = jobpath(db=self.db, job_id=job_id, user=self.user)
             if convert_to_object:
-                job = job.load_object(project=job.project_hdf5.copy())
+                job = job.load_object()
             job._job_id = job_id
             if convert_to_object:
                 job.reset_job_id(job_id=job_id)
@@ -791,7 +791,7 @@ class Project(ProjectPath, HasGroups):
         elif db_entry:
             job = jobpath(db=self.db, db_entry=db_entry)
             if convert_to_object:
-                job = job.load_object(project=job.project_hdf5.copy())
+                job = job.load_object()
             if convert_to_object:
                 job.set_input_to_read_only()
             return job
@@ -1206,7 +1206,7 @@ class Project(ProjectPath, HasGroups):
             job_path=job_path
         )
         if convert_to_object:
-            job = job.load_object(project=job.project_hdf5.copy())
+            job = job.load_object()
         job.set_input_to_read_only()
         return job
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -782,14 +782,14 @@ class Project(ProjectPath, HasGroups):
         if job_id:
             job = jobpath(db=self.db, job_id=job_id, user=self.user)
             if convert_to_object:
-                job = job.load_object()
+                job = job.to_object()
                 job.reset_job_id(job_id=job_id)
                 job.set_input_to_read_only()
             return job
         elif db_entry:
             job = jobpath(db=self.db, db_entry=db_entry)
             if convert_to_object:
-                job = job.load_object()
+                job = job.to_object()
                 job.set_input_to_read_only()
             return job
         else:
@@ -1203,7 +1203,7 @@ class Project(ProjectPath, HasGroups):
             job_path=job_path
         )
         if convert_to_object:
-            job = job.load_object()
+            job = job.to_object()
         job.set_input_to_read_only()
         return job
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -781,9 +781,8 @@ class Project(ProjectPath, HasGroups):
         jobpath = getattr(importlib.import_module("pyiron_base.job.path"), "JobPath")
         if job_id:
             job = jobpath(db=self.db, job_id=job_id, user=self.user)
-            job = job.load_object(
-                convert_to_object=convert_to_object, project=job.project_hdf5.copy()
-            )
+            if convert_to_object:
+                job = job.load_object(project=job.project_hdf5.copy())
             job._job_id = job_id
             if convert_to_object:
                 job.reset_job_id(job_id=job_id)
@@ -791,9 +790,8 @@ class Project(ProjectPath, HasGroups):
             return job
         elif db_entry:
             job = jobpath(db=self.db, db_entry=db_entry)
-            job = job.load_object(
-                convert_to_object=convert_to_object, project=job.project_hdf5.copy()
-            )
+            if convert_to_object:
+                job = job.load_object(project=job.project_hdf5.copy())
             if convert_to_object:
                 job.set_input_to_read_only()
             return job
@@ -1207,9 +1205,8 @@ class Project(ProjectPath, HasGroups):
         job = getattr(importlib.import_module("pyiron_base.job.path"), "JobPathBase")(
             job_path=job_path
         )
-        job = job.load_object(
-            convert_to_object=convert_to_object, project=job.project_hdf5.copy()
-        )
+        if convert_to_object:
+            job = job.load_object(project=job.project_hdf5.copy())
         job.set_input_to_read_only()
         return job
 

--- a/pyiron_base/table/datamining.py
+++ b/pyiron_base/table/datamining.py
@@ -453,7 +453,7 @@ class PyironTable(HasGroups):
         diff_dict_lst = []
         for job_inspect in tqdm(job_lst):
             if self.convert_to_object:
-                job = job_inspect.load_object()
+                job = job_inspect.to_object()
             else:
                 job = job_inspect
             diff_dict = self._apply_list_of_functions_on_job(

--- a/tests/job/test_copyto.py
+++ b/tests/job/test_copyto.py
@@ -28,7 +28,7 @@ class TestCopyTo(TestWithProject):
 
         jobc = self.project.inspect(job.id)
         copyc = jobc.copy_to(jobc.project_hdf5, "job_core_copy")
-        self.assertEqual(jobc.load_object().script_path, copyc.load_object().script_path,
+        self.assertEqual(jobc.to_object().script_path, copyc.to_object().script_path,
                          "Script path not equal after JobCore copy.")
 
         os.remove("foo.py")


### PR DESCRIPTION
It was only used in a few places and only convoluted the logic around loading jobs from job core objects.  With this the only way to instantiate a job from an inspect object is `to_object`.