### PR TITLE
Refresh job status while waiting on project

### DIFF
--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -216,6 +216,7 @@ def wait_for_jobs(project, interval_in_s=5, max_iterations=100, recursive=True):
     finished = False
     for _ in range(max_iterations):
         project.update_from_remote(recursive=True)
+        project.refresh_job_status()
         df = project.job_table(recursive=recursive)
         if all(df.status.isin(job_status_finished_lst)):
             finished = True


### PR DESCRIPTION
I've noticed that `wait_for_jobs` fails with an error if a job crashes on the queue and the job status is not updated from `running`. I'm calling `refresh_job_status` now inside the waiting loop, which should work, but there might be better ways of doing it.