### PR TITLE
Remote job error handling

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1306,8 +1306,8 @@ class Project(ProjectPath, HasGroups):
 
     def wait_for_jobs(
         self,
-        interval_in_s=0,
-        max_iterations=1,
+        interval_in_s=5,
+        max_iterations=100,
         recursive=True,
         ignore_exceptions=False,
     ):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -606,7 +606,9 @@ class Project(ProjectPath, HasGroups):
         Args:
             recursive (bool): search subprojects [True/False] - default=True
         """
-        return update_from_remote(project=self, recursive=recursive, ignore_exceptions=ignore_exceptions)
+        return update_from_remote(
+            project=self, recursive=recursive, ignore_exceptions=ignore_exceptions
+        )
 
     def job_table(
         self,
@@ -1296,7 +1298,13 @@ class Project(ProjectPath, HasGroups):
             job=job, interval_in_s=interval_in_s, max_iterations=max_iterations
         )
 
-    def wait_for_jobs(self, interval_in_s=5, max_iterations=100, recursive=True, ignore_exceptions=False):
+    def wait_for_jobs(
+        self,
+        interval_in_s=5,
+        max_iterations=100,
+        recursive=True,
+        ignore_exceptions=False,
+    ):
         """
         Wait for the calculation in the project to be finished
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -605,6 +605,12 @@ class Project(ProjectPath, HasGroups):
 
         Args:
             recursive (bool): search subprojects [True/False] - default=True
+            ignore_exceptions (bool): ignore eventual exceptions when retrieving jobs - default=False
+
+        Returns:
+            returns None if ignore_exceptions is False or when no error occured.
+            returns a list with job ids when errors occured, but were ignored
+
         """
         return update_from_remote(
             project=self, recursive=recursive, ignore_exceptions=ignore_exceptions
@@ -1300,8 +1306,8 @@ class Project(ProjectPath, HasGroups):
 
     def wait_for_jobs(
         self,
-        interval_in_s=5,
-        max_iterations=100,
+        interval_in_s=0,
+        max_iterations=1,
         recursive=True,
         ignore_exceptions=False,
     ):
@@ -1312,6 +1318,7 @@ class Project(ProjectPath, HasGroups):
             interval_in_s (int): interval when the job status is queried from the database - default 5 sec.
             max_iterations (int): maximum number of iterations - default 100
             recursive (bool): search subprojects [True/False] - default=True
+            ignore_exceptions (bool): ignore eventual exceptions when retrieving jobs - default=False
 
         Raises:
             ValueError: max_iterations reached, but jobs still running

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -599,14 +599,14 @@ class Project(ProjectPath, HasGroups):
         """
         return [(key, self[key]) for key in self.keys()]
 
-    def update_from_remote(self, recursive=True):
+    def update_from_remote(self, recursive=True, ignore_exceptions=False):
         """
         Update jobs from the remote server
 
         Args:
             recursive (bool): search subprojects [True/False] - default=True
         """
-        update_from_remote(project=self, recursive=recursive)
+        return update_from_remote(project=self, recursive=recursive, ignore_exceptions=ignore_exceptions)
 
     def job_table(
         self,
@@ -1296,7 +1296,7 @@ class Project(ProjectPath, HasGroups):
             job=job, interval_in_s=interval_in_s, max_iterations=max_iterations
         )
 
-    def wait_for_jobs(self, interval_in_s=5, max_iterations=100, recursive=True):
+    def wait_for_jobs(self, interval_in_s=5, max_iterations=100, recursive=True, ignore_exceptions=False):
         """
         Wait for the calculation in the project to be finished
 
@@ -1313,6 +1313,7 @@ class Project(ProjectPath, HasGroups):
             interval_in_s=interval_in_s,
             max_iterations=max_iterations,
             recursive=recursive,
+            ignore_exceptions=ignore_exceptions,
         )
 
     @staticmethod

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -211,7 +211,7 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
 
 
 def wait_for_jobs(
-    project, interval_in_s=0, max_iterations=1, recursive=True, ignore_exceptions=False
+    project, interval_in_s=5, max_iterations=100, recursive=True, ignore_exceptions=False
 ):
     """
     Wait for the calculation in the project to be finished

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -6,7 +6,6 @@ Set of functions to interact with the queuing system directly from within pyiron
 """
 
 import warnings
-from logging import warning
 import pandas
 import time
 from pyiron_base.state import state

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -211,7 +211,11 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
 
 
 def wait_for_jobs(
-    project, interval_in_s=5, max_iterations=100, recursive=True, ignore_exceptions=False
+    project,
+    interval_in_s=5,
+    max_iterations=100,
+    recursive=True,
+    ignore_exceptions=False,
 ):
     """
     Wait for the calculation in the project to be finished

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -286,7 +286,7 @@ def update_from_remote(project, recursive=True):
                     warnings.warn(
                         f"An error occured while trying to retrieve job {job_id}\n"
                         "Error message: \n{e}"
-                        )
+                    )
 
 
 def validate_que_request(item):

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -221,6 +221,7 @@ def wait_for_jobs(
         interval_in_s (int): interval when the job status is queried from the database - default 5 sec.
         max_iterations (int): maximum number of iterations - default 100
         recursive (bool): search subprojects [True/False] - default=True
+        ignore_exceptions (bool): ignore eventual exceptions when retrieving jobs - default=False
 
     Raises:
         ValueError: max_iterations reached, but jobs still running
@@ -245,6 +246,11 @@ def update_from_remote(project, recursive=True, ignore_exceptions=False):
     Args:
         project: Project instance the jobs is located in
         recursive (bool): search subprojects [True/False] - default=True
+        ignore_exceptions (bool): ignore eventual exceptions when retrieving jobs - default=False
+
+    Returns:
+        returns None if ignore_exceptions is False or when no error occured.
+        returns a list with job ids when errors occured, but were ignored
     """
     if state.queue_adapter is not None and state.queue_adapter.remote_flag:
         df_project = project.job_table(recursive=recursive)

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -288,7 +288,7 @@ def update_from_remote(project, recursive=True, ignore_exceptions=False):
                     if ignore_exceptions:
                         state.logger.warning(
                             f"An error occured while trying to retrieve job {job_id}\n"
-                            "Error message: \n{e}"
+                            f"Error message: \n{e}"
                         )
                         failed_jobs.append(job_id)
                     else:

--- a/pyiron_base/server/queuestatus.py
+++ b/pyiron_base/server/queuestatus.py
@@ -210,7 +210,9 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                 )
 
 
-def wait_for_jobs(project, interval_in_s=0, max_iterations=1, recursive=True, ignore_exceptions=False):
+def wait_for_jobs(
+    project, interval_in_s=0, max_iterations=1, recursive=True, ignore_exceptions=False
+):
     """
     Wait for the calculation in the project to be finished
 
@@ -293,6 +295,7 @@ def update_from_remote(project, recursive=True, ignore_exceptions=False):
                         raise e
         if len(failed_jobs) > 0:
             return failed_jobs
+
 
 def validate_que_request(item):
     """


### PR DESCRIPTION
Make fetching jobs from a remote server more robust by simply catching all exceptions and printing them as a warning. Right now wait_for_jobs() aborts completely when some error occured that f.e. does not leave the hdf5 file in a valid state, so if you sent 1000 jobs to the cluster and try to get them back it may occur that you need to hack your way around errors by manually fetching the failed job/deleting them completely/whatever to avoid it being in front of the other jobs on the list. Also prevents that you come back after lunch just to notice that all jobs are still on the cluster instead of you computer.
This simply catches all exceptions and prints them as a warning together with the job id. Not sure if this is really a smart way to handle this but at least it is really robust.

Additionally I changed the interval_in_s and max_iterations defaults to only try to get jobs once. This makes more sense in my opinion since asking the login node for a list of all your jobs every few seconds just puts a lot of really unnecessary load on them,
especially if I consider the typical runtime of a job that is sent to a cluster to be > 1h. So at least my typical use case is to sent a lot of jobs and than get them back a few hours or a day later for analysis.