### PR TITLE
Settings promises

### DIFF
--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -12,7 +12,7 @@ instantiated.
 It is possible to run pyiron only with default behaviour from the `Settings` class itself, but standard behaviour is to
 update the configuration by reading information stored on the system.
 First, `Settings` tries to read these updates from a file the operating system environment keys are searched for
-`'PYIRONCONFIG'`, and if this doesn't exist then a default location (~/.pyiron_config) is used.
+`'PYIRONCONFIG'`, and if this doesn't exist then a default location (~/.pyiron) is used.
 Second, if no file can be found in either of these locations, `Settings` tries to update the configuration by looking
 for system environment variables containing `'PYIRON'`.
 Additionally, if either of the conda flags `'CONDA_PREFIX'` or `'CONDA_DIR'` are system environment variables, they get

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -106,7 +106,7 @@ class Settings(metaclass=Singleton):
 
         # Build the SQLalchemy connection strings from config data
         if not self._configuration["disable_database"]:
-            self._configuration = self.convert_database_config(
+            self._configuration = self._convert_database_config(
                 config=self._configuration
             )
 
@@ -346,7 +346,7 @@ class Settings(metaclass=Singleton):
             self._configuration["sql_table_name"] = parser.get(section, "JOB_TABLE")
 
     @staticmethod
-    def convert_database_config(config):
+    def _convert_database_config(config):
         # Build the SQLalchemy connection strings
         if config["sql_type"] == "Postgres":
             config["sql_connection_string"] = (

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -2,14 +2,14 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 """
-The `Settings` object controls all the parameters of the pyiron environment that are specific to your particular
+The :class:`Settings` object controls all the parameters of the pyiron environment that are specific to your particular
 configuration: your username, where on the filesystem to look for resources, and all flags necessary to define how
 pyiron objects relate to your database (or lack thereof).
 It is universally available for import an instantiation, and the python interpreter only ever sees a single instance of
-it, so modifications to the `Settings` in one place are available everywhere else that `Settings` gets/has gotten
+it, so modifications to the :class:`Settings` in one place are available everywhere else that `Settings` gets/has gotten
 instantiated.
 
-It is possible to run pyiron only with default behaviour from the `Settings` class itself, but standard behaviour is to
+It is possible to run pyiron only with default behaviour from the `Settings` class itself, but standard practice is to
 update the configuration by reading information stored on the system.
 The highest priority is to read values to read a configuration file identified in the `'PYIRONCONFIG'` system
 environment variable.
@@ -19,10 +19,10 @@ Last, it looks in the other system environment variables.
 Additionally, if either of the conda flags `'CONDA_PREFIX'` or `'CONDA_DIR'` are system environment variables, they get
 `/share/pyiron` appended to them and these values are *appended* to the resource paths.
 
-Finally, `Settings` converts any file paths to be in the appropriate format for your OS.
+Finally, :class:`Settings` converts any file paths from your OS to something pyiron-compatible.
 
-In addition to these core responsibilities, at the moment `Settings` also hosts the logger, the queue adapter (for
-sending pyiron jobs off to remote resources), and a publication list (for keeping track of what should be cited
+In addition to these core responsibilities, at the moment :class:`Settings` also hosts the logger, the queue adapter
+(for sending pyiron jobs off to remote resources), and a publication list (for keeping track of what should be cited
 depending on which parts of pyiron are actually used).
 """
 
@@ -247,17 +247,13 @@ class Settings(metaclass=Singleton):
 
     def _config_parse_file(self, config_file):
         """
-        Read section in configuration file and return a dictionary with the corresponding parameters.
+        Parse the config file and use it to populate the configuration.
 
         Args:
             config_file(str): confi file to parse
-
-        Returns:
-            dict: dictionary with the environment configuration
         """
         # load config parser - depending on Python version
         parser = ConfigParser(inline_comment_prefixes=(";",))
-        key_map = self._configfile_configuration_map
 
         # read config
         parser.read(config_file)
@@ -437,7 +433,6 @@ class Settings(metaclass=Singleton):
     @property
     def queue_adapter(self):
         return self._queue_adapter
-
 
     @staticmethod
     def _init_queue_adapter(resource_path_lst):

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -226,37 +226,6 @@ class Settings(metaclass=Singleton):
         ]
 
     @property
-    def queue_adapter(self):
-        return self._queue_adapter
-
-    @property
-    def publication_lst(self):
-        """
-        List of publications currently in use.
-
-        Returns:
-            list: list of publications
-        """
-        all_publication = []
-        for v in self._publication_lst.values():
-            if isinstance(v, list):
-                all_publication += v
-            else:
-                all_publication.append(v)
-        return all_publication
-
-    def publication_add(self, pub_dict):
-        """
-        Add a publication to the list of publications
-
-        Args:
-            pub_dict (dict): The key should be the name of the code used and the value a list of publications to cite.
-        """
-        for key, value in pub_dict.items():
-            if key not in self._publication_lst.keys():
-                self._publication_lst[key] = value
-
-    @property
     def login_user(self):
         """
         Get the username of the current user
@@ -275,31 +244,6 @@ class Settings(metaclass=Singleton):
             list: path of paths
         """
         return self._configuration["resource_paths"]
-
-    @staticmethod
-    def _init_queue_adapter(resource_path_lst):
-        """
-        Initialize the queue adapter if a folder queues is found in one of the resource paths which contains a
-        queue configuration file (queue.yaml).
-
-        Args:
-            resource_path_lst (list): List of resource paths
-
-        Returns:
-            pysqa.QueueAdapter:
-        """
-        for resource_path in resource_path_lst:
-            if (
-                os.path.exists(resource_path)
-                and "queues" in os.listdir(resource_path)
-                and (
-                    "queue.yaml" in os.listdir(os.path.join(resource_path, "queues")) or
-                    "clusters.yaml" in os.listdir(os.path.join(resource_path, "queues"))
-                )
-            ):
-                queueadapter = getattr(importlib.import_module("pysqa"), "QueueAdapter")
-                return queueadapter(directory=os.path.join(resource_path, "queues"))
-        return None
 
     def _config_parse_file(self, config_file):
         """
@@ -489,6 +433,63 @@ class Settings(metaclass=Singleton):
                 else:
                     config[v] = environment[k]
         return config
+
+    @property
+    def queue_adapter(self):
+        return self._queue_adapter
+
+
+    @staticmethod
+    def _init_queue_adapter(resource_path_lst):
+        """
+        Initialize the queue adapter if a folder queues is found in one of the resource paths which contains a
+        queue configuration file (queue.yaml).
+
+        Args:
+            resource_path_lst (list): List of resource paths
+
+        Returns:
+            pysqa.QueueAdapter:
+        """
+        for resource_path in resource_path_lst:
+            if (
+                os.path.exists(resource_path)
+                and "queues" in os.listdir(resource_path)
+                and (
+                    "queue.yaml" in os.listdir(os.path.join(resource_path, "queues")) or
+                    "clusters.yaml" in os.listdir(os.path.join(resource_path, "queues"))
+                )
+            ):
+                queueadapter = getattr(importlib.import_module("pysqa"), "QueueAdapter")
+                return queueadapter(directory=os.path.join(resource_path, "queues"))
+        return None
+
+    @property
+    def publication_lst(self):
+        """
+        List of publications currently in use.
+
+        Returns:
+            list: list of publications
+        """
+        all_publication = []
+        for v in self._publication_lst.values():
+            if isinstance(v, list):
+                all_publication += v
+            else:
+                all_publication.append(v)
+        return all_publication
+
+    def publication_add(self, pub_dict):
+        """
+        Add a publication to the list of publications
+
+        Args:
+            pub_dict (dict): The key should be the name of the code used and the value a list of publications to cite.
+        """
+        for key, value in pub_dict.items():
+            if key not in self._publication_lst.keys():
+                self._publication_lst[key] = value
 
     @property
     def publication(self):

--- a/pyiron_base/settings/generic.py
+++ b/pyiron_base/settings/generic.py
@@ -2,9 +2,27 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 """
-The settings file provides the attributes of the configuration as properties.
+The `Settings` object controls all the parameters of the pyiron environment that are specific to your particular
+configuration: your username, where on the filesystem to look for resources, and all flags necessary to define how
+pyiron objects relate to your database (or lack thereof).
+It is universally available for import an instantiation, and the python interpreter only ever sees a single instance of
+it, so modifications to the `Settings` in one place are available everywhere else that `Settings` gets/has gotten
+instantiated.
 
-The settings object is additionally responsible for the queue adapter, the logger, and the publications list.
+It is possible to run pyiron only with default behaviour from the `Settings` class itself, but standard behaviour is to
+update the configuration by reading information stored on the system.
+First, `Settings` tries to read these updates from a file the operating system environment keys are searched for
+`'PYIRONCONFIG'`, and if this doesn't exist then a default location (~/.pyiron_config) is used.
+Second, if no file can be found in either of these locations, `Settings` tries to update the configuration by looking
+for system environment variables containing `'PYIRON'`.
+Additionally, if either of the conda flags `'CONDA_PREFIX'` or `'CONDA_DIR'` are system environment variables, they get
+`/share/pyiron` appended to them and these values are *appended* to the resource paths.
+
+Finally, `Settings` converts any file paths to be in the appropriate format for your OS.
+
+In addition to these core responsibilities, at the moment `Settings` also hosts the logger, the queue adapter (for
+sending pyiron jobs off to remote resources), and a publication list (for keeping track of what should be cited
+depending on which parts of pyiron are actually used).
 """
 
 import os

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -75,14 +75,6 @@ class TestUnpacking(PyironTestCase):
         path_import = pr_imp.path
         path_original = getdir(path_original)
         path_import = getdir(path_import)
-        print(f"DEBUG \n"
-              f" print(path_original, path_import)\n"
-              f"> {path_original, path_import}\n"
-              f" os.listdir(path_original)\n"
-              f"> {os.listdir(path_original)}\n"
-              f" os.listdir(path_import)\n"
-              f"> {os.listdir(path_import)}\n"
-              f"END DEBUG")
         compare_obj = dircmp(path_original, path_import)
         self.assertEqual(len(compare_obj.diff_files), 0)
         pr.remove(enable=True)

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -102,8 +102,6 @@ class TestSettings(TestCase):
         self.env["CONDA_DIR"] = str(pyiron)  # Does not contain /share/pyiron -- shouldn't get added
 
         self.s._update_configuration(self.s._configuration)
-        print("Searched string", pyiron.as_posix(), "Actual resources", self.s._configuration["resource_paths"])
-        print("Before length", before, "after length", len(self.s._configuration["resource_paths"]))
         self.assertTrue(
             any([pyiron.as_posix() in p for p in self.s._configuration["resource_paths"]]),
             msg="The new resource should have been added"

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -132,8 +132,6 @@ class TestSettings(TestCase):
         self.env["PYIRONCONFIG"] = str(local)
         self._pop_conda_env_variables()
         self.s._update_configuration(self.s._configuration)
-        print("Manual list", [self._niceify_path(p1), self._niceify_path(p2)])
-        print("Read config", self.s._configuration['resource_paths'])
         self.assertListEqual(
             [self._niceify_path(p1), self._niceify_path(p2)],
             self.s._configuration['resource_paths']

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -102,10 +102,10 @@ class TestSettings(TestCase):
         self.env["CONDA_DIR"] = str(pyiron)  # Does not contain /share/pyiron -- shouldn't get added
 
         self.s._update_configuration(self.s._configuration)
-        print("Searched string", str(pyiron))
-        print("Actual resources", self.s._configuration["resource_paths"])
+        print("Searched string", pyiron.as_posix(), "Actual resources", self.s._configuration["resource_paths"])
+        print("Before length", before, "after length", len(self.s._configuration["resource_paths"]))
         self.assertTrue(
-            str(pyiron) in self.s._configuration["resource_paths"],
+            any([pyiron.as_posix() in p for p in self.s._configuration["resource_paths"]]),
             msg="The new resource should have been added"
         )
         self.assertEqual(

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -1,0 +1,135 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from unittest import TestCase
+from pyiron_base.settings.generic import Settings, convert_path
+import os
+from pathlib import Path
+from configparser import ConfigParser, NoOptionError
+
+
+class TestSettings(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.env = os.environ
+        cls.cwd = os.getcwd()
+        cls.parser = ConfigParser(inline_comment_prefixes=(";",))
+        cls.s = Settings()
+
+    def test_config_update_order(self):
+        # Config file in env
+        local_loc = Path(self.cwd + "/.pyiron")
+        local_val = "settings_test_local"
+        local_loc.write_text(f"[DEFAULT]\nTYPE = {local_val}\n")
+        self.env["PYIRONCONFIG"] = str(local_loc)
+
+        # Default config file
+        default_loc = Path("~/.pyiron").expanduser()
+        backup_loc = Path("~/.pyiron_test_config_update_order_backup").expanduser()
+        try:
+            default_loc.rename(backup_loc)
+        except FileNotFoundError:
+            pass
+        default_val = "settings_test_default"
+        default_loc.write_text(f"[DEFAULT]\nTYPE = {default_val}\n")
+
+        # System environment variables
+        env_val = "settings_test_env"
+        self.env["PYIRONSQLTYPE"] = str(env_val)
+
+        # Now peel them off one at a time to make sure we have the promised order of resolution
+        self.s._update_configuration(self.s._configuration)
+        self.assertEqual(
+            local_val, self.s._configuration["sql_type"],
+            msg="A config file specified in the env takes top priority."
+        )
+
+        self.env.pop("PYIRONCONFIG")
+        local_loc.unlink()
+        self.s._update_configuration(self.s._configuration)
+        self.assertEqual(
+            default_val, self.s._configuration["sql_type"],
+            msg="The default config file takes priority over the env variables"
+        )
+
+        default_loc.unlink()
+        self.s._update_configuration(self.s._configuration)
+        self.assertEqual(
+            env_val, self.s._configuration["sql_type"],
+            msg="Value should be read from system environment"
+        )
+
+        # self.env.pop("PYIRONSQLTYPE")
+        # self.s._update_configuration(self.s._configuration)
+        # self.assertEqual(
+        #     s._default_configuration["sql_type"], s._configuration["sql_type"],
+        #     msg="Code base default should be used after all other options are exhausted"
+        # )
+        # TODO: Include the default value in the update loop
+        #       Right now it either retains the old value (even if you del s and re-instantiate)
+        #       or doesn't know about the field at all (if you s._configuration.pop("sql_type")
+        #       But right now I'm not trying to change behaviour, just refactor.
+
+        try:  # Restore any preexisting config file
+            backup_loc.rename(default_loc)
+        except FileNotFoundError:
+            pass
+
+    def test_singleness(self):
+        s2 = Settings()
+        self.assertIs(self.s, s2, msg="There should only ever be one Settings instance")
+
+    def test_appending_conda_resources(self):
+        conda_keys = ["CONDA_PREFIX", "CONDA_DIR"]
+        for conda_key in conda_keys:
+            try:
+                self.env.pop(conda_key)
+            except KeyError:
+                pass
+
+        self.s._update_configuration(self.s._configuration)  # Clean out any old conda paths
+        before = len(self.s._configuration["resource_paths"])
+
+        here = Path(".").resolve()
+        share = Path("./share").resolve()
+        pyiron = Path("./share/pyiron").resolve()
+        pyiron.mkdir(parents=True)
+
+        self.env[conda_keys[0]] = str(here)  # Contains /share/pyiron -- should get added
+        self.env[conda_keys[1]] = str(pyiron)  # Does not contain /share/pyiron -- shouldn't get added
+
+        self.s._update_configuration(self.s._configuration)
+        self.assertTrue(
+            str(pyiron) in self.s._configuration["resource_paths"],
+            msg="The new resource should have been added"
+        )
+        self.assertEqual(
+            before + 1,
+            len(self.s._configuration["resource_paths"]),
+            msg="The new resource should only have been added once, as the other path didn't have share/pyiron"
+        )
+        pyiron.rmdir()
+        share.rmdir()
+
+    def _niceify_path(self, p: str):
+        return (Path(p)
+         .expanduser()
+         .resolve()
+         .absolute()
+         .as_posix()
+         .replace("\\", "/")
+         )
+
+    def test_path_conversion(self):
+        local = Path(self.cwd + "/.pyiron")
+        p1 = '~/here/is/a/path/'
+        p2 = 'here\\is\\another'  # TODO: Is this really good enough? Is it really windowsy enough?
+        local.write_text(f"[DEFAULT]\nRESOURCE_PATHS = {p1}, {p2}\n")
+        self.env["PYIRONCONFIG"] = str(local)
+        self.s._update_configuration(self.s._configuration)
+        self.assertListEqual(
+            [self._niceify_path(p1), self._niceify_path(p2)],
+            self.s._configuration['resource_paths']
+        )
+        local.unlink()

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -3,10 +3,10 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from unittest import TestCase
-from pyiron_base.settings.generic import Settings, convert_path
+from pyiron_base.settings.generic import Settings
 import os
 from pathlib import Path
-from configparser import ConfigParser, NoOptionError
+from configparser import ConfigParser
 
 
 class TestSettings(TestCase):

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -114,14 +114,15 @@ class TestSettings(TestCase):
         pyiron.rmdir()
         share.rmdir()
 
-    def _niceify_path(self, p: str):
+    @staticmethod
+    def _niceify_path(p: str):
         return (Path(p)
-         .expanduser()
-         .resolve()
-         .absolute()
-         .as_posix()
-         .replace("\\", "/")
-         )
+                .expanduser()
+                .resolve()
+                .absolute()
+                .as_posix()
+                .replace("\\", "/")
+                )
 
     def test_path_conversion(self):
         local = Path(self.cwd + "/.pyiron")

--- a/tests/settings/test_generic.py
+++ b/tests/settings/test_generic.py
@@ -102,6 +102,8 @@ class TestSettings(TestCase):
         self.env["CONDA_DIR"] = str(pyiron)  # Does not contain /share/pyiron -- shouldn't get added
 
         self.s._update_configuration(self.s._configuration)
+        print("Searched string", str(pyiron))
+        print("Actual resources", self.s._configuration["resource_paths"])
         self.assertTrue(
             str(pyiron) in self.s._configuration["resource_paths"],
             msg="The new resource should have been added"


### PR DESCRIPTION
Define and test the promises of the `Settings` class.

@pmrv and I have been talking about getting spec written. Re-reading [Joel's take on spec](https://www.joelonsoftware.com/2000/10/02/painless-functional-specifications-part-1-why-bother/) I wonder whether we aren't being too fine grained by having a special spec document for each (important?) class? With that said, once I sat down to write something spec-like for `Settings` I realised (a) that I *still* don't really grok what settings is doing, and (b) having this sort of high-level description of what the point is is absolutely critical.

So what should we do with this stuff? I am not totally against putting it in separate documents (cf. Marvin's spec/had_hdf.md), and I could also see this sort of thing just being in the class docstring. At the moment I put it at the module level docstring, although I am really seriously wondering if the class level is better.

Also, at the moment, the spec and tests are pretty much written to match the code and not exactly to match the designed behaviour I'd want. I might play around with it in the future.

@pmrv sorry, but I don't know if I'm going to get all the way to database access by the end of the week 😛 