### PR TITLE
Fix delete_aborted_job fix

### DIFF
--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -147,44 +147,17 @@ class JobFactory(PyironFactory):
                 Returns:
                     GenericJob: job object depending on the job_type selected
                 """
-                job = JobClass(
+                return JobType(
                     class_name=name,
-                    project=self._project,
-                    job_class_dict=self._job_class_dict
+                    project=ProjectHDFio(project=self._project.copy(), file_name=job_name),
+                    job_name=job_name,
+                    job_class_dict=self._job_class_dict,
+                    delete_existing_job=delete_existing_job,
+                    delete_aborted_job=delete_aborted_job
                 )
-                return job.create(job_name=job_name, delete_existing_job=delete_existing_job)
             return wrapper
         else:
             raise AttributeError("no job class named '{}' defined".format(name))
-
-
-class JobClass(object):
-    """
-    Small wrapper class to create object instances of any job type using pr.create.job.Code()
-    """
-    def __init__(self, class_name, project, job_class_dict):
-        self._class_name = class_name
-        self._project = project
-        self._job_class_dict = job_class_dict
-
-    def create(self, job_name, delete_existing_job=False):
-        """
-        Internal helper function for pr.create.job.Code()
-
-        Args:
-            job_name (str): name of the job
-            delete_existing_job (bool): delete an existing job - default false
-
-        Returns:
-            GenericJob: job object depending on the job_type selected
-        """
-        return JobType(
-            class_name=self._class_name,
-            project=ProjectHDFio(project=self._project.copy(), file_name=job_name),
-            job_name=job_name,
-            job_class_dict=self._job_class_dict,
-            delete_existing_job=delete_existing_job
-        )
 
 
 class JobTypeChoice(metaclass=Singleton):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -130,7 +130,7 @@ class JobFactory(PyironFactory):
 
     def __getattr__(self, name):
         if name in self._job_class_dict.keys():
-            def wrapper(job_name, delete_existing_job=False):
+            def wrapper(job_name, delete_existing_job=False, delete_aborted_job=False):
                 """
                 Create one of the following jobs:
                 - 'ExampleJob': example job just generating random number
@@ -142,6 +142,7 @@ class JobFactory(PyironFactory):
                 Args:
                     job_name (str): name of the job
                     delete_existing_job (bool): delete an existing job - default false
+                    delete_aborted_job (bool): delete an existing and aborted job - default false
 
                 Returns:
                     GenericJob: job object depending on the job_type selected


### PR DESCRIPTION
I missed that #465 was actually broken, because I got lost in the redirection.  So while I was at it I inlined the `JobClass` class wrapper.