### PR TITLE
Use a blacklist from wrapping values

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -274,7 +274,7 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
         self.table_name = table_name
         self._lazy = lazy
         if init is not None:
-            self.update(init, wrap=True, blacklist=wrap_blacklist)
+            self.update(init, wrap=True, blacklist=wrap_blacklist + (str,))
 
     def __len__(self):
         return len(self._store)

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -274,7 +274,7 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
         self.table_name = table_name
         self._lazy = lazy
         if init is not None:
-            self.update(init, wrap=True, blacklist=wrap_blacklist + (str,))
+            self.update(init, wrap=True, blacklist=wrap_blacklist)
 
     def __len__(self):
         return len(self._store)
@@ -593,7 +593,7 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
     @classmethod
     def _wrap_val(cls, val, blacklist):
         if isinstance(val, (Sequence, Set, Mapping)) and not isinstance(val, blacklist):
-            return cls(val)
+            return cls(val, wrap_blacklist=blacklist)
         else:
             return val
 
@@ -610,6 +610,8 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
                                        or Mapping
             **kwargs: update from this mapping as well
         """
+        if str not in blacklist:
+            blacklist += (str,)
         if wrap and (isinstance(wrap, bool) or not isinstance(init, blacklist)):
             if isinstance(init, (Sequence, Set)):
                 for v in init:

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -15,8 +15,8 @@ import pandas as pd
 
 
 class Sub(DataContainer):
-    def __init__(self, init=None, table_name=None, lazy=False):
-        super().__init__(init=init, table_name=table_name, lazy=lazy)
+    def __init__(self, init=None, table_name=None, lazy=False, wrap_blacklist=()):
+        super().__init__(init=init, table_name=table_name, lazy=lazy, wrap_blacklist=())
         self.foo = 42
 
 class TestDataContainer(TestWithCleanProject):
@@ -198,11 +198,10 @@ class TestDataContainer(TestWithCleanProject):
         pl = DataContainer()
         pl.update([ {"a": 1, "b": 2}, [{"c": 3, "d": 4}] ], wrap=True, blacklist=(dict,))
         self.assertTrue(isinstance(pl[0], dict), "nested dict wrapped, even if black listed")
-        breakpoint()
         self.assertTrue(isinstance(pl[1][0], dict), "nested dict wrapped, even if black listed")
         pl.clear()
 
-        pl.update({"a": [1, 2, 3], "b": {"c": [4, 5, 6]}}, wrap=True, blacklist=(dict,))
+        pl.update({"a": [1, 2, 3], "b": {"c": [4, 5, 6]}}, wrap=True, blacklist=(list,))
         self.assertTrue(isinstance(pl.a, list), "nested list wrapped, even if black listed")
         self.assertTrue(isinstance(pl.b.c, list), "nested list wrapped, even if black listed")
         pl.clear()

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -193,6 +193,20 @@ class TestDataContainer(TestWithCleanProject):
         pl.update(d)
         self.assertEqual(dict(pl), d, "update without options does not call generic method")
 
+    def test_update_blacklist(self):
+        """Wrapping nested mapping should only apply to types not in the blacklist."""
+        pl = DataContainer()
+        pl.update([ {"a": 1, "b": 2}, [{"c": 3, "d": 4}] ], wrap=True, blacklist=(dict,))
+        self.assertTrue(isinstance(pl[0], dict), "nested dict wrapped, even if black listed")
+        breakpoint()
+        self.assertTrue(isinstance(pl[1][0], dict), "nested dict wrapped, even if black listed")
+        pl.clear()
+
+        pl.update({"a": [1, 2, 3], "b": {"c": [4, 5, 6]}}, wrap=True, blacklist=(dict,))
+        self.assertTrue(isinstance(pl.a, list), "nested list wrapped, even if black listed")
+        self.assertTrue(isinstance(pl.b.c, list), "nested list wrapped, even if black listed")
+        pl.clear()
+
     def test_extend(self):
         pl = DataContainer()
         pl.extend([1, 2, 3])

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -19,7 +19,6 @@ class Sub(DataContainer):
         super().__init__(init=init, table_name=table_name, lazy=lazy)
         self.foo = 42
 
-
 class TestDataContainer(TestWithCleanProject):
 
     @property


### PR DESCRIPTION
When initializing `DataContainer`s, previously only values that are list,
dict, or tuples were recursively wrapped into `DataContainer`s.  Now
`__init__` and `update` take an explicit black list of types that are
mappings but should not be wrapped.  This changes the behavior such that
more values are now wrapped, unless explicitly black listed.

This allows to wrap e.g. HDF5 files as returned from h5py.  For our `FileHDFio` objects #469 is also needed.