### PR TITLE
Fix bug when writing empty FlattenedStorage

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -150,8 +150,10 @@ class FlattenedStorage(HasHDF):
             num_elements (int): pre-allocation for per elements arrays
         """
         # tracks allocated versed as yet used number of chunks/elements
-        self._num_chunks_alloc = self.num_chunks = num_chunks
-        self._num_elements_alloc = self.num_elements = num_elements
+        self._num_chunks_alloc = num_chunks
+        self._num_elements_alloc = num_elements
+        self.num_chunks = 0
+        self.num_elements = 0
         # store the starting index for properties with unknown length
         self.current_element_index = 0
         # store the index for properties of known size, stored at the same index as the chunk

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -271,6 +271,21 @@ class TestFlattenedStorage(TestWithProject):
 
         self.assertEqual(store.has_array("missing"), None, "has_array does not return None for nonexisting array.")
 
+    def test_hdf_empty(self):
+        """Writing an empty storage should result in an empty storage when reading."""
+        store = FlattenedStorage()
+        hdf = self.project.create_hdf(self.project.path, "empty")
+        store.to_hdf(hdf, "empty")
+        store_read = hdf["empty"].to_object()
+        self.assertEqual(len(store), len(store_read),
+                         "Length of empty storage not equal after writing/reading!")
+
+        store = FlattenedStorage(num_chunks=5, num_elements=10)
+        hdf = self.project.create_hdf(self.project.path, "empty")
+        store.to_hdf(hdf, "empty")
+        store_read = hdf["empty"].to_object()
+        self.assertEqual(len(store), len(store_read),
+                         "Length of empty storage not equal after writing/reading!")
 
     def test_hdf_chunklength_one(self):
         """Reading a storage with all chunks of length one should give back exactly what was written!"""


### PR DESCRIPTION
When writing an empty storage and then reading it, it came out as length 1 (or whatever the pre-allocation was), because I initialized `num_chunks`/`num_elements` to the pre-allocation previously.