### PR TITLE
Fix off-by-one in FlattenedStorage

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -713,7 +713,7 @@ class FlattenedStorage(HasHDF):
         if new_elements > self._num_elements_alloc:
             self._resize_elements(max(new_elements, self._num_elements_alloc * 2))
         if self.current_chunk_index + 1 > self._num_chunks_alloc:
-            self._resize_chunks(self._num_chunks_alloc * 2)
+            self._resize_chunks(max(1, self._num_chunks_alloc * 2))
 
         if new_elements > self.num_elements:
             self.num_elements = new_elements

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -96,6 +96,17 @@ class TestFlattenedStorage(TestWithProject):
                                    store_static._per_chunk_arrays["bar"][:store_dynamic.current_element_index]).all(),
                         "Array of per chunk quantity not equal after adding chunks.")
 
+        # Regression test, where adding chunks to a storage with no pre-allocation raised an error
+        store_empty = FlattenedStorage(num_chunks=0, num_elements=0)
+        store_empty.add_array("foo", per="element")
+        store_empty.add_array("bar", per="chunk")
+
+        try:
+            for f, b in zip(foo, bar):
+                store_empty.add_chunk(len(f), foo=f, bar=b)
+        except:
+            self.fail("Empty storage should be correctly resized when adding chunks!")
+
     def test_init(self):
         """Adding arrays via __init__ should be equivalent to adding them via add_chunks manually."""
 


### PR DESCRIPTION
When resizing a storage the number of allocated chunks are doubled, but
this breaks when there's no chunks pre-allocated (because, naja,
2*0==0...).  Normally this does not happen, because new storages start
with a pre-allocation of one, but in the case of an empty storage read
from HDF it does occur.  This now takes care to allocate at least one
chunk everytime.