### PR TITLE
All include header in job_table even if empty

### DIFF
--- a/pyiron_base/database/jobtable.py
+++ b/pyiron_base/database/jobtable.py
@@ -219,9 +219,7 @@ def job_table(
             pandas.reset_option('display.max_rows')
             pandas.reset_option('display.max_columns')
         pandas.set_option("display.max_colwidth", max_colwidth)
-        df = pandas.DataFrame(job_dict)
-        if len(job_dict) == 0:
-            return df
+        df = pandas.DataFrame(job_dict, columns=columns)
         if job_name_contains != '':
             df = df[df.job.str.contains(job_name_contains)]
         if sort_by in columns:


### PR DESCRIPTION
Previously calling `job_table` on an empty project gives an empty data frame with no header.  This breaks indexing and some of our related methods of `Project` (e.g. `get_jobs_status()`).  This PR just makes sure the columns are always defined.