### PR TITLE
Set default project for WorkerJob

### DIFF
--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -128,7 +128,7 @@ class WorkerJob(PythonTemplateJob):
         super(WorkerJob, self).__init__(project, job_name)
         if not state.database.database_is_disabled:
             self.input.project = project.path
-        else: 
+        else:
             self.input.project = self.working_directory
         self.input.cores_per_job = 1
         self.input.sleep_interval = 10

--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -126,7 +126,10 @@ class WorkerJob(PythonTemplateJob):
 
     def __init__(self, project, job_name):
         super(WorkerJob, self).__init__(project, job_name)
-        self.input.project = project.path
+        if not state.database.database_is_disabled:
+            self.input.project = project.path
+        else: 
+            self.input.project = self.working_directory
         self.input.cores_per_job = 1
         self.input.sleep_interval = 10
         self.input.child_runtime = 0

--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -126,7 +126,7 @@ class WorkerJob(PythonTemplateJob):
 
     def __init__(self, project, job_name):
         super(WorkerJob, self).__init__(project, job_name)
-        self.input.project = None
+        self.input.project = project.path
         self.input.cores_per_job = 1
         self.input.sleep_interval = 10
         self.input.child_runtime = 0


### PR DESCRIPTION
The `WorkerJob` needs an input project assigned, but the default is `None` and it's not checked before the worker job starts running, which leads to silent death of the worker if you forget to assign one.  I've set the default now to be the project of the worker itself, because that seems to me the common use case.  If that's too specific we should instead add a `validate_ready_to_run` method that does this check.