### PR TITLE
Store pandas dataframe as single object in data frame 

### DIFF
--- a/pyiron_base/table/datamining.py
+++ b/pyiron_base/table/datamining.py
@@ -614,7 +614,7 @@ class TableJob(GenericJob):
     def _save_output(self):
         with self.project_hdf5.open("output") as hdf5_output:
             df = self.pyiron_table._df
-            cont = DataContainer(df.to_dict())
+            cont = DataContainer(df)
             cont.to_hdf(hdf=hdf5_output, group_name="table")
 
     def to_hdf(self, hdf=None, group_name=None):

--- a/pyiron_base/table/datamining.py
+++ b/pyiron_base/table/datamining.py
@@ -613,9 +613,7 @@ class TableJob(GenericJob):
 
     def _save_output(self):
         with self.project_hdf5.open("output") as hdf5_output:
-            df = self.pyiron_table._df
-            cont = DataContainer(df)
-            cont.to_hdf(hdf=hdf5_output, group_name="table")
+            self.pyiron_table._df.to_hdf(hdf5_output, "table")
 
     def to_hdf(self, hdf=None, group_name=None):
         """
@@ -692,8 +690,7 @@ class TableJob(GenericJob):
         if hdf_version=="0.3.0":
             with self.project_hdf5.open("output") as hdf5_output:
                 if "table" in hdf5_output.list_groups():
-                    data = hdf5_output["table"].to_object().to_builtin()
-                    self._pyiron_table._df = pandas.DataFrame(data)
+                    self._pyiron_table._df = pandas.read_hdf(hdf5_output, "table")
         else:
             pyiron_table = os.path.join(self.working_directory, "pyirontable.csv")
             if os.path.exists(pyiron_table):

--- a/pyiron_base/table/datamining.py
+++ b/pyiron_base/table/datamining.py
@@ -613,7 +613,7 @@ class TableJob(GenericJob):
 
     def _save_output(self):
         with self.project_hdf5.open("output") as hdf5_output:
-            self.pyiron_table._df.to_hdf(hdf5_output, "table")
+            self.pyiron_table._df.to_hdf(hdf5_output.file_name, hdf5_output.h5_path + "/table")
 
     def to_hdf(self, hdf=None, group_name=None):
         """
@@ -690,7 +690,7 @@ class TableJob(GenericJob):
         if hdf_version=="0.3.0":
             with self.project_hdf5.open("output") as hdf5_output:
                 if "table" in hdf5_output.list_groups():
-                    self._pyiron_table._df = pandas.read_hdf(hdf5_output, "table")
+                    self._pyiron_table._df = pandas.read_hdf(hdf5_output.file_name, hdf5_output.h5_path + "/table")
         else:
             pyiron_table = os.path.join(self.working_directory, "pyirontable.csv")
             if os.path.exists(pyiron_table):


### PR DESCRIPTION
Converting to dictionary is terribly slow: 
```
from pyiron_base import DataContainer
from pyiron_base import Project
import pandas
with open("test.csv", "w") as f:
    f.write(",a,b\n")
    for i in range(100000): 
        f.write(str(i) + ",1,2\n")
df = pandas.read_csv("test.csv", index_col=0)
pr = Project(".")
hdf = pr.create_hdf(".", "test")
dc = DataContainer(df.to_dict())
dc.to_hdf(hdf)
```
This takes forever, while with a small change it is in the order of ms: 
```
dc = DataContainer(df)
```