### PR TITLE
More filtering options in Project.iter_jobs

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -10,6 +10,7 @@ from io import StringIO
 import unittest
 from os.path import split, join
 from os import remove
+from pyiron_base import PythonTemplateJob
 from pyiron_base.project.generic import Project
 from abc import ABC
 from inspect import getfile
@@ -87,5 +88,17 @@ class TestWithCleanProject(TestWithProject, ABC):
     def tearDown(self):
         self.project.remove_jobs_silently(recursive=True)
 
+
+class ToyJob(PythonTemplateJob):
+    def __init__(self, project, job_name):
+        """A toyjob to test export/import functionalities."""
+        super(ToyJob, self).__init__(project, job_name)
+        self.input['input_energy'] = 100
+
+    # This function is executed
+    def run_static(self):
+        with self.project_hdf5.open("output/generic") as h5out:
+            h5out["energy_tot"] = self.input["input_energy"]
+        self.status.finished = True
 
 _TO_SKIP = [PyironTestCase, TestWithProject, TestWithCleanProject]

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -126,7 +126,7 @@ class TestWithFilledProject(TestWithProject, ABC):
             job.run()
             job = pr_sub.create_job(job_type=ToyJob, job_name="toy_2")
             job.run()
-            job.status.aborted = True
+            job.status.suspended = True
 
     @classmethod
     def tearDownClass(cls):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -49,6 +49,7 @@ from pyiron_base.server.queuestatus import (
 from pyiron_base.job.external import Notebook
 from pyiron_base.project.data import ProjectData
 from pyiron_base.archiving import import_archive, export_archive
+from typing import List, Generator
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -512,7 +513,7 @@ class Project(ProjectPath, HasGroups):
         """
         return self.load(job_specifier=job_specifier, convert_to_object=False)
 
-    def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> list:
+    def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> List[int]:
         """
         Get a list of job ids in a project based on matching values from any column in the project database
 
@@ -543,7 +544,8 @@ class Project(ProjectPath, HasGroups):
             return []
         return df[mask]["id"].to_list()
 
-    def iter_jobs(self, path=None, recursive=True, convert_to_object=True, progress=True, **kwargs):
+    def iter_jobs(self, path: str = None, recursive: bool = True, convert_to_object: bool = True, progress: bool = True,
+                  **kwargs: dict) -> Generator:
         """
         Iterate over the jobs within the current project and it is sub projects
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -524,7 +524,10 @@ class Project(ProjectPath, HasGroups):
             return []
         mask = np.ones_like(df.index, dtype=bool)
         for key, val in kwargs.items():
-            mask &= df[key] == val
+            if val is None:
+                mask &= df[key].isnull()
+            else:
+                mask &= df[key] == val
         if not mask.any():
             return []
         return df[mask]["id"].to_list()

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -519,7 +519,7 @@ class Project(ProjectPath, HasGroups):
     def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> list:
         if len(kwargs.keys()) == 0:
             return self.get_job_ids(recursive=recursive)
-        df = self.job_table(recursive=True)
+        df = self.job_table(recursive=recursive)
         if df.empty:
             return []
         mask = np.ones_like(df.index, dtype=bool)
@@ -529,7 +529,8 @@ class Project(ProjectPath, HasGroups):
             return []
         return df[mask]["id"].to_list()
 
-    def iter_jobs(self, path=None, recursive=True, convert_to_object=True, status=None, job_type=None, progress=True):
+    def iter_jobs(self, path=None, recursive=True, convert_to_object=True,
+                  status=None, job_type=None, progress=True):
         """
         Iterate over the jobs within the current project and it is sub projects
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -520,12 +520,14 @@ class Project(ProjectPath, HasGroups):
         if len(kwargs.keys()) == 0:
             return self.get_job_ids(recursive=recursive)
         df = self.job_table(recursive=True)
-        for key, val in kwargs.items():
-            df = df[df[key] == val]
         if df.empty:
             return []
-        else:
-            return df["id"]
+        mask = np.ones_like(df.index, dtype=bool)
+        for key, val in kwargs.items():
+            mask &= df[key] == val
+        if not mask.any():
+            return []
+        return df[mask]["id"].to_list()
 
     def iter_jobs(self, path=None, recursive=True, convert_to_object=True, status=None, job_type=None, progress=True):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -516,6 +516,17 @@ class Project(ProjectPath, HasGroups):
         """
         return self.load(job_specifier=job_specifier, convert_to_object=False)
 
+    def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> list:
+        if len(kwargs.keys()) == 0:
+            return self.get_job_ids(recursive=recursive)
+        df = self.job_table(recursive=True)
+        for key, val in kwargs.items():
+            df = df[df[key] == val]
+        if df.empty:
+            return []
+        else:
+            return df["id"]
+
     def iter_jobs(self, path=None, recursive=True, convert_to_object=True, status=None, job_type=None, progress=True):
         """
         Iterate over the jobs within the current project and it is sub projects

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -522,7 +522,8 @@ class Project(ProjectPath, HasGroups):
 
         Args:
             recursive (bool): True if entries from subprojects are considered
-            **kwargs (dict): Optional arguments with keys matching the project database column name
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished")
 
         Returns:
             list: List of job IDs
@@ -533,6 +534,10 @@ class Project(ProjectPath, HasGroups):
         if df.empty:
             return []
         mask = np.ones_like(df.index, dtype=bool)
+        db_columns = self.get_db_columns()
+        for key in kwargs.keys():
+            if key not in db_columns:
+                raise ValueError("Column name {} does not exist in the project database!")
         for key, val in kwargs.items():
             if val is None:
                 mask &= df[key].isnull()
@@ -551,7 +556,9 @@ class Project(ProjectPath, HasGroups):
             recursive (bool): search subprojects [True/False] - True by default
             convert_to_object (bool): load the full GenericJob object (default) or just the HDF5 / JobCore object
             progress (bool): if True (default), add an interactive progress bar to the iteration
-            **kwargs (dict): Can be
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished")
+
         Returns:
             yield: Yield of GenericJob or JobCore
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -512,7 +512,7 @@ class Project(ProjectPath, HasGroups):
         """
         return self.load(job_specifier=job_specifier, convert_to_object=False)
 
-    def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> list:
+    def get_filtered_job_ids(self, recursive: bool = True, **kwargs: dict) -> List[int]:
         """
         Get a list of job ids in a project based on matching values from any column in the project database
 
@@ -543,7 +543,7 @@ class Project(ProjectPath, HasGroups):
             return []
         return df[mask]["id"].to_list()
 
-    def iter_jobs(self, path=None, recursive=True, convert_to_object=True, progress=True, **kwargs):
+    def iter_jobs(self, path=None, recursive: bool=True, convert_to_object: bool=True, progress: bool=True, **kwargs) -> Iterator[GenericJob]:
         """
         Iterate over the jobs within the current project and it is sub projects
 

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -4,22 +4,8 @@ from pyiron_base import Project
 from pyiron_base.archiving.import_archive import getdir, extract_archive
 from pandas._testing import assert_frame_equal
 from filecmp import dircmp
-from pyiron_base import PythonTemplateJob
 from shutil import rmtree
-from pyiron_base._tests import PyironTestCase
-
-
-class ToyJob(PythonTemplateJob):
-    def __init__(self, project, job_name):
-        """A toyjob to test export/import functionalities."""
-        super(ToyJob, self).__init__(project, job_name)
-        self.input['input_energy'] = 100
-
-    # This function is executed
-    def run_static(self):
-        with self.project_hdf5.open("output/generic") as h5out:
-            h5out["energy_tot"] = self.input["input_energy"]
-        self.status.finished = True
+from pyiron_base._tests import PyironTestCase, ToyJob
 
 
 class TestUnpacking(PyironTestCase):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -6,7 +6,7 @@ import unittest
 from os.path import dirname, join, abspath
 from os import remove
 from pyiron_base.project.generic import Project
-from pyiron_base._tests import PyironTestCase, TestWithProject, TestWithFilledProject
+from pyiron_base._tests import PyironTestCase, TestWithProject, TestWithFilledProject, ToyJob
 from pyiron_base.toolkit import BaseTools
 
 
@@ -61,7 +61,6 @@ class TestProjectOperations(TestWithFilledProject):
 
     def test_job_table(self):
         df = self.project.job_table()
-        print(df)
         self.assertEqual(len(df), 4)
         self.assertEqual(" ".join(df.status.sort_values().unique()), "aborted finished suspended")
 
@@ -75,6 +74,21 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="suspended")), 0)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, hamilton="ToyJob")), 2)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, parentid=None)), 4)
+
+    def test_get_iter_jobs(self):
+        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=True)],
+                         [100] * 4)
+        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=False)],
+                         [100] * 2)
+        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=False,
+                                                                                             status="aborted")],
+                         [100])
+        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=True,
+                                                                                             job="toy_2")],
+                         [100] * 2)
+        self.assertEqual([val for val in self.project.iter_jobs(recursive=False, status="suspended")], [])
+        self.assertIsInstance([val for val in self.project.iter_jobs(recursive=True, status="suspended",
+                                                                     convert_to_object=True)][0], ToyJob)
 
 
 class TestToolRegistration(TestWithProject):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -6,7 +6,7 @@ import unittest
 from os.path import dirname, join, abspath
 from os import remove
 from pyiron_base.project.generic import Project
-from pyiron_base._tests import PyironTestCase, TestWithProject
+from pyiron_base._tests import PyironTestCase, TestWithProject, TestWithFilledProject
 from pyiron_base.toolkit import BaseTools
 
 
@@ -55,6 +55,25 @@ class TestProjectData(PyironTestCase):
                 pass
         except:
             self.fail("Iterating over empty project with set status flag should not raise exception.")
+
+
+class TestProjectOperations(TestWithFilledProject):
+
+    def test_job_table(self):
+        df = self.project.job_table()
+        print(df)
+        self.assertEqual(len(df), 4)
+        self.assertEqual(" ".join(df.status.sort_values().unique()), "aborted finished suspended")
+
+    def test_get_filtered_job_ids(self):
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False)), 2)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True)), 4)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="finished")), 2)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="finished")), 1)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="suspended")), 1)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="aborted")), 1)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="suspended")), 0)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, hamilton="ToyJob")), 2)
 
 
 class TestToolRegistration(TestWithProject):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -74,6 +74,7 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="aborted")), 1)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="suspended")), 0)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, hamilton="ToyJob")), 2)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, parentid=None)), 4)
 
 
 class TestToolRegistration(TestWithProject):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -79,16 +79,8 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertRaises(ValueError, self.project.get_filtered_job_ids, gibberish=True)
 
     def test_get_iter_jobs(self):
-        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=True)],
-                         [100] * 4)
-        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=False)],
-                         [100] * 2)
-        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=False,
-                                                                                             status="aborted")],
-                         [100])
-        self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=True,
-                                                                                             job="toy_2")],
-                         [100] * 2)
+        self.assertEqual([job.output.data_out for job in self.project.iter_jobs(recursive=True,
+                                                                                convert_to_object=True)], [101] * 4)
         self.assertEqual([val for val in self.project.iter_jobs(recursive=False, status="suspended")], [])
         self.assertIsInstance([val for val in self.project.iter_jobs(recursive=True, status="suspended",
                                                                      convert_to_object=True)][0], ToyJob)

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -74,6 +74,9 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="suspended")), 0)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, hamilton="ToyJob")), 2)
         self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, parentid=None)), 4)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="finished", job="toy_1")), 2)
+        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="finished", job="toy_1")), 1)
+        self.assertRaises(ValueError, self.project.get_filtered_job_ids, gibberish=True)
 
     def test_get_iter_jobs(self):
         self.assertEqual([val["output/generic/energy_tot"] for val in self.project.iter_jobs(recursive=True)],


### PR DESCRIPTION
This PR extends `pr.iter_jobs()` to include filtering based on matching column values (eg. `pr.iter_jobs(hamilton="Vasp")` or `pr.iter_jobs(parentid=None)`