### PR TITLE
Script job support MPI run

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -737,6 +737,12 @@ class GenericJob(JobCore):
         if self.server.cores == 1 or not self.executable.mpi:
             executable = str(self.executable)
             shell = True
+        elif isinstance(self.executable.executable_path, list):
+            executable = self.executable.executable_path[:] + [
+                str(self.server.cores),
+                str(self.server.threads),
+            ]
+            shell = False
         else:
             executable = [
                 self.executable.executable_path,
@@ -745,6 +751,7 @@ class GenericJob(JobCore):
             ]
             shell = False
         try:
+            print(executable, shell)
             out = subprocess.run(
                 executable,
                 cwd=self.project_hdf5.working_directory,

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -751,7 +751,6 @@ class GenericJob(JobCore):
             ]
             shell = False
         try:
-            print(executable, shell)
             out = subprocess.run(
                 executable,
                 cwd=self.project_hdf5.working_directory,

--- a/pyiron_base/job/script.py
+++ b/pyiron_base/job/script.py
@@ -241,8 +241,10 @@ class ScriptJob(GenericJob):
         if isinstance(path, str):
             self._script_path = self._get_abs_path(path)
             self.executable = self._executable_command(
-                working_directory=self.working_directory, script_path=self._script_path,
-                enable_mpi4py=self._enable_mpi4py, cores=self.server.cores
+                working_directory=self.working_directory,
+                script_path=self._script_path,
+                enable_mpi4py=self._enable_mpi4py,
+                cores=self.server.cores,
             )
             if self._enable_mpi4py:
                 self.executable._mpi = True
@@ -254,8 +256,10 @@ class ScriptJob(GenericJob):
     def enable_mpi4py(self):
         if not self._enable_mpi4py:
             self.executable = self._executable_command(
-                working_directory=self.working_directory, script_path=self._script_path,
-                enable_mpi4py=True, cores=self.server.cores
+                working_directory=self.working_directory,
+                script_path=self._script_path,
+                enable_mpi4py=True,
+                cores=self.server.cores,
             )
             self.executable._mpi = True
         self._enable_mpi4py = True
@@ -263,8 +267,10 @@ class ScriptJob(GenericJob):
     def disable_mpi4py(self):
         if self._enable_mpi4py:
             self.executable = self._executable_command(
-                working_directory=self.working_directory, script_path=self._script_path,
-                enable_mpi4py=False, cores=self.server.cores
+                working_directory=self.working_directory,
+                script_path=self._script_path,
+                enable_mpi4py=False,
+                cores=self.server.cores,
             )
             self.executable._mpi = False
         self._enable_mpi4py = False
@@ -368,7 +374,9 @@ class ScriptJob(GenericJob):
         pass
 
     @staticmethod
-    def _executable_command(working_directory, script_path, enable_mpi4py=False, cores=1):
+    def _executable_command(
+        working_directory, script_path, enable_mpi4py=False, cores=1
+    ):
         """
         internal function to generate the executable command to either use jupyter or python
 


### PR DESCRIPTION
Based on our discussion I extended the script job class to support MPI4py to at least have a quick way to use pyiron for an high throughput study. 

```
import os
from pyiron_base import Project

script_py = """\
from mpi4py import MPI

comm = MPI.COMM_WORLD
size = comm.Get_size()
rank = comm.Get_rank()

print(size, rank)
"""

file_name = "test.py"
with open(file_name, "w") as f:
    f.writelines(script_py)

pr = Project("test")
job = pr.create.job.ScriptJob("script")
job.script_path = os.path.abspath(file_name)
job.server.cores = 2
job.enable_mpi4py()
job.run()
```