### PR TITLE
Extending tests to run one unittest suite for the oldest supported python

### DIFF
--- a/.github/workflows/old_python.yml
+++ b/.github/workflows/old_python.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test python3.6
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        python-version: 3.6
+        mamba-version: "0.17.0"
+        channels: conda-forge
+        channel-priority: strict
+        auto-update-conda: true  
+        environment-file: .ci_support/environment.yml
+    - name: Setup
+      shell: bash -l {0}
+      run: |
+        python .ci_support/pyironconfig.py
+        pip install --no-deps .
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 30
+      run: coverage run --omit pyiron/_version.py -m unittest discover tests

--- a/.github/workflows/old_python.yml
+++ b/.github/workflows/old_python.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test python3.6
+name: Test python3.7
 
 on:
   push:
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
         mamba-version: "0.17.0"
         channels: conda-forge
         channel-priority: strict


### PR DESCRIPTION
In https://github.com/pyiron/pyiron_base/pull/547 we need to fix broken python3.6 support. We have to do this since we were only alerted on the unittests of other repositories running older python version:
- pyiron/pyiron_gui#93
- pyiron/pyiron_contrib#270

Thus, I now add one unit test run with python3.6 on a linux machine to check for this type of errors.