### PR TITLE
Fix issue with worker log

### DIFF
--- a/pyiron_base/job/worker.py
+++ b/pyiron_base/job/worker.py
@@ -181,6 +181,7 @@ class WorkerJob(PythonTemplateJob):
         pr = self.project_to_watch
         self.project_hdf5.create_working_directory()
         log_file = os.path.join(self.working_directory, "worker.log")
+        os.makedirs(self.working_directory, exist_ok=True)
         active_job_ids = []
         process = psutil.Process(os.getpid())
         with Pool(processes=int(self.server.cores / self.cores_per_job)) as pool:
@@ -260,6 +261,7 @@ class WorkerJob(PythonTemplateJob):
         self.project_hdf5.create_working_directory()
         working_directory = self.working_directory
         log_file = os.path.join(working_directory, "worker.log")
+        os.makedirs(self.working_directory, exist_ok=True)
         file_memory_lst = []
         process = psutil.Process(os.getpid())
         with Pool(processes=int(self.server.cores / self.cores_per_job)) as pool:


### PR DESCRIPTION
In the unit tests the following error is commonly printed:
```
Traceback (most recent call last):
166
  File "/usr/local/miniconda/envs/test/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
167
    self.run()
168
  File "/usr/local/miniconda/envs/test/lib/python3.10/multiprocessing/process.py", line 108, in run
169
    self._target(*self._args, **self._kwargs)
170
  File "/Users/runner/work/pyiron_base/pyiron_base/pyiron_base/job/generic.py", line 1772, in multiprocess_wrapper
171
    job_wrap.job.run_static()
172
  File "/Users/runner/work/pyiron_base/pyiron_base/pyiron_base/job/worker.py", line 174, in run_static
173
    self.run_static_with_database()
174
  File "/Users/runner/work/pyiron_base/pyiron_base/pyiron_base/job/worker.py", line 234, in run_static_with_database
175
    with open(log_file, "a") as f:
176
FileNotFoundError: [Errno 2] No such file or directory: '/Users/runner/work/pyiron_base/pyiron_base/tests/job/test_worker/runner_hdf5/runner/worker.log'
```