### PR TITLE
Fix integration workflows to run if needed

### DIFF
--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled, opened, synchronize]
+    types: [labeled, opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -13,10 +13,9 @@ on:
 jobs:
   build:
     if: |
-      ${{ github.event.type == 'PushEvent' ||
-          ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
-       }}
-
+      github.event_name == 'push' ||
+      ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
+    
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -13,10 +13,9 @@ on:
 jobs:
   build:
     if: |
-      ${{ github.event.type == 'PushEvent' ||
-          ( github.event.type == 'PullRequestEvent'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
-       }}
-
+      github.event_name == 'push' ||
+      ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
+    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [labeled, opened, synchronize]
+    types: [labeled, opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Unittests
 
 on:
   push:


### PR DESCRIPTION
I hope I finally fixed all the bugs on when the workflows are executed! Some testing in https://github.com/niklassiemer/test_checkout/pull/6

Compatibility workflows correctly
- [x]  skipped if no integration label (a67d5db)
- [x] started on setting integration label
- [x] started on pushing to the PR if integration label is there (c6adc1f)
- [x] skipped on pushing to the PR if the integration label was removed (023aa26)
- [x] started on reopen of the PR if the integration label is there (2fb2f72)
- [x] started on merge with master, although the integration label was removed (6640f11)