### PR TITLE
Do not show job remove progress bar during unit tests

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -85,7 +85,7 @@ class TestWithCleanProject(TestWithProject, ABC):
     Tests that start and remove a project for their suite, and remove jobs from the project for each test.
     """
     def tearDown(self):
-        self.project.remove_jobs_silently(recursive=True)
+        self.project.remove_jobs_silently(recursive=True, progress=False)
 
 
 class ToyJob(PythonTemplateJob):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1000,10 +1000,9 @@ class Project(ProjectPath, HasGroups):
         if not isinstance(recursive, bool):
             raise ValueError('recursive must be a boolean')
         if not self.view_mode:
-            if progress:
-                job_id_lst = tqdm(self.get_job_ids(recursive=recursive))
-            else:
-                job_id_lst = self.get_job_ids(recursive=recursive)
+            job_id_lst = self.get_job_ids(recursive=recursive)
+            if progress and len(job_id_lst) > 0:
+                job_id_lst = tqdm(job_id_lst)
             for job_id in job_id_lst:
                 if job_id not in self.get_job_ids(recursive=recursive):
                     continue


### PR DESCRIPTION
I like the feature for interactive use, but it clutters the output of the unit tests a lot, so I disable it in `TestWithCleanProject`.