### PR TITLE
Filtering

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -92,6 +92,7 @@ class IsDatabase(ABC):
             full_table=False,
             element_lst=None,
             job_name_contains='',
+            **kwargs,
     ):
         """
         Access the job_table.
@@ -110,7 +111,9 @@ class IsDatabase(ABC):
             max_colwidth (int): set the column width
             full_table (bool): Whether to show the entire pandas table
             element_lst (list): list of elements required in the chemical formular - by default None
-            job_name_contains (str): a string which should be contained in every job_name
+            job_name_contains (str): (deprecated) A string which should be contained in every job_name
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished")
 
         Returns:
             pandas.Dataframe: Return the result as a pandas.Dataframe object

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -92,7 +92,6 @@ class IsDatabase(ABC):
             full_table=False,
             element_lst=None,
             job_name_contains='',
-            **kwargs,
     ):
         """
         Access the job_table.
@@ -112,8 +111,6 @@ class IsDatabase(ABC):
             full_table (bool): Whether to show the entire pandas table
             element_lst (list): list of elements required in the chemical formular - by default None
             job_name_contains (str): (deprecated) A string which should be contained in every job_name
-            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
-                            (eg. status="finished")
 
         Returns:
             pandas.Dataframe: Return the result as a pandas.Dataframe object

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -7,6 +7,7 @@ DatabaseAccess class deals with accessing the database
 
 import pyiron_base.settings.logger
 from abc import ABC, abstractmethod
+import warnings
 import numpy as np
 import re
 import time
@@ -79,6 +80,38 @@ class IsDatabase(ABC):
     ):
         pass
 
+    @staticmethod
+    def _get_filtered_job_table(df, **kwargs: dict):
+        """
+        Get a list of job ids in a project based on matching values from any column in the project database
+
+        Args:
+            df (pandas.DataFrame): DataFrame to be filtered
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished")
+
+        Returns:
+            list: DataFrame containing filtered jobs
+        """
+        if len(kwargs) == 0 or df.empty:
+            return df
+        mask = np.ones_like(df.index, dtype=bool)
+        for key in kwargs.keys():
+            if key not in list(df.columns):
+                raise ValueError("Column name {} does not exist in the project database!")
+        for key, val in kwargs.items():
+            if val is None:
+                mask &= df[key].isnull()
+            elif str(val).startswith('*') and str(val).endswith('*'):
+                mask &= df[key].str.contains(str(val).replace('*', ''))
+            elif str(val).endswith('*'):
+                mask &= df[key].str.startswith(str(val).replace('*', ''))
+            elif str(val).startswith('*'):
+                mask &= df[key].str.endswith(str(val).replace('*', ''))
+            else:
+                mask &= df[key] == val
+        return df[mask]
+
     def job_table(
             self,
             sql_query,
@@ -92,6 +125,7 @@ class IsDatabase(ABC):
             full_table=False,
             element_lst=None,
             job_name_contains='',
+            **kwargs,
     ):
         """
         Access the job_table.
@@ -152,7 +186,9 @@ class IsDatabase(ABC):
                 columns=columns,
         )
         if job_name_contains != '':
-            df = df[df.job.str.contains(job_name_contains)]
+            warnings.warn("`job_name_contains` is deprecated - use `job='*term*'` instead")
+            kwargs['job'] = '*{}*'.format(job_name_contains)
+        df = self._get_filtered_job_table(df, **kwargs)
         if sort_by is not None:
             return df.sort_values(by=sort_by)
         return df

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -81,7 +81,7 @@ class IsDatabase(ABC):
         pass
 
     @staticmethod
-    def _get_filtered_job_table(df: pd.DataFrame, **kwargs: dict) -> pd.DataFrame:
+    def _get_filtered_job_table(df: pandas.DataFrame, **kwargs: dict) -> pandas.DataFrame:
         """
         Get a job table in a project based on matching values from any column in the project database
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -83,7 +83,7 @@ class IsDatabase(ABC):
     @staticmethod
     def _get_filtered_job_table(df: pd.DataFrame, **kwargs: dict) -> pd.DataFrame:
         """
-        Get a list of job ids in a project based on matching values from any column in the project database
+        Get a job table in a project based on matching values from any column in the project database
 
         Args:
             df (pandas.DataFrame): DataFrame to be filtered

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -145,6 +145,9 @@ class IsDatabase(ABC):
             full_table (bool): Whether to show the entire pandas table
             element_lst (list): list of elements required in the chemical formular - by default None
             job_name_contains (str): (deprecated) A string which should be contained in every job_name
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished"). Asterisk can be used to denote a wildcard, for zero or more
+                            instances of any character
 
         Returns:
             pandas.Dataframe: Return the result as a pandas.Dataframe object

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -81,7 +81,7 @@ class IsDatabase(ABC):
         pass
 
     @staticmethod
-    def _get_filtered_job_table(df, **kwargs: dict):
+    def _get_filtered_job_table(df: pd.DataFrame, **kwargs: dict) -> pd.DataFrame:
         """
         Get a list of job ids in a project based on matching values from any column in the project database
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -538,6 +538,12 @@ class Project(ProjectPath, HasGroups):
         for key, val in kwargs.items():
             if val is None:
                 mask &= df[key].isnull()
+            elif str(val).startswith('*') and str(val).endswith('*'):
+                mask &= df[key].str.contains(str(val).replace('*', ''))
+            elif str(val).endswith('*'):
+                mask &= df[key].str.startswith(str(val).replace('*', ''))
+            elif str(val).startswith('*'):
+                mask &= df[key].str.endswith(str(val).replace('*', ''))
             else:
                 mask &= df[key] == val
         if not mask.any():
@@ -1539,7 +1545,7 @@ class Project(ProjectPath, HasGroups):
         Add a new creator to the project class.
 
         Example)
-        
+
         >>> from pyiron_base import Project, Toolkit
         >>> class MyTools(Toolkit):
         ...     @property

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -624,7 +624,10 @@ class Project(ProjectPath, HasGroups):
         job_name_contains='',
         **kwargs: dict,
     ):
-        return self.db.job_table(
+        if job_name_contains != '':
+            warnings.warn("`job_name_contains` is deprecated - use `job='*term*'` instead")
+            kwargs['job'] = '*{}*'.format(job_name_contains)
+        jt = self.db.job_table(
             sql_query=self.sql_query,
             user=self.user,
             project_path=self.project_path,
@@ -634,9 +637,9 @@ class Project(ProjectPath, HasGroups):
             sort_by=sort_by,
             full_table=full_table,
             element_lst=element_lst,
-            job_name_contains=job_name_contains,
             **kwargs,
         )
+        return self._get_filtered_job_table(jt, **kwargs)
     job_table.__doc__ = '\n'.join([
         line for line in FileTable.job_table.__doc__.split('\n')
         if all([item not in line for item in ['sql_query (str)', 'user (str)', 'project_path (str)']])

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -857,8 +857,7 @@ class Project(ProjectPath, HasGroups):
             *jobs (str, int): name of the job or job ID, any number of them
         """
         if len(jobs) == 0:
-            df = self.job_table()
-            jobs = df[df.status == "running"].id
+            jobs = self.job_table(status='running').id
         if self.db is not None:
             for job_specifier in jobs:
                 if isinstance(job_specifier, str):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -593,28 +593,6 @@ class Project(ProjectPath, HasGroups):
         job_name_contains='',
         **kwargs: dict,
     ):
-        """
-        Access the job_table.
-
-        Args:
-            recursive (bool): search subprojects [True/False]
-            columns (list): by default only the columns ['job', 'project', 'chemicalformula'] are selected, but the
-                            user can select a subset of ['id', 'status', 'chemicalformula', 'job', 'subjob', 'project',
-                            'projectpath', 'timestart', 'timestop', 'totalcputime', 'computer', 'hamilton', 'hamversion',
-                            'parentid', 'masterid']
-            all_columns (bool): Select all columns - this overwrites the columns option.
-            sort_by (str): Sort by a specific column
-            max_colwidth (int): set the column width
-            full_table (bool): Whether to show the entire pandas table
-            element_lst (list): list of elements required in the chemical formular - by default None
-            job_name_contains (str): (deprecated) A string which should be contained in every job_name
-            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
-                            (eg. status="finished"). Asterisk can be used to denote a wildcard, for zero or more
-                            instances of any character
-
-        Returns:
-            pandas.Dataframe: Return the result as a pandas.Dataframe object
-        """
         return self.db.job_table(
             sql_query=self.sql_query,
             user=self.user,
@@ -627,6 +605,10 @@ class Project(ProjectPath, HasGroups):
             element_lst=element_lst,
             **kwargs,
         )
+    job_table.__doc__ = '\n'.join([
+        ll for ll in FileTable.job_table.__doc__.split('\n')
+        if not any([item in ll for item in ['sql_query (str)', 'user (str)', 'project_path (str)']])
+    ])
 
     def get_jobs_status(self, recursive=True, element_lst=None):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -648,7 +648,7 @@ class Project(ProjectPath, HasGroups):
             pandas.Dataframe: Return the result as a pandas.Dataframe object
         """
         if job_name_contains != '':
-            warnings.warn("`job_name_contains` is deprecated - use `job='*term*'` instead")
+            warn("`job_name_contains` is deprecated - use `job='*term*'` instead")
             kwargs['job'] = '*{}*'.format(job_name_contains)
         jt = self.db.job_table(
             sql_query=self.sql_query,

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -627,25 +627,8 @@ class Project(ProjectPath, HasGroups):
         full_table=False,
         element_lst=None,
         job_name_contains='',
+        **kwargs: dict,
     ):
-        """
-        Access the job_table
-
-        Args:
-            recursive (bool): search subprojects [True/False] - default=True
-            columns (list): by default only the columns ['job', 'project', 'chemicalformula'] are selected, but the
-                            user can select a subset of ['id', 'status', 'chemicalformula', 'job', 'subjob', 'project',
-                            'projectpath', 'timestart', 'timestop', 'totalcputime', 'computer', 'hamilton',
-                            'hamversion', 'parentid', 'masterid']
-            all_columns (bool): Select all columns - this overwrites the columns option.
-            sort_by (str): Sort by a specific column
-            full_table (bool): Whether to show the entire pandas table
-            element_lst (list): list of elements required in the chemical formular - by default None
-            job_name_contains (str): a string which should be contained in every job_name
-
-        Returns:
-            pandas.Dataframe: Return the result as a pandas.Dataframe object
-        """
         return self.db.job_table(
             sql_query=self.sql_query,
             user=self.user,
@@ -657,7 +640,12 @@ class Project(ProjectPath, HasGroups):
             full_table=full_table,
             element_lst=element_lst,
             job_name_contains=job_name_contains,
+            **kwargs,
         )
+    job_table.__doc__ = '\n'.join([
+        line for line in FileTable.job_table.__doc__.split('\n')
+        if all([item not in line for item in ['sql_query (str)', 'user (str)', 'project_path (str)']])
+    ])
 
     def get_jobs_status(self, recursive=True, element_lst=None):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -555,7 +555,8 @@ class Project(ProjectPath, HasGroups):
             convert_to_object (bool): load the full GenericJob object (default) or just the HDF5 / JobCore object
             progress (bool): if True (default), add an interactive progress bar to the iteration
             **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
-                            (eg. status="finished")
+                            (eg. status="finished"). Asterisk can be used to denote a wildcard, for zero or more
+                            instances of any character
 
         Returns:
             yield: Yield of GenericJob or JobCore
@@ -624,6 +625,28 @@ class Project(ProjectPath, HasGroups):
         job_name_contains='',
         **kwargs: dict,
     ):
+        """
+        Access the job_table.
+
+        Args:
+            recursive (bool): search subprojects [True/False]
+            columns (list): by default only the columns ['job', 'project', 'chemicalformula'] are selected, but the
+                            user can select a subset of ['id', 'status', 'chemicalformula', 'job', 'subjob', 'project',
+                            'projectpath', 'timestart', 'timestop', 'totalcputime', 'computer', 'hamilton', 'hamversion',
+                            'parentid', 'masterid']
+            all_columns (bool): Select all columns - this overwrites the columns option.
+            sort_by (str): Sort by a specific column
+            max_colwidth (int): set the column width
+            full_table (bool): Whether to show the entire pandas table
+            element_lst (list): list of elements required in the chemical formular - by default None
+            job_name_contains (str): (deprecated) A string which should be contained in every job_name
+            **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
+                            (eg. status="finished"). Asterisk can be used to denote a wildcard, for zero or more
+                            instances of any character
+
+        Returns:
+            pandas.Dataframe: Return the result as a pandas.Dataframe object
+        """
         if job_name_contains != '':
             warnings.warn("`job_name_contains` is deprecated - use `job='*term*'` instead")
             kwargs['job'] = '*{}*'.format(job_name_contains)
@@ -640,10 +663,6 @@ class Project(ProjectPath, HasGroups):
             **kwargs,
         )
         return self._get_filtered_job_table(jt, **kwargs)
-    job_table.__doc__ = '\n'.join([
-        line for line in FileTable.job_table.__doc__.split('\n')
-        if all([item not in line for item in ['sql_query (str)', 'user (str)', 'project_path (str)']])
-    ])
 
     def get_jobs_status(self, recursive=True, element_lst=None):
         """

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -64,19 +64,19 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(df), 4)
         self.assertEqual(" ".join(df.status.sort_values().unique()), "aborted finished suspended")
 
-    def test_get_filtered_job_ids(self):
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False)), 2)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True)), 4)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="finished")), 2)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="finished")), 1)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="suspended")), 1)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="aborted")), 1)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="suspended")), 0)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, hamilton="ToyJob")), 2)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, parentid=None)), 4)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=True, status="finished", job="toy_1")), 2)
-        self.assertEqual(len(self.project.get_filtered_job_ids(recursive=False, status="finished", job="toy_1")), 1)
-        self.assertRaises(ValueError, self.project.get_filtered_job_ids, gibberish=True)
+    def test_filtered_job_table(self):
+        self.assertEqual(len(self.project.job_table(recursive=False)), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True)), 4)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="finished")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=False, status="finished")), 1)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="suspended")), 1)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="aborted")), 1)
+        self.assertEqual(len(self.project.job_table(recursive=False, status="suspended")), 0)
+        self.assertEqual(len(self.project.job_table(recursive=False, hamilton="ToyJob")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True, parentid=None)), 4)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="finished", job="toy_1")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=False, status="finished", job="toy_1")), 1)
+        self.assertRaises(ValueError, self.project.job_table, gibberish=True)
 
     def test_get_iter_jobs(self):
         self.assertEqual([job.output.data_out for job in self.project.iter_jobs(recursive=True,

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -75,6 +75,9 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(self.project.job_table(recursive=False, hamilton="ToyJob")), 2)
         self.assertEqual(len(self.project.job_table(recursive=True, parentid=None)), 4)
         self.assertEqual(len(self.project.job_table(recursive=True, status="finished", job="toy_1")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True, job="toy*")), 4)
+        self.assertEqual(len(self.project.job_table(recursive=True, job="*_1*")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True, job="*_*")), 4)
         self.assertEqual(len(self.project.job_table(recursive=False, status="finished", job="toy_1")), 1)
         self.assertRaises(ValueError, self.project.job_table, gibberish=True)
 


### PR DESCRIPTION
I did the extension of the filtering function as we discussed today. In short, @sudarsan-surendralal implemented:

```python
for job in pr.iter_jobs(job='md_something'):
    ....
````

And with this PR, we will be able to do the following as well:

```python
for job in pr.iter_jobs(job='md*'):
    ....
````

It should be self-explanatory but it means all jobs with their job names starting with `md`.

In addition to `Project.iter_jobs`, the same functionality is available to `Project.job_table` now as well.