### PR TITLE
use dependabot token

### DIFF
--- a/.github/workflows/format_black.yml
+++ b/.github/workflows/format_black.yml
@@ -30,4 +30,5 @@ jobs:
     - name: push
       uses: ad-m/github-push-action@master
       with:
+        github_token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
         branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Using the GITHUB_TOKEN does not retrigger CI, therefore, using the dependabot token now.