### PR TITLE
Always write error.out

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -775,7 +775,9 @@ class GenericJob(JobCore):
             else:
                 job_crashed = True
 
-        with open(posixpath.join(self.project_hdf5.working_directory, "error.out"), mode="w") as f_err:
+        with open(
+            posixpath.join(self.project_hdf5.working_directory, "error.out"), mode="w"
+        ) as f_err:
             f_err.write(out)
 
         self.set_input_to_read_only()

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -754,12 +754,8 @@ class GenericJob(JobCore):
                 universal_newlines=True,
                 check=True,
             ).stdout
-            with open(
-                posixpath.join(self.project_hdf5.working_directory, "error.out"),
-                mode="w",
-            ) as f_err:
-                f_err.write(out)
         except subprocess.CalledProcessError as e:
+            out = e.output
             if e.returncode in self.executable.accepted_return_codes:
                 pass
             elif not self.server.accept_crash:
@@ -778,6 +774,9 @@ class GenericJob(JobCore):
                 raise RuntimeError("Job aborted")
             else:
                 job_crashed = True
+
+        with open(posixpath.join(self.project_hdf5.working_directory, "error.out"), mode="w") as f_err:
+            f_err.write(out)
 
         self.set_input_to_read_only()
         self.status.collect = True


### PR DESCRIPTION
Previously error.out was written when the job was successful and
error.msg when not.  In case the job returned an accepted non zero
return nothing was written due to a bug.  This commit writes all the
output of the job to error.out in all cases, plus error.msg when the job
errors out for backwards compatibility.

I introduced the bug in #537.