### PR TITLE
Add copy, split and merge methods to FlattenedStorage

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -550,29 +550,29 @@ class FlattenedStorage(HasHDF):
                 split._per_chunk_arrays[k] = np.copy(split._per_chunk_arrays[k])
         return split
 
-    def merge(self, store: "FlattenedStorage") -> "FlattenedStorage":
+    def join(self, store: "FlattenedStorage") -> "FlattenedStorage":
         """
         Merge given storage into this one.
 
         `self` and `store` may not share any arrays.  Arrays defined on `stores` are copied and then added to `self`.
 
         Args:
-            store (:class:`.FlattenedStorage`): storage to merge
+            store (:class:`.FlattenedStorage`): storage to join
 
         Returns:
             :class:`.FlattenedStorage`: self
         """
         if len(self) != len(store):
-            raise ValueError("FlattenedStorages to be merged have to be of the same length!")
+            raise ValueError("FlattenedStorages to be joined have to be of the same length!")
         if (self["length"] != store["length"]).any():
-            raise ValueError("FlattenedStorages to be merged have to have same length chunks everywhere!")
+            raise ValueError("FlattenedStorages to be joined have to have same length chunks everywhere!")
         shared_elements = set(self._per_element_arrays).intersection(store._per_element_arrays)
         shared_chunks = set(self._per_chunk_arrays).intersection(store._per_chunk_arrays)
         shared_chunks.remove("start_index")
         shared_chunks.remove("length")
         shared_chunks.remove("identifier")
         if len(shared_elements) > 0 or len(shared_chunks) > 0:
-            raise ValueError("FlattenedStorages to be merged may not have any common arrays!")
+            raise ValueError("FlattenedStorages to be joined may not have any common arrays!")
 
         for k, a in store._per_element_arrays.items():
             self._per_element_arrays[k] = a

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -122,6 +122,31 @@ class FlattenedStorage(HasHDF):
 
     Arrays may be of more complicated shape, too, see :method:`.add_array` for details.
 
+    Use :method:`.copy` to obtain a deep copy of the storage, for shallow copies using the builting `copy.copy` is
+    sufficient.
+
+    >>> copy = store.copy()
+    >>> copy["even", 0]
+    array([0])
+    >>> copy["even", 1]
+    array([4, 6])
+    >>> copy["even"]
+    array([0, 4, 6, 8, 10, 12])
+
+    Storages can be :method:`.split` and :method:`.join` again as long as their internal chunk structure is consistent,
+    i.e. same number of chunks and same chunk lengths.  If this is not the case a `ValueError` is raised.
+
+    >>> even = store.split(["even"])
+    >>> bool(even.has_array("even"))
+    True
+    >>> bool(even.has_array("odd"))
+    False
+    >>> odd = store.split(["odd"])
+
+    :method:`.join` adds new arrays to the storage it is called on in-place.  To leave it unchanged, simply call copy
+    before join.
+    >>> both = even.copy().join(odd)
+
     Chunks may be given string names, either by passing `identifier` to :method:`.add_chunk` or by setting to the
     special per chunk array "identifier"
 

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -18,6 +18,7 @@ __status__ = "production"
 __date__ = "Jul 16, 2020"
 
 
+import copy
 from typing import Callable
 
 import numpy as np
@@ -202,6 +203,15 @@ class FlattenedStorage(HasHDF):
 
     def __len__(self):
         return self.current_chunk_index
+
+    def copy(self):
+        """
+        Return a deep copy of the storage.
+
+        Returns:
+            :class:`.FlattenedStorage`: copy of self
+        """
+        return copy.deepcopy(self)
 
     def find_chunk(self, identifier):
         """

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -325,11 +325,35 @@ class TestFlattenedStorage(TestWithProject):
         self.assertTrue((both_store["even"] == even_store["even"]).all(),
                         "Per element array 'even' not present after merge!")
         self.assertTrue((both_store["odd"] == odd_store["odd"]).all(),
-                        "Per element array 'odd' not present after merge!")
+                        "Per chunk array 'odd' not present after merge!")
         self.assertTrue((both_store["even_sum"] == even_store["even_sum"]).all(),
                         "Per element array 'even_sum' not present after merge!")
         self.assertTrue((both_store["odd_sum"] == odd_store["odd_sum"]).all(),
-                        "Per element array 'odd_sum' not present after merge!")
+                        "Per chunk array 'odd_sum' not present after merge!")
+
+    def test_split(self):
+        """split deep copy all the selected arrays to the new storage."""
+        store = FlattenedStorage(even=self.even, odd=self.odd, even_sum = self.even_sum, odd_sum=self.odd_sum)
+        odd_store = store.split(("odd", "odd_sum"))
+
+        self.assertTrue("odd" in odd_store._per_element_arrays,
+                        "Per element array 'odd' not present after split!")
+        self.assertTrue((store["odd"] == odd_store["odd"]).all(),
+                        "Per element array 'odd' incorrectly copied after split!")
+        self.assertTrue("odd_sum" in odd_store._per_chunk_arrays,
+                        "Per chunk array 'odd_sum' not present after split!")
+        self.assertTrue((store["odd_sum"] == odd_store["odd_sum"]).all(),
+                        "Per chunk array 'odd_sum' incorrectly copied after split!")
+
+        odd_before = odd_store["odd"]
+        odd_sum_before = odd_store["odd_sum"]
+        store["odd", 2] *= 2
+        store["odd_sum", 2] *= 2
+        self.assertTrue((odd_before == odd_store["odd"]).all(),
+                        f"Per element array changed in copy when original is!")
+        self.assertTrue((odd_sum_before == odd_store["odd_sum"]).all(),
+                        f"Per chunk array changed in copy when original is!")
+
 
     def test_getitem_setitem(self):
         """Using __getitem__/__setitem__ should be equivalent to using get_array/set_array."""
@@ -432,8 +456,8 @@ class TestFlattenedStorage(TestWithProject):
         even_before = copy["even"]
         even_sum_before = copy["even_sum"]
         store["even", 2] *= 2
-        store["even", 2] *= 2
+        store["even_sum", 2] *= 2
         self.assertTrue((even_before == copy["even"]).all(),
                         f"Per element array changed in copy when original is!")
         self.assertTrue((even_sum_before == copy["even_sum"]).all(),
-                        f"Per element array changed in copy when original is!")
+                        f"Per chunk array changed in copy when original is!")

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -405,3 +405,21 @@ class TestFlattenedStorage(TestWithProject):
             else:
                 self.assertEqual(v, read._fill_values[k], "value read from hdf differs from original value")
         self.assertEqual(read._fill_values.keys(), store._fill_values.keys(), "keys read from hdf differ from original keys")
+
+    def test_copy(self):
+        """copy should give the same data and be a deep copy."""
+        store = FlattenedStorage(even=self.even, odd=self.odd, even_sum=self.even_sum, odd_sum=self.odd_sum)
+        copy  = store.copy()
+
+        for k in "even", "odd", "even_sum", "odd_sum":
+            with self.subTest(k=k):
+                self.assertTrue((store[k] == copy[k]).all(), f"Array {k} not equal after copy!")
+
+        even_before = copy["even"]
+        even_sum_before = copy["even_sum"]
+        store["even", 2] *= 2
+        store["even", 2] *= 2
+        self.assertTrue((even_before == copy["even"]).all(),
+                        f"Per element array changed in copy when original is!")
+        self.assertTrue((even_sum_before == copy["even_sum"]).all(),
+                        f"Per element array changed in copy when original is!")

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -373,9 +373,9 @@ class TestFlattenedStorage(TestWithProject):
         store["odd", 2] *= 2
         store["odd_sum", 2] *= 2
         self.assertTrue((odd_before == odd_store["odd"]).all(),
-                        f"Per element array changed in copy when original is!")
+                        "Per element array changed in copy when original is!")
         self.assertTrue((odd_sum_before == odd_store["odd_sum"]).all(),
-                        f"Per chunk array changed in copy when original is!")
+                        "Per chunk array changed in copy when original is!")
 
 
     def test_getitem_setitem(self):

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -317,19 +317,19 @@ class TestFlattenedStorage(TestWithProject):
             self.assertEqual(v.dtype, some_sub._per_element_arrays[k].dtype,
                             f"Element array {k} present in sample storage, but wrong dtype!")
 
-    def test_merge(self):
-        """All arrays should be present in merged storage."""
+    def test_join(self):
+        """All arrays should be present in joined storage."""
         even_store = FlattenedStorage(even=self.even, even_sum=self.even_sum)
         odd_store = FlattenedStorage(odd=self.odd, odd_sum=self.odd_sum)
-        both_store = even_store.copy().merge(odd_store)
+        both_store = even_store.copy().join(odd_store)
         self.assertTrue((both_store["even"] == even_store["even"]).all(),
-                        "Per element array 'even' not present after merge!")
+                        "Per element array 'even' not present after join!")
         self.assertTrue((both_store["odd"] == odd_store["odd"]).all(),
-                        "Per chunk array 'odd' not present after merge!")
+                        "Per chunk array 'odd' not present after join!")
         self.assertTrue((both_store["even_sum"] == even_store["even_sum"]).all(),
-                        "Per element array 'even_sum' not present after merge!")
+                        "Per element array 'even_sum' not present after join!")
         self.assertTrue((both_store["odd_sum"] == odd_store["odd_sum"]).all(),
-                        "Per chunk array 'odd_sum' not present after merge!")
+                        "Per chunk array 'odd_sum' not present after join!")
 
     def test_split(self):
         """split deep copy all the selected arrays to the new storage."""

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -317,6 +317,20 @@ class TestFlattenedStorage(TestWithProject):
             self.assertEqual(v.dtype, some_sub._per_element_arrays[k].dtype,
                             f"Element array {k} present in sample storage, but wrong dtype!")
 
+    def test_merge(self):
+        """All arrays should be present in merged storage."""
+        even_store = FlattenedStorage(even=self.even, even_sum=self.even_sum)
+        odd_store = FlattenedStorage(odd=self.odd, odd_sum=self.odd_sum)
+        both_store = even_store.copy().merge(odd_store)
+        self.assertTrue((both_store["even"] == even_store["even"]).all(),
+                        "Per element array 'even' not present after merge!")
+        self.assertTrue((both_store["odd"] == odd_store["odd"]).all(),
+                        "Per element array 'odd' not present after merge!")
+        self.assertTrue((both_store["even_sum"] == even_store["even_sum"]).all(),
+                        "Per element array 'even_sum' not present after merge!")
+        self.assertTrue((both_store["odd_sum"] == odd_store["odd_sum"]).all(),
+                        "Per element array 'odd_sum' not present after merge!")
+
     def test_getitem_setitem(self):
         """Using __getitem__/__setitem__ should be equivalent to using get_array/set_array."""
         store = FlattenedStorage(even=self.even, odd=self.odd, mylen=[1, 2, 3])

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -355,7 +355,7 @@ class TestFlattenedStorage(TestWithProject):
                                 "left array not the same after join.")
 
     def test_split(self):
-        """split deep copy all the selected arrays to the new storage."""
+        """split should deep copy all the selected arrays to the new storage."""
         store = FlattenedStorage(even=self.even, odd=self.odd, even_sum = self.even_sum, odd_sum=self.odd_sum)
         odd_store = store.split(("odd", "odd_sum"))
 
@@ -481,6 +481,6 @@ class TestFlattenedStorage(TestWithProject):
         store["even", 2] *= 2
         store["even_sum", 2] *= 2
         self.assertTrue((even_before == copy["even"]).all(),
-                        f"Per element array changed in copy when original is!")
+                        "Per element array changed in copy when original is!")
         self.assertTrue((even_sum_before == copy["even_sum"]).all(),
-                        f"Per chunk array changed in copy when original is!")
+                        "Per chunk array changed in copy when original is!")


### PR DESCRIPTION
I've added some methods to split and merge FlattenedStorages that share the same chunk structure.  For now I'm deep-copying all the arrays involved for simplicity.  If we find later that this is a performance bottleneck we can address that separately. 