### PR TITLE
Faster hdf reading

### DIFF
--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -116,7 +116,7 @@ class FileHDFio(HasGroups, MutableMapping):
                 # try to read it here and one more time to verify it's not a group below).
                 obj = h5io.read_hdf5(self.file_name, title=self._get_h5_path(item))
                 return obj
-            except ValueError:
+            except (ValueError, OSError):
                 # h5io couldn't find a dataset with name item, but there still might be a group with that name, which we
                 # check in the rest of the method
                 pass

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -123,11 +123,8 @@ class FileHDFio(HasGroups, MutableMapping):
 
             item_lst = item.split("/")
             if len(item_lst) == 1 and item_lst[0] != "..":
-                content = self.list_all()
-                if item in content["nodes"]:
-                    obj = h5io.read_hdf5(self.file_name, title=self._get_h5_path(item))
-                    return obj
-                if item in content["groups"]:
+                # if item in self.list_nodes() we would have caught it in the fast path above
+                if item in self.list_groups():
                     with self.open(item) as hdf_item:
                         obj = hdf_item.copy()
                         return obj

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -106,6 +106,21 @@ class FileHDFio(HasGroups, MutableMapping):
                 return self.values()
             raise NotImplementedError("Implement if needed, e.g. for [:]")
         else:
+            try:
+                # fast path, a good amount of accesses will want to fetch a specific dataset it knows exists in the
+                # file, there's therefor no point in checking whether item is a group or a node or even worse recursing
+                # in case when item contains '/'.  In most cases read_hdf5 will grab the correct data straight away and
+                # if not we will still check thoroughly below.  Since list_nodes()/list_groups() each open the
+                # underlying file once, this reduces the number of file opens in the most-likely case from 2 to 1 (1 to
+                # check whether the data is there and 1 to read it) and increases in the worst case from 1 to 2 (1 to
+                # try to read it here and one more time to verify it's not a group below).
+                obj = h5io.read_hdf5(self.file_name, title=self._get_h5_path(item))
+                return obj
+            except ValueError:
+                # h5io couldn't find a dataset with name item, but there still might be a group with that name, which we
+                # check in the rest of the method
+                pass
+
             item_lst = item.split("/")
             if len(item_lst) == 1 and item_lst[0] != "..":
                 if item in self.list_nodes():

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -123,10 +123,11 @@ class FileHDFio(HasGroups, MutableMapping):
 
             item_lst = item.split("/")
             if len(item_lst) == 1 and item_lst[0] != "..":
-                if item in self.list_nodes():
+                content = self.list_all()
+                if item in content["nodes"]:
                     obj = h5io.read_hdf5(self.file_name, title=self._get_h5_path(item))
                     return obj
-                if item in self.list_groups():
+                if item in content["groups"]:
                     with self.open(item) as hdf_item:
                         obj = hdf_item.copy()
                         return obj


### PR DESCRIPTION
I'm waiting for pyiron to submit a large number of jobs right now, so I thought I have a look at how to make it faster.

One of the *major* bottlenecks is calling `list_all()`/`list_groups()`/`list_nodes()` to check what datasets/groups are inside the HDF5 files.  In fact roughly 75%(!) of loading a small lammps job is spent in `FileHDFio.list_all()`.

This makes two changes:
1. Eagerly try load read data directly with `h5io.read_hdf5` instead of checking first whether it is there and then reading it.  This makes a simple read like `job['output/generic/energy_pot']` faster by about a factor 5, so that it takes roughly the same amount of time as calling `h5io.read_hdf5` directly on a file.
2. Use `list_all()` instead of `list_nodes()` and `list_groups` together.  This saves opening the HDF5 file once.

Both together make loading a lammps jobs about 10% faster.

I want to mention that this
```python
h5io.read_hdf5(j.project_hdf5.file_name, title=j.name + '/output/generic/energy_pot')
```
is still about twice as slow as directly doing
```python
with h5py.File(j.project_hdf5.file_name) as f:
    a = f[j.name + '/output/generic/energy_pot']
```
so there's still room for improvement.