### PR TITLE
Correctly resize string arrays in FlattenedStorage

### DIFF
--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -517,7 +517,7 @@ class FlattenedStorage(HasHDF):
         if name in self._per_element_arrays:
             if self._per_element_arrays[name].dtype.char == "U":
                 self._per_element_arrays[name] = ensure_str_array_size(
-                        self._per_element_arrays[name], max(map(len, value))
+                    self._per_element_arrays[name], max(map(len, value))
                 )
             self._per_element_arrays[name][self._get_per_element_slice(frame)] = value
         elif name in self._per_chunk_arrays:
@@ -527,7 +527,7 @@ class FlattenedStorage(HasHDF):
                 else:
                     strlen = len(value)
                 self._per_chunk_arrays[name] = ensure_str_array_size(
-                        self._per_chunk_arrays[name], strlen
+                    self._per_chunk_arrays[name], strlen
                 )
             self._per_chunk_arrays[name][frame] = value
         else:

--- a/pyiron_base/generic/flattenedstorage.py
+++ b/pyiron_base/generic/flattenedstorage.py
@@ -485,21 +485,50 @@ class FlattenedStorage(HasHDF):
         """
         Add array for given structure.
 
-        Works for per atom and per arrays.
+        Works for per chunk and per element arrays.
 
         Args:
             name (str): name of array to set
             frame (int, str): selects structure to set, as in :method:`.get_strucure()`
+            value: value (for per chunk) or array of values (for per element); type and shape as per :meth:`.hasarray()`.
 
         Raises:
             `KeyError`: if array with name does not exists
         """
 
+        def ensure_str_array_size(array, strlen):
+            """
+            Ensures that the given array can store at least string of length `strlen`.
+
+            Args:
+                array (ndarray): array of dtype <U
+                strlen (int): maximum length that should fit in it
+            Returns:
+                ndarray: either `array` or resized copy
+            """
+            current_length = array.itemsize // np.dtype("1U").itemsize
+            if current_length < strlen:
+                return array.astype(f"{2 * strlen}U")
+            else:
+                return array
+
         if isinstance(frame, str):
             frame = self.find_chunk(frame)
         if name in self._per_element_arrays:
+            if self._per_element_arrays[name].dtype.char == "U":
+                self._per_element_arrays[name] = ensure_str_array_size(
+                        self._per_element_arrays[name], max(map(len, value))
+                )
             self._per_element_arrays[name][self._get_per_element_slice(frame)] = value
         elif name in self._per_chunk_arrays:
+            if self._per_chunk_arrays[name].dtype.char == "U":
+                if isinstance(value, np.ndarray) and value.ndim == 0:
+                    strlen = len(value.item())
+                else:
+                    strlen = len(value)
+                self._per_chunk_arrays[name] = ensure_str_array_size(
+                        self._per_chunk_arrays[name], strlen
+                )
             self._per_chunk_arrays[name][frame] = value
         else:
             raise KeyError(f"no array named {name}")

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -500,9 +500,13 @@ class TestFlattenedStorage(TestWithProject):
         """string arrays should be automatically resized, when longer strings are added"""
 
         store = FlattenedStorage()
-        store.add_array("string", dtype="<3U", per="chunk")
-        for i in range(14):
-            store.add_chunk(1, string="a" * i)
-        for i in range(14):
-            self.assertEqual(store["string", i], "a" * i,
-                             "String array not correctly resized!")
+        store.add_array("chunkstr", dtype="<3U", per="chunk")
+        store.add_array("elemstr", shape=(2,), dtype="<3U", per="element")
+        for i in range(1, 14):
+            store.add_chunk(1, chunkstr="a" * i, elemstr=["a" * i] * 2)
+        for i in range(1, 14):
+            self.assertEqual(store["chunkstr", i - 1], "a" * i,
+                             "Per chunk string array not correctly resized!")
+            self.assertEqual(store["elemstr", i - 1].tolist(),
+                             [["a" * i] * 2],
+                             "Per element string array not correctly resized!")

--- a/tests/generic/test_flattenedstorage.py
+++ b/tests/generic/test_flattenedstorage.py
@@ -495,3 +495,14 @@ class TestFlattenedStorage(TestWithProject):
                         "Per element array changed in copy when original is!")
         self.assertTrue((even_sum_before == copy["even_sum"]).all(),
                         "Per chunk array changed in copy when original is!")
+
+    def test_string_resize(self):
+        """string arrays should be automatically resized, when longer strings are added"""
+
+        store = FlattenedStorage()
+        store.add_array("string", dtype="<3U", per="chunk")
+        for i in range(14):
+            store.add_chunk(1, string="a" * i)
+        for i in range(14):
+            self.assertEqual(store["string", i], "a" * i,
+                             "String array not correctly resized!")


### PR DESCRIPTION
For string numpy arrays the string length is part of the item size, i.e. `np.dtype('<10U')` can store at most strings of length 10.  However when setting elements in this array they will be silently truncated.  Since this is obviously annoying, so this now resizing the item size on the fly when strings are put into the storage that exceed the previous item size.