### PR TITLE
Fix compatibility workflows run condition.

### DIFF
--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled, opened, synchronize]
+    types: [labeled, opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -13,9 +13,8 @@ on:
 jobs:
   build:
     if: |
-      ${{ github.event.type == 'PushEvent' ||
-          ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
-       }}
+      github.event.type == 'PushEvent' ||
+      ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
 
     runs-on: ${{ matrix.operating-system }}
     strategy:

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -13,9 +13,8 @@ on:
 jobs:
   build:
     if: |
-      ${{ github.event.type == 'PushEvent' ||
-          ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
-       }}
+      github.event.type == 'PushEvent' ||
+      ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled, opened, synchronize]
+    types: [labeled, opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
Restrict compatibility workflows to really run only if the `integration` label is present (and on push to master). Tested in #505 