### PR TITLE
FileTable hotfix 

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -153,13 +153,13 @@ class FileTable(IsDatabase, metaclass=Singleton):
         element_lst=None
     ):
         self.update()
-        if project is None:
-            project = self._project
+        if project_path is None:
+            project_path = self._project
         if len(self._job_table) != 0:
             if recursive:
-                df = self._job_table[self._job_table.project.str.contains(project)]
+                df = self._job_table[self._job_table.project.str.contains(project_path)]
             else:
-                df = self._job_table[self._job_table.project == project]
+                df = self._job_table[self._job_table.project == project_path]
         else:
             return self._job_table
 

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -168,7 +168,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
             project = self._project
         if columns is None:
             columns = ["id", "project"]
-        df = self.job_table(project=project, recursive=recursive, columns=columns)
+        df = self.job_table(sql_query=None, user=s.login_user, project_path=project, recursive=recursive, columns=columns)
         if len(df) == 0:
             dictionary = {}
             for key in columns:

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -157,9 +157,9 @@ class FileTable(IsDatabase, metaclass=Singleton):
             project_path = self._project
         if len(self._job_table) != 0:
             if recursive:
-                df = self._job_table[self._job_table.project.str.contains(project_path)]
+                return self._job_table[self._job_table.project.str.contains(project_path)]
             else:
-                df = self._job_table[self._job_table.project == project_path]
+                return self._job_table[self._job_table.project == project_path]
         else:
             return self._job_table
 

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -168,7 +168,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
             project = self._project
         if columns is None:
             columns = ["id", "project"]
-        df = self.job_table(sql_query=None, user=s.login_user, project_path=project, recursive=recursive, columns=columns)
+        df = self.job_table(sql_query=None, user=None, project_path=project, recursive=recursive, columns=columns)
         if len(df) == 0:
             dictionary = {}
             for key in columns:

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -781,7 +781,7 @@ class GenericJob(JobCore):
             self.project.db.update()
         else:
             ft = FileTable(project=self.project_hdf5.path + "_hdf5/")
-            df = ft.job_table(all_columns=True)
+            df = ft.job_table(sql_query=None, user=s.login_user, project_path=None, all_columns=True)
             db_dict_lst = []
             for j, st, sj, p, h, hv, c, ts, tp, tc in zip(
                     df.job.values,


### PR DESCRIPTION
Fixes #482.

In #336 I tried to match the methods getting the job_table from both `DatabaseAccess` and `FileTable` and as part of that introduced `user` and `sql_query` to the method on `FileTable`.  When calling `get_job_table` from a `Project` these values are always supplied and then ignored, but there were two sites that called `FileTable.get_job_table` directly that I had missed earlier.