### PR TITLE
Easy rewrite

### DIFF
--- a/pyiron_base/job/core.py
+++ b/pyiron_base/job/core.py
@@ -459,6 +459,19 @@ class JobCore(HasGroups):
         if self.job_id:
             self.project.db.delete_item(self.job_id)
 
+    def rewrite_hdf5(self, info: bool = False, exclude_groups: list = None, exclude_nodes: list = None) -> None:
+        """
+        Rewrite the hdf5 file of the job
+
+        Args:
+            info (True/False): whether to give the information on how much space has been saved
+            exclude_groups (list/None): list of groups to delete from hdf
+            exclude_nodes (list/None): list of nodes to delete from hdf
+        """
+        self.project_hdf5.rewrite_hdf5(self.job_name, info=info,
+                                       exclude_groups=exclude_groups,
+                                       exclude_nodes=exclude_nodes)
+
     def to_object(self, object_type=None, **qwargs):
         """
         Load the full pyiron object from an HDF5 file

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -8,6 +8,7 @@ from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.generic import GenericJob
 from pyiron_base._tests import TestWithFilledProject
 
+
 class ReturnCodeJob(GenericJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
@@ -22,6 +23,7 @@ class ReturnCodeJob(GenericJob):
 
     def collect_output(self):
         pass
+
 
 class TestGenericJob(TestWithFilledProject):
     def test_db_entry(self):
@@ -192,8 +194,16 @@ class TestGenericJob(TestWithFilledProject):
         self.assertEqual(job_copy.project_hdf5.path.split('/')[-2], parent_job.job_name)
         self.assertEqual(job_copy.job_name, new_job_name)
 
-    # def test_sub_job_name(self):
-    #     pass
+    def test_rewrite_hdf5(self):
+        job = self.project.load("toy_1")
+        init_nodes = job.project_hdf5.list_nodes()
+        init_groups = job.project_hdf5.list_groups()
+        job.rewrite_hdf5(info=True)
+        self.assertEqual(job.project_hdf5.list_nodes(), init_nodes, "Some nodes missing after rewrite")
+        self.assertEqual(job.project_hdf5.list_groups(), init_groups, "Some groups missing after rewrite")
+        job.rewrite_hdf5(exclude_groups=[init_groups[0]], exclude_nodes=[init_nodes[0]])
+        self.assertEqual(job.project_hdf5.list_nodes(), init_nodes[1:], "Nodes not removed after rewrite")
+        self.assertEqual(job.project_hdf5.list_groups(), init_groups[1:], "Groups not removed after rewrite")
 
     def test_version(self):
         pass


### PR DESCRIPTION
Currently the way we rewrite the hdf5 file of a job is:

```python 
job.project_hdf5.rewrite_hdf5(job.job_name)
```
I simplified this to

```python 
job.rewrite_hdf5()
```