### PR TITLE
convert missing_ok to try/except

### DIFF
--- a/tests/state/test_settings.py
+++ b/tests/state/test_settings.py
@@ -36,7 +36,10 @@ class TestSettings(TestCase):
         s.update()
 
     def setUp(self) -> None:
-        self.default_loc.unlink(missing_ok=True)
+        try:
+            self.default_loc.unlink()
+        except FileNotFoundError:
+            pass
         for k, _ in self.env.items():
             if "PYIRON" in k:
                 self.env.pop(k)


### PR DESCRIPTION
The option missing_ok is a python-3.8 feature internally using try/except.