### PR TITLE
Limit the timeout for windows workflows

### DIFF
--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -47,7 +47,7 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: ${{matrix.test_timeout}}
+      timeout-minutes: ${{ fromJSON(matrix.test_timeout) }}
       run: |
         cd ../pyiron_atomistics
         python -m unittest discover tests/

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -47,7 +47,7 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: ${{ fromJSON(matrix.test_timeout) }}
+      timeout-minutes: 30
       run: |
         cd ../pyiron_atomistics
         python -m unittest discover tests/

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ 3.9 ]
-        test_timeout: 30 # this allows only 10 minutes for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ 3.9 ]
-        test_timeout: 10 # this allows only 10 minutes for the test step to be completed.
+        test_timeout: 30 # this allows only 10 minutes for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ 3.9 ]
+        test_timeout: 10 # this allows only 10 minutes for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2
@@ -46,6 +47,7 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
+      timeout-minutes: ${{matrix.test_timeout}}
       run: |
         cd ../pyiron_atomistics
         python -m unittest discover tests/

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,4 +35,5 @@ jobs:
         pip install --no-deps .
     - name: Tests
       shell: bash -l {0}
+      timeout-minutes: 30
       run: python -m unittest discover test_benchmarks

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9]
+        test_timeout: 30 # this allows only 30 minutes at maximum for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2
@@ -35,4 +36,5 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
+      timeout-minutes: ${{matrix.test_timeout}}
       run: coverage run --omit pyiron/_version.py -m unittest discover tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,8 +17,6 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9]
-        test_timeout:
-          - 30 # this allows only 30 minutes at maximum for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9]
-        test_timeout: 30 # this allows only 30 minutes at maximum for the test step to be completed.
+        test_timeout:
+          - 30 # this allows only 30 minutes at maximum for the test step to be completed.
 
     steps:
     - uses: actions/checkout@v2
@@ -36,5 +37,5 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: ${{ fromJSON(matrix.test_timeout) }}
+      timeout-minutes: 30
       run: coverage run --omit pyiron/_version.py -m unittest discover tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -36,5 +36,5 @@ jobs:
         pip install --no-deps .
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: ${{matrix.test_timeout}}
+      timeout-minutes: ${{ fromJSON(matrix.test_timeout) }}
       run: coverage run --omit pyiron/_version.py -m unittest discover tests


### PR DESCRIPTION
The purpose is to limit the timeout for windows workflows. The default value is 360 minutes. I first wanted to limit only windows timeout, but does it make sense that any of the tests take six hours to finish?!
So I limited all the tests to 30 minutes at maximum. As far as I checked, our tests finish in one or two minutes, so this timeout is even too long, but I wanted to stay on the safe side.