### PR TITLE
Add delete_aborted_job flag

### DIFF
--- a/pyiron_base/job/factory.py
+++ b/pyiron_base/job/factory.py
@@ -42,13 +42,14 @@ class JobFactoryCore(PyironFactory, ABC):
 
     def __getattr__(self, name):
         if name in self._job_class_dict.keys():
-            def wrapper(job_name, delete_existing_job=False) -> Type[GenericJob]:
+            def wrapper(job_name, delete_existing_job=False, delete_aborted_job=False) -> Type[GenericJob]:
                 """
                 Create a job.
 
                 Args:
                     job_name (str): name of the job
                     delete_existing_job (bool): delete an existing job - default false
+                    delete_aborted_job (bool): delete an existing and aborted job - default false
 
                 Returns:
                     GenericJob: job object depending on the job_type selected
@@ -58,7 +59,8 @@ class JobFactoryCore(PyironFactory, ABC):
                     project=ProjectHDFio(project=self._project.copy(), file_name=job_name),
                     job_name=job_name,
                     job_class_dict=self._job_class_dict,
-                    delete_existing_job=delete_existing_job
+                    delete_existing_job=delete_existing_job,
+                    delete_aborted_job=delete_aborted_job
                 )
             return wrapper
         else:

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -38,7 +38,7 @@ class JobType(object):
     The JobTypeBase class creates a new object of a given class type.
     """
 
-    def __new__(cls, class_name, project, job_name, job_class_dict, delete_existing_job=False):
+    def __new__(cls, class_name, project, job_name, job_class_dict, delete_existing_job=False, delete_aborted_job=False):
         """
         The __new__() method allows to create objects from other classes - the class selected by class_name
 
@@ -47,6 +47,8 @@ class JobType(object):
             project (Project): Project object (defines path where job will be created and stored)
             job_name (str): name of the job (must be unique within this project path)
             job_class_dict (dict): dictionary with the jobtypes to choose from.
+            delete_existing_job (bool): delete an existing job - default false
+            delete_aborted_job (bool): delete an existing and aborted job - default false
 
         Returns:
             GenericJob: object of type class_name
@@ -66,7 +68,7 @@ class JobType(object):
                 "No HDF5 file found - remove database entry and create new job! {}".format(job.job_name)
             )
             delete_existing_job = True
-        if delete_existing_job:
+        if delete_existing_job or job.status.aborted and delete_aborted_job:
             job.remove()
             job = job_class(project, job_name)
         if job.status.aborted:

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -68,7 +68,7 @@ class JobType(object):
                 "No HDF5 file found - remove database entry and create new job! {}".format(job.job_name)
             )
             delete_existing_job = True
-        if delete_existing_job or job.status.aborted and delete_aborted_job:
+        if delete_existing_job or (job.status.aborted and delete_aborted_job):
             job.remove()
             job = job_class(project, job_name)
         if job.status.aborted:


### PR DESCRIPTION
I often find myself doing something like

```python
j = pr.create.job.WhatEver(name)
if j.status.aborted:
  j.remove()
  j = pr.create.job.WhatEver(name)
```

so I added a flag just like `delete_existing_job`.