### PR TITLE
Worker: Use Pool rather than Threadpool

### DIFF
--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -235,7 +235,7 @@ class WorkerJob(PythonTemplateJob):
         working_directory = self.working_directory
         log_file = os.path.join(working_directory, "worker.log")
         file_memory_lst = []
-        with ThreadPool(
+        with Pool(
                 processes=int(self.server.cores / self.cores_per_job)
         ) as pool:
             while True:

--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -236,7 +236,7 @@ class WorkerJob(PythonTemplateJob):
         log_file = os.path.join(working_directory, "worker.log")
         file_memory_lst = []
         with Pool(
-                processes=int(self.server.cores / self.cores_per_job)
+            processes=int(self.server.cores / self.cores_per_job)
         ) as pool:
             while True:
                 file_lst = [

--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -7,7 +7,7 @@ Worker Class to execute calculation in an asynchronous way
 import os
 import time
 from datetime import datetime
-from multiprocessing.pool import ThreadPool
+from multiprocessing import Pool
 import numpy as np
 from pyiron_base.state import state
 from pyiron_base.job.template import PythonTemplateJob
@@ -171,7 +171,7 @@ class WorkerJob(PythonTemplateJob):
         self.project_hdf5.create_working_directory()
         log_file = os.path.join(self.working_directory, "worker.log")
         active_job_ids = []
-        with ThreadPool(
+        with Pool(
             processes=int(self.server.cores / self.cores_per_job)
         ) as pool:
             while True:


### PR DESCRIPTION
The Threadpool was causing resource unavailable issues most likely related to the internal process lock.