### PR TITLE
Create job name including rounding and special character replacement

### DIFF
--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -122,9 +122,10 @@ _special_symbol_replacements = {
 }
 
 
-def _get_safe_job_name(name, ndigits=8, special_symbols={}):
+def _get_safe_job_name(name, ndigits=8, special_symbols=None):
     d_special_symbols = _special_symbol_replacements.copy()
-    d_special_symbols.update(special_symbols)
+    if special_symbols is not None:
+        d_special_symbols.update(special_symbols)
     def round_(value, ndigits=ndigits):
         if isinstance(value, float) and ndigits is not None:
             return round(value, ndigits=ndigits)

--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -123,7 +123,7 @@ _special_symbol_replacements = {
 }
 
 
-def _get_safe_job_name(name, ndigits=8, special_symbols=None):
+def _get_safe_job_name(name: str, ndigits: Union[int, None] = 8, special_symbols: Union[Dict, None] = None):
     d_special_symbols = _special_symbol_replacements.copy()
     if special_symbols is not None:
         d_special_symbols.update(special_symbols)

--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -122,7 +122,8 @@ _special_symbol_replacements = {
 }
 
 
-def _get_safe_job_name(name, ndigits=8):
+def _get_safe_job_name(name, ndigits=8, special_symbols={}):
+    _special_symbol_replacements.update(special_symbols)
     def round_(value, ndigits=ndigits):
         if isinstance(value, float) and ndigits is not None:
             return round(value, ndigits=ndigits)

--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -123,7 +123,8 @@ _special_symbol_replacements = {
 
 
 def _get_safe_job_name(name, ndigits=8, special_symbols={}):
-    _special_symbol_replacements.update(special_symbols)
+    d_special_symbols = _special_symbol_replacements.copy()
+    d_special_symbols.update(special_symbols)
     def round_(value, ndigits=ndigits):
         if isinstance(value, float) and ndigits is not None:
             return round(value, ndigits=ndigits)
@@ -133,7 +134,7 @@ def _get_safe_job_name(name, ndigits=8, special_symbols={}):
         job_name = '_'.join([str(nn) for nn in name_rounded])
     else:
         job_name = name
-    for k, v in _special_symbol_replacements.items():
+    for k, v in d_special_symbols.items():
         job_name = job_name.replace(k, v)
     _is_valid_job_name(job_name=job_name)
     return job_name

--- a/pyiron_base/job/util.py
+++ b/pyiron_base/job/util.py
@@ -11,6 +11,7 @@ from pyiron_base.generic.util import static_isinstance
 import tarfile
 import stat
 import shutil
+from typing import Union, Dict
 
 __author__ = "Jan Janssen"
 __copyright__ = (

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -31,6 +31,7 @@ from pyiron_base.database.jobtable import (
 from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.generic.filedata import load_file
 from pyiron_base.generic.util import deprecate
+from pyiron_base.job.util import _special_symbol_replacements, _get_safe_job_name
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.job.jobtype import JobType, JobTypeChoice, JobFactory
 from pyiron_base.server.queuestatus import (
@@ -1593,6 +1594,30 @@ class Creator:
     @property
     def job(self):
         return self._job_factory
+
+    def job_name(self, job_name, ndigits=8, special_symbols={}):
+        """
+        Creation of job names with special symbol replacement and rounding of floating numbers
+
+        Args:
+            job_name (str/list): Job name
+            ndigits (int/None): Decimal digits to round floats to a given precision. `None` if
+                no rounding should be performed.
+            special_symbols (dict): Replacement of special symbols.
+
+        Returns:
+            (str): Job name
+
+        Default `special_symbols`: default_special_symbols_to_be_replaced
+        """
+        return _get_safe_job_name(
+            name=job_name, ndigits=ndigits, special_symbols=special_symbols
+        )
+
+    job_name.__doc__ = job_name.__doc__.replace(
+        'default_special_symbols_to_be_replaced',
+        str(_special_symbol_replacements)
+    )
 
     def table(self, job_name="table", delete_existing_job=False):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1595,7 +1595,8 @@ class Creator:
     def job(self):
         return self._job_factory
 
-    def job_name(self, job_name, ndigits=8, special_symbols={}):
+    @staticmethod
+    def job_name(job_name, ndigits=8, special_symbols=None):
         """
         Creation of job names with special symbol replacement and rounding of floating numbers
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -47,7 +47,7 @@ from pyiron_base.server.queuestatus import (
 from pyiron_base.job.external import Notebook
 from pyiron_base.project.data import ProjectData
 from pyiron_base.archiving import import_archive, export_archive
-from typing import Generator
+from typing import Generator, Union, Dict
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -1594,8 +1594,6 @@ class Creator:
     @property
     def job(self):
         return self._job_factory
-
-
 
     @staticmethod
     def job_name(

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1595,8 +1595,12 @@ class Creator:
     def job(self):
         return self._job_factory
 
+
+
     @staticmethod
-    def job_name(job_name, ndigits=8, special_symbols=None):
+    def job_name(
+        job_name: str, ndigits: Union[int, None] = 8, special_symbols: Union[Dict, None] = None
+    ):
         """
         Creation of job names with special symbol replacement and rounding of floating numbers
 

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -56,6 +56,12 @@ class TestProjectData(PyironTestCase):
         except:
             self.fail("Iterating over empty project with set status flag should not raise exception.")
 
+    def test_create_job_name(self):
+        self.assertEqual(self.project.create.job_name(['job', 0.1]), 'job_0d1')
+        self.assertEqual(self.project.create.job_name(['job', 0.1], special_symbols={'.': 'c'}), 'job_0c1')
+        self.assertEqual(self.project.create.job_name(['job', 1.0000000000005]), 'job_1d0')
+        self.assertEqual(self.project.create.job_name(['job', 1.0000000000005], ndigits=None), 'job_1d0000000000005')
+
 
 class TestProjectOperations(TestWithFilledProject):
 


### PR DESCRIPTION
Following today's discussion, I implemented this function `pr.create.job_name` that does the job name replacement as in `pr.create.job.MyJob(job_name=blablabla)` including all the options, i.e. number of digits and job replacement dictionary