### PR TITLE
Use srun to submit jobs to a separate node rather than to the background 

### DIFF
--- a/pyiron_base/server/runmode.py
+++ b/pyiron_base/server/runmode.py
@@ -25,6 +25,7 @@ run_mode_lst = [
     "manual",
     "thread",
     "worker",
+    "srun",
     "interactive",
     "interactive_non_modal",
 ]


### PR DESCRIPTION
It is a SLURM specific feature - but a powerful one so we should think about a way to incorporate the ability to handle multiple jobs within one queue allocation. Basically separate the `srun` part from the `sbatch` part - but that is a more fundamental change, here it is more like a workaround to test the hypothesis.  