### PR TITLE
Disable `project_check_enable` and retain `root_path`/`project_path`

### DIFF
--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Setup
       shell: bash -l {0}
       run: |
-        python .ci_support/pyironconfig.py
         pip install --no-deps .
         conda env update --name test --file .ci_support/environment-notebooks.yml
     - name: Test

--- a/pyiron_base/database/manager.py
+++ b/pyiron_base/database/manager.py
@@ -212,17 +212,17 @@ class DatabaseManager(metaclass=Singleton):
         """
         full_path = full_path if full_path.endswith("/") else full_path + "/"
 
-        if not self.project_check_enabled:
-            return None
-
         for path in s.configuration["project_paths"]:
             if path in full_path:
                 return path
 
-        raise ValueError(
-            f"the current path {full_path} is not included in the .pyiron configuration 'project_paths': "
-            f"{s.configuration['project_paths']}"
-        )
+        if self.project_check_enabled:
+            raise ValueError(
+                f"the current path {full_path} is not included in the .pyiron configuration 'project_paths': "
+                f"{s.configuration['project_paths']}"
+            )
+        else:
+            return None
 
     def update(self):
         """

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -127,6 +127,8 @@ class Settings(metaclass=Singleton):
             self._update_from_dict(env_dict)
         elif file_dict is not None:
             self._update_from_dict(file_dict)
+        else:
+            self._configuration['project_check_enabled'] = False
 
         for k in ["CONDA_PREFIX", "CONDA_DIR"]:
             if k in os.environ.keys():

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -127,8 +127,6 @@ class Settings(metaclass=Singleton):
             self._update_from_dict(env_dict)
         elif file_dict is not None:
             self._update_from_dict(file_dict)
-        else:
-            self._configuration['project_check_enabled'] = False
 
         for k in ["CONDA_PREFIX", "CONDA_DIR"]:
             if k in os.environ.keys():
@@ -155,7 +153,7 @@ class Settings(metaclass=Singleton):
             "sql_type": "SQLite",
             "sql_user_key": None,
             "sql_database": None,
-            "project_check_enabled": True,
+            "project_check_enabled": False,
             "disable_database": False,
         })
 

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -19,9 +19,11 @@ class TestDatabaseManager(TestWithProject):
         self.assertEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
                          msg="Database manager should be initialized by settings.")
         self.dbm._database_is_disabled = True
-        self.assertNotEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
-                            msg="But after that it should be independent from the settings")
-        self.dbm._database_is_disabled = False  # Re-enable it at the end of the test
+        try:
+            self.assertNotEqual(self.s.configuration["disable_database"], self.dbm.database_is_disabled,
+                                msg="But after that it should be independent from the settings")
+        finally:
+            self.dbm._database_is_disabled = False  # Re-enable it at the end of the test
 
     def test_file_top_path(self):
         # Store settings
@@ -30,24 +32,40 @@ class TestDatabaseManager(TestWithProject):
         disable_before = self.s.configuration["disable_database"]
 
         try:
-            with self.subTest('disable project_check_enabled'):
-                self.s.configuration["project_check_enabled"] = False
-                self.assertIs(self.dbm.top_path(self.project_path + "/test"), None)
+            new_root_path = self.s.convert_path_to_abs_posix(os.getcwd())
+            self.s.configuration["project_check_enabled"] = True
+            self.s.configuration["project_paths"] = [new_root_path]
+            self.s.configuration["disable_database"] = False
 
-            with self.subTest('enable project_check_enabled'):
-                new_root_path = self.s.convert_path_to_abs_posix(os.getcwd())
-                self.s.configuration["project_check_enabled"] = True
-                self.s.configuration["project_paths"] = [new_root_path]
+            with self.subTest('enabled'):
                 # Otherwise has the chance to override project_check_enabled... Thus:
-                self.s.configuration["disable_database"] = False
                 self.assertTrue(self.dbm.top_path(self.project_path + "/test") in self.project_path)
 
-            with self.subTest("test Project.root_path and Project.project_path for a new sub-Project"):
+            with self.subTest("enabled: test Project.root_path and Project.project_path for a new sub-Project"):
                 sub_pr = self.project.open('sub_project')
                 self.assertEqual(sub_pr.root_path, new_root_path + '/')
                 self.assertEqual(sub_pr.project_path,
                                  os.path.join(os.path.relpath(self.project_path, os.getcwd()),
                                               'sub_project').replace("\\", '/') + '/')
+            with self.subTest("enabled: path not in config"):
+                self.assertRaises(ValueError, self.dbm.top_path, os.path.abspath('..'))
+
+            self.s.configuration["project_check_enabled"] = False
+
+            with self.subTest('disabled'):
+                # Otherwise has the chance to override project_check_enabled... Thus:
+                self.assertTrue(self.dbm.top_path(self.project_path + "/test") in self.project_path)
+
+            with self.subTest("disabled: test Project.root_path and Project.project_path for a new sub-Project"):
+                sub_pr = self.project.open('sub_project')
+                self.assertEqual(sub_pr.root_path, new_root_path + '/')
+                self.assertEqual(sub_pr.project_path,
+                                 os.path.join(os.path.relpath(self.project_path, os.getcwd()),
+                                              'sub_project').replace("\\", '/') + '/')
+            with self.subTest("disabled: path not in config"):
+                self.assertIs(self.dbm.top_path(os.path.abspath('..')), None,
+                              msg="Non-None top_path for path not in the config and project_check_enabled is False.")
+
         finally:
             # Put things back the way you found them
             self.s.configuration["project_check_enabled"] = check_before

--- a/tests/database/test_manager.py
+++ b/tests/database/test_manager.py
@@ -66,6 +66,12 @@ class TestDatabaseManager(TestWithProject):
                 self.assertIs(self.dbm.top_path(os.path.abspath('..')), None,
                               msg="Non-None top_path for path not in the config and project_check_enabled is False.")
 
+            self.s.configuration["project_paths"] = []
+            with self.subTest("test setting for old 'project_check_enabled is False' behavior"):
+                sub_pr = self.project.open('sub_project')
+                self.assertIs(sub_pr.root_path, None)
+                self.assertEqual(sub_pr.project_path, self.project_path + '/sub_project/')
+
         finally:
             # Put things back the way you found them
             self.s.configuration["project_check_enabled"] = check_before


### PR DESCRIPTION
Following our discussions in the meeting, I now removed the setup of our `.pyiron` in the setup. This also tests the intended use case `conda install pyiron` and running notebooks.