### PR TITLE
Unittesting template with filled projects

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -126,13 +126,6 @@ class TestWithFilledProject(TestWithProject, ABC):
             job.run()
             job.status.aborted = True
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.project.remove(enable=True)
-        try:
-            remove(join(cls.file_location, "pyiron.log"))
-        except FileNotFoundError:
-            pass
 
 
 _TO_SKIP = [PyironTestCase, TestWithProject, TestWithCleanProject, TestWithFilledProject]

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -112,9 +112,6 @@ class TestWithFilledProject(TestWithProject, ABC):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.project_path = getfile(cls)[:-3].replace("\\", "/")
-        cls.file_location, cls.project_name = split(cls.project_path)
-        cls.project = Project(cls.project_path)
         job = cls.project.create_job(job_type=ToyJob, job_name="toy_1")
         job.run()
         job = cls.project.create_job(job_type=ToyJob, job_name="toy_2")

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -93,7 +93,7 @@ class ToyJob(PythonTemplateJob):
     def __init__(self, project, job_name):
         """A toyjob to test export/import functionalities."""
         super(ToyJob, self).__init__(project, job_name)
-        self.input['input_energy'] = 100
+        self.input.in_data = 100
 
     # This function is executed
     def run_static(self):

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -100,7 +100,8 @@ class ToyJob(PythonTemplateJob):
         self.status.running = True
         self.output.data_out = self.input.data_in + 1
         self.status.finished = True
-
+        self.to_hdf()
+        
 
 class TestWithFilledProject(TestWithProject, ABC):
 

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -102,7 +102,7 @@ class ToyJob(PythonTemplateJob):
         self.status.finished = True
 
 
-class TestWithFilledProject(PyironTestCase, ABC):
+class TestWithFilledProject(TestWithProject, ABC):
 
     """
     Tests that creates a projects, creates jobs and sub jobs in it, and at the end of unit testing,

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -93,7 +93,7 @@ class ToyJob(PythonTemplateJob):
     def __init__(self, project, job_name):
         """A toyjob to test export/import functionalities."""
         super(ToyJob, self).__init__(project, job_name)
-        self.input.in_data = 100
+        self.input.data_in = 100
 
     # This function is executed
     def run_static(self):

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -127,5 +127,4 @@ class TestWithFilledProject(TestWithProject, ABC):
             job.status.aborted = True
 
 
-
 _TO_SKIP = [PyironTestCase, TestWithProject, TestWithCleanProject, TestWithFilledProject]

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -10,6 +10,7 @@ from io import StringIO
 import unittest
 from os.path import split, join
 from os import remove
+from pyiron_base import PythonTemplateJob
 from pyiron_base.project.generic import Project
 from abc import ABC
 from inspect import getfile
@@ -87,5 +88,17 @@ class TestWithCleanProject(TestWithProject, ABC):
     def tearDown(self):
         self.project.remove_jobs_silently(recursive=True)
 
+
+class ToyJob(PythonTemplateJob):
+    def __init__(self, project, job_name):
+        """A toyjob to test export/import functionalities."""
+        super(ToyJob, self).__init__(project, job_name)
+        self.input['input_energy'] = 100
+
+    # This function is executed
+    def run_static(self):
+        with self.project_hdf5.open("output/generic") as h5out:
+            h5out["energy_tot"] = self.input["input_energy"]
+        self.status.finished = True
 
 _TO_SKIP = [PyironTestCase, TestWithProject, TestWithCleanProject]

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -97,8 +97,8 @@ class ToyJob(PythonTemplateJob):
 
     # This function is executed
     def run_static(self):
-        with self.project_hdf5.open("output/generic") as h5out:
-            h5out["energy_tot"] = self.input["input_energy"]
+        self.status.running = True
+        self.output.data_out = self.input.data_in + 1
         self.status.finished = True
 
 

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -5,7 +5,6 @@ from pyiron_base.archiving.export_archive import export_database
 import pandas as pd
 from pandas._testing import assert_frame_equal
 from filecmp import dircmp
-from pyiron_base import PythonTemplateJob
 from shutil import rmtree
 from pyiron_base._tests import PyironTestCase, ToyJob
 

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -7,20 +7,7 @@ from pandas._testing import assert_frame_equal
 from filecmp import dircmp
 from pyiron_base import PythonTemplateJob
 from shutil import rmtree
-from pyiron_base._tests import PyironTestCase
-
-
-class ToyJob(PythonTemplateJob):
-    def __init__(self, project, job_name):
-        """A toyjob to test export/import functionalities."""
-        super(ToyJob, self).__init__(project, job_name)
-        self.input['input_energy'] = 100
-
-    # This function is executed
-    def run_static(self):
-        with self.project_hdf5.open("output/generic") as h5out:
-            h5out["energy_tot"] = self.input["input_energy"]
-        self.status.finished = True
+from pyiron_base._tests import PyironTestCase, ToyJob
 
 
 class TestPack(PyironTestCase):

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -130,9 +130,9 @@ class TestUnpacking(PyironTestCase):
         self.pr.pack(destination_path=self.arch_dir_comp, compress=True)
         self.imp_pr.unpack(origin_path=self.arch_dir_comp, compress=True)
         j = self.imp_pr.load(self.job.name)
-        self.assertEqual(self.job.input["input_energy"], j.input["input_energy"],
+        self.assertEqual(self.job.input["data_in"], j.input["data_in"],
                          "Input values not properly copied to imported job.")
-        self.assertEqual(self.job["output/energy_tot"], j["output/energy_tot"],
+        self.assertEqual(self.job["data_out"], j["data_out"],
                          "Output values not properly copied to imported job.")
 
     def test_import_with_targz_extension(self):

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -4,22 +4,8 @@ from pyiron_base import Project
 from pyiron_base.archiving.import_archive import getdir, extract_archive
 from pandas._testing import assert_frame_equal
 from filecmp import dircmp
-from pyiron_base import PythonTemplateJob
 from shutil import rmtree
-from pyiron_base._tests import PyironTestCase
-
-
-class ToyJob(PythonTemplateJob):
-    def __init__(self, project, job_name):
-        """A toyjob to test export/import functionalities."""
-        super(ToyJob, self).__init__(project, job_name)
-        self.input['input_energy'] = 100
-
-    # This function is executed
-    def run_static(self):
-        with self.project_hdf5.open("output/generic") as h5out:
-            h5out["energy_tot"] = self.input["input_energy"]
-        self.status.finished = True
+from pyiron_base._tests import PyironTestCase, ToyJob
 
 
 class TestUnpacking(PyironTestCase):

--- a/tests/table/test_datamining.py
+++ b/tests/table/test_datamining.py
@@ -3,18 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
-from pyiron_base.job.template import PythonTemplateJob
-from pyiron_base._tests import TestWithProject
+from pyiron_base._tests import TestWithProject, ToyJob
 
-class ToyJob(PythonTemplateJob):
-    def __init__(self, project, job_name):
-        super(ToyJob, self).__init__(project, job_name)
-        self.input['input_energy'] = 100
-
-    def run_static(self):
-        with self.project_hdf5.open("output/generic") as h5out:
-            h5out["energy_tot"] = self.input["input_energy"]
-        self.status.finished = True
 
 class TestProjectData(TestWithProject):
 


### PR DESCRIPTION
I think it is useful in many cases (Edit:  For example https://github.com/pyiron/pyiron_base/pull/476) to have test case templates with a `cls.project` class attribute which already has a few jobs and sub projects. Here's a minimal implementation.