### PR TITLE
give entries indices

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -806,6 +806,8 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
             def normalize_key(name):
                 # split a dataset/group name into the position in the list and
                 # the key
+                if '__index_' not in name:
+                    return -1, name
                 k, i = name.split("__index_", maxsplit=1)
                 i = int(i)
                 if k == "":


### PR DESCRIPTION
There are some input entries in `GenericMaster` (e.g. `child_id_func`, `generic_dict` (?), `job_list`) which are not enumerated and therefore give an error when split by `__index_` is effectuated. I don't whether these entries should come first or last, because I don't really understand in the first place why the enumeration really matters. Anyway I put them to the top - let me know what you think.