### PR TITLE
Test against more versions for backwards compatibility

### DIFF
--- a/.ci_support/test_backwards.sh
+++ b/.ci_support/test_backwards.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-pip install --no-deps pyiron_base==0.1.21
-echo "Before save";
-for t in tests/backwards/*save.py; do
-    echo "Running $t";
-    python $t
+versions=('0.1.48' '0.2.24' '0.3.0')
+
+for v in ${versions[@]}; do
+    pip install --no-deps pyiron_base==$v
+    echo "Before save";
+    for t in tests/backwards/*save.py; do
+        echo "Running $t";
+        python $t
+    done
 done
 
 pip install --no-deps .


### PR DESCRIPTION
We somehow forgot to update the backwards tests after bumping minor level version.  I rewrote the script to save jobs from version 0.1.48 (the last 0.1 release), 0.2.24 (the last 0.2) and 0.3.0.  

Generally the backwards tests could use some more love and harnessing to make it easier to write them, but I don't have the time right now.