### PR TITLE
Grab watchdog lock before checking connection status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Fix race condition when talking to the database, this could result in cryptic error messages "connection closed" when
+  performing a lot of database queries in a row ([#636](https://github.com/pyiron/pyiron_base/pull/636))
 
 # pyiron_base-0.5.0
 - Create CHANGELOG.md ([#623](https://github.com/pyiron/pyiron_base/pull/623))

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -347,28 +347,28 @@ class AutorestoredConnection:
     def execute(self, *args, **kwargs):
         while True:
             try:
-                if self._conn is None or self._conn.closed:
-                    self._conn = self.engine.connect()
-                    if self._timeout > 0:
-                        # only log reconnections when we keep the connection alive between requests otherwise we'll spam
-                        # the log
-                        if self._conn is None:
-                            self._logger.info(
-                                "Reconnecting to DB; connection not existing."
-                            )
-                        else:
-                            self._logger.info("Reconnecting to DB; connection closed.")
-                        if self._watchdog is not None:
-                            # in case connection is dead, but watchdog is still up, something else killed the connection,
-                            # make the watchdog quit, then making a new one
-                            self._watchdog.kill()
-                        self._watchdog = ConnectionWatchDog(
-                            self._conn, self._lock, timeout=self._timeout
-                        )
-                        self._watchdog.start()
-                if self._timeout > 0:
-                    self._watchdog.kick()
                 with self._lock:
+                    if self._conn is None or self._conn.closed:
+                        self._conn = self.engine.connect()
+                        if self._timeout > 0:
+                            # only log reconnections when we keep the connection alive between requests otherwise we'll spam
+                            # the log
+                            if self._conn is None:
+                                self._logger.info(
+                                    "Reconnecting to DB; connection not existing."
+                                )
+                            else:
+                                self._logger.info("Reconnecting to DB; connection closed.")
+                            if self._watchdog is not None:
+                                # in case connection is dead, but watchdog is still up, something else killed the connection,
+                                # make the watchdog quit, then making a new one
+                                self._watchdog.kill()
+                            self._watchdog = ConnectionWatchDog(
+                                self._conn, self._lock, timeout=self._timeout
+                            )
+                            self._watchdog.start()
+                    if self._timeout > 0:
+                        self._watchdog.kick()
                     result = self._conn.execute(*args, **kwargs)
                     break
             except OperationalError as e:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -358,7 +358,9 @@ class AutorestoredConnection:
                                     "Reconnecting to DB; connection not existing."
                                 )
                             else:
-                                self._logger.info("Reconnecting to DB; connection closed.")
+                                self._logger.info(
+                                    "Reconnecting to DB; connection closed."
+                                )
                             if self._watchdog is not None:
                                 # in case connection is dead, but watchdog is still up, something else killed the connection,
                                 # make the watchdog quit, then making a new one


### PR DESCRIPTION
Before we first check whether the connection is alive, then kick the
watchdog and only then grab the lock to make the SQL query.  There's a
race condition in this as sketched below, where the watchdog acquires
the lock and closes the connection after we check that it's still alive,
but before we acquire the lock.

```
Main Thread                     Watchdog Thread
-----------                     ---------------

                                TIMER RUNS OUT
                                        |
                                        v
CHECK CONNECTION        ~       ACQUIRE LOCK
    |                                   |
    |                                   v
    |                           CLOSE CONNECTION
    |                                   |
    |                                   v
    |                           RELEASE LOCK
    |
    v
ACQUIRE LOCK
    |
    v
EXECUTE SQL QUERY
    |
    v
RELEASE LOCK
```

The solution is to protect also the checking of the connection with the
same lock, so that closing of the connection happens only before or
after we checked the connection *and* executed our query.

@prince-mathews Please check whether your issue from the meeting persist with this branch.