### PR TITLE
Allow custom return codes

### DIFF
--- a/pyiron_base/job/executable.py
+++ b/pyiron_base/job/executable.py
@@ -85,7 +85,7 @@ class Executable(object):
     @accepted_return_codes.setter
     def accepted_return_codes(self, value):
         if not isinstance(value, list) or any(not isinstance(c, int) or c > 255 for c in value):
-            raise ValueError(f"accepted_return_codes must be a list of integers <= 255!")
+            raise ValueError("accepted_return_codes must be a list of integers <= 255!")
         self._accepted_return_codes = value
 
     @property

--- a/pyiron_base/job/executable.py
+++ b/pyiron_base/job/executable.py
@@ -73,6 +73,20 @@ class Executable(object):
         self._mpi = False
         if self._executable_lst:
             self.version = self.default_version
+        self._accepted_return_codes = [0]
+
+    @property
+    def accepted_return_codes(self):
+        """
+        list of int: accept all of the return codes in this list as the result of a successful run
+        """
+        return self._accepted_return_codes
+
+    @accepted_return_codes.setter
+    def accepted_return_codes(self, value):
+        if not isinstance(value, list) or any(not isinstance(c, int) or c > 255 for c in value):
+            raise ValueError(f"accepted_return_codes must be a list of integers <= 255!")
+        self._accepted_return_codes = value
 
     @property
     def version(self):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -735,7 +735,9 @@ class GenericJob(JobCore):
             ) as f_err:
                 f_err.write(out)
         except subprocess.CalledProcessError as e:
-            if not self.server.accept_crash:
+            if e.returncode in self.executable.accepted_return_codes:
+                pass
+            elif not self.server.accept_crash:
                 self._logger.warning("Job aborted")
                 self._logger.warning(e.output)
                 self.status.aborted = True

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -728,6 +728,7 @@ class GenericJob(JobCore):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
+                check=True
             ).stdout
             with open(
                 posixpath.join(self.project_hdf5.working_directory, "error.out"),


### PR DESCRIPTION
Some executables may use more then just return code 0, to signal
a successful run.  This change allows set additional return codes that
should be accepted as successful.

@s4b7r Please give this a try if it resolves #496 for you.  You should be able to set the custom return codes simply by
```python
class ToyBashJob(GenericJob):
    def __init__(self, project, job_name):
        super().__init__(project, job_name) 
        self.input = GenericParameters(table_name="input")
        self.input['input_energy'] = 100
        self.executable = "cat input > output"
        self.executable.accepted_return_codes += [1,2,3]
...
```