### PR TITLE
Dynamic loading of classes

### DIFF
--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -12,8 +12,11 @@ def _get_class_path_lst():
     class_path_lst = []
     for path in path_lst:
         class_path_lst += [
-            cp for cp, files in
-            [[cp, os.listdir(cp)] for cp in [os.path.join(path, c) for c in os.listdir(path)]]
+            cp
+            for cp, files in [
+                [cp, os.listdir(cp)]
+                for cp in [os.path.join(path, c) for c in os.listdir(path)]
+            ]
             if "script.py" in files and "input.json" in files
         ]
     return class_path_lst
@@ -36,13 +39,22 @@ def _init_constructor(class_name, script_path, input_dict):
 
 def _class_constructor(cp):
     from pyiron_base.job.script import ScriptJob
+
     class_name = os.path.basename(cp)
     script_path = os.path.join(cp, "script.py")
     input_dict = _load_input(path=cp)
-    return type(class_name, (ScriptJob,), {
-        "__init__": _init_constructor(class_name=class_name, script_path=script_path, input_dict=input_dict)
-    })
+    return type(
+        class_name,
+        (ScriptJob,),
+        {
+            "__init__": _init_constructor(
+                class_name=class_name, script_path=script_path, input_dict=input_dict
+            )
+        },
+    )
 
 
 def get_template_classes():
-    return {os.path.basename(cp): _class_constructor(cp=cp) for cp in _get_class_path_lst()}
+    return {
+        os.path.basename(cp): _class_constructor(cp=cp) for cp in _get_class_path_lst()
+    }

--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -55,9 +55,7 @@ def class_constructor(cp):
 
 
 def _get_template_classes():
-    return {
-        os.path.basename(cp): cp for cp in _get_class_path_lst()
-    }
+    return {os.path.basename(cp): cp for cp in _get_class_path_lst()}
 
 
 JOB_DYN_DICT = _get_template_classes()

--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -1,0 +1,48 @@
+import os
+import json
+from pyiron_base.state import state
+
+
+def _get_class_path_lst():
+    path_lst = [
+        os.path.abspath(os.path.expanduser(os.path.join(p, "template")))
+        for p in state.settings.resource_paths
+        if "template" in os.listdir(p)
+    ]
+    class_path_lst = []
+    for path in path_lst:
+        class_path_lst += [
+            cp for cp, files in
+            [[cp, os.listdir(cp)] for cp in [os.path.join(path, c) for c in os.listdir(path)]]
+            if "script.py" in files and "input.json" in files
+        ]
+    return class_path_lst
+
+
+def _load_input(path):
+    with open(os.path.join(path, "input.json")) as f:
+        return json.load(f)
+
+
+def _init_constructor(class_name, script_path, input_dict):
+    def __init__(self, project, job_name):
+        super(self.__class__, self).__init__(project, job_name)
+        self.__name__ = class_name
+        self.input.update(input_dict)
+        self.script_path = script_path
+
+    return __init__
+
+
+def _class_constructor(cp):
+    from pyiron_base.job.script import ScriptJob
+    class_name = os.path.basename(cp)
+    script_path = os.path.join(cp, "script.py")
+    input_dict = _load_input(path=cp)
+    return type(class_name, (ScriptJob,), {
+        "__init__": _init_constructor(class_name=class_name, script_path=script_path, input_dict=input_dict)
+    })
+
+
+def get_template_classes():
+    return {os.path.basename(cp): _class_constructor(cp=cp) for cp in _get_class_path_lst()}

--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -5,9 +5,9 @@ from pyiron_base.state import state
 
 def _get_class_path_lst():
     path_lst = [
-        os.path.abspath(os.path.expanduser(os.path.join(p, "template")))
+        os.path.abspath(os.path.expanduser(os.path.join(p, "templates")))
         for p in state.settings.resource_paths
-        if os.path.exists(p) and "template" in os.listdir(p)
+        if os.path.exists(p) and "templates" in os.listdir(p)
     ]
     class_path_lst = []
     for path in path_lst:

--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -37,7 +37,7 @@ def _init_constructor(class_name, script_path, input_dict):
     return __init__
 
 
-def _class_constructor(cp):
+def class_constructor(cp):
     from pyiron_base.job.script import ScriptJob
 
     class_name = os.path.basename(cp)
@@ -54,7 +54,10 @@ def _class_constructor(cp):
     )
 
 
-def get_template_classes():
+def _get_template_classes():
     return {
-        os.path.basename(cp): _class_constructor(cp=cp) for cp in _get_class_path_lst()
+        os.path.basename(cp): cp for cp in _get_class_path_lst()
     }
+
+
+JOB_DYN_DICT = _get_template_classes()

--- a/pyiron_base/generic/dynamic.py
+++ b/pyiron_base/generic/dynamic.py
@@ -7,7 +7,7 @@ def _get_class_path_lst():
     path_lst = [
         os.path.abspath(os.path.expanduser(os.path.join(p, "template")))
         for p in state.settings.resource_paths
-        if "template" in os.listdir(p)
+        if os.path.exists(p) and "template" in os.listdir(p)
     ]
     class_path_lst = []
     for path in path_lst:

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -21,7 +21,7 @@ from pyiron_base.generic.util import deprecate
 
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.state import state
-from pyiron_base.generic.dynamic import get_template_classes
+from pyiron_base.generic.dynamic import JOB_DYN_DICT, class_constructor
 import warnings
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
@@ -1369,8 +1369,7 @@ class ProjectHDFio(FileHDFio):
         if not class_path.startswith("abc."):
             class_object = self.import_class(class_name)
         else:
-            dyn_class_dict = get_template_classes()
-            class_object = dyn_class_dict[class_path.split(".")[-1]]
+            class_object = class_constructor(cp=JOB_DYN_DICT[class_path.split(".")[-1]])
 
         # Backwards compatibility since the format of TYPE changed
         if class_name != str(class_object):

--- a/pyiron_base/generic/hdfio.py
+++ b/pyiron_base/generic/hdfio.py
@@ -21,6 +21,7 @@ from pyiron_base.generic.util import deprecate
 
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.state import state
+from pyiron_base.generic.dynamic import get_template_classes
 import warnings
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
@@ -1364,7 +1365,12 @@ class ProjectHDFio(FileHDFio):
                 "Object type in hdf5-file must be identical to input parameter"
             )
         class_name = class_name or self.get("TYPE")
-        class_object = self.import_class(class_name)
+        class_path = class_name.split("<class '")[-1].split("'>")[0]
+        if not class_path.startswith("abc."):
+            class_object = self.import_class(class_name)
+        else:
+            dyn_class_dict = get_template_classes()
+            class_object = dyn_class_dict[class_path.split(".")[-1]]
 
         # Backwards compatibility since the format of TYPE changed
         if class_name != str(class_object):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -13,7 +13,7 @@ from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.generic.util import Singleton
 from pyiron_base.generic.factory import PyironFactory
 from pyiron_base.job.jobstatus import job_status_finished_lst
-from pyiron_base.generic.dynamic import get_template_classes
+from pyiron_base.generic.dynamic import JOB_DYN_DICT, class_constructor
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -135,7 +135,7 @@ class JobFactory(PyironFactory):
 
     def __init__(self, project):
         self._job_class_dict = JOB_CLASS_DICT
-        self._job_dyn_dict = get_template_classes()
+        self._job_dyn_dict = JOB_DYN_DICT
         self._project = project
 
     def __dir__(self):
@@ -206,7 +206,10 @@ class JobFactory(PyironFactory):
                             project=self._project.copy(), file_name=job_name
                         ),
                         job_name=job_name,
-                        job_class_dict=self._job_dyn_dict.keys(),
+                        job_class_dict={
+                            name: class_constructor(cp=cp)
+                            for name, cp in self._job_dyn_dict.items()
+                        },
                         delete_existing_job=delete_existing_job,
                         delete_aborted_job=delete_aborted_job,
                     )

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -135,13 +135,14 @@ class JobFactory(PyironFactory):
 
     def __init__(self, project):
         self._job_class_dict = JOB_CLASS_DICT
+        self._job_dyn_dict = get_template_classes()
         self._project = project
 
     def __dir__(self):
         """
         Enable autocompletion by overwriting the __dir__() function.
         """
-        return list(self._job_class_dict.keys())
+        return list(self._job_class_dict.keys()) + list(self._job_dyn_dict.keys())
 
     def __getattr__(self, name):
         if name in self._job_class_dict.keys():
@@ -177,8 +178,7 @@ class JobFactory(PyironFactory):
 
             return wrapper
         else:
-            job_dyn_dict = get_template_classes()
-            if name in job_dyn_dict.keys():
+            if name in self._job_dyn_dict.keys():
 
                 def wrapper(
                     job_name, delete_existing_job=False, delete_aborted_job=False
@@ -206,7 +206,7 @@ class JobFactory(PyironFactory):
                             project=self._project.copy(), file_name=job_name
                         ),
                         job_name=job_name,
-                        job_class_dict=job_dyn_dict,
+                        job_class_dict=self._job_dyn_dict.keys(),
                         delete_existing_job=delete_existing_job,
                         delete_aborted_job=delete_aborted_job,
                     )

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -180,7 +180,9 @@ class JobFactory(PyironFactory):
             job_dyn_dict = get_template_classes()
             if name in job_dyn_dict.keys():
 
-                def wrapper(job_name, delete_existing_job=False, delete_aborted_job=False):
+                def wrapper(
+                    job_name, delete_existing_job=False, delete_aborted_job=False
+                ):
                     """
                     Create one of the following jobs:
                     - 'ExampleJob': example job just generating random number

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -13,6 +13,7 @@ from pyiron_base.generic.hdfio import ProjectHDFio
 from pyiron_base.generic.util import Singleton
 from pyiron_base.generic.factory import PyironFactory
 from pyiron_base.job.jobstatus import job_status_finished_lst
+from pyiron_base.generic.dynamic import get_template_classes
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -113,13 +114,12 @@ class JobType(object):
         else:
             job_type = job_type_lst[-1]
 
-        for job_class_name in list(job_class_dict.keys()):
-            if job_type == job_class_name:
-                job_class = job_class_dict[job_class_name]
-                if isinstance(job_class, str):
-                    job_module = importlib.import_module(job_class)
-                    job_class = getattr(job_module, job_class_name)
-                return job_class
+        if job_type in job_class_dict.keys():
+            job_class = job_class_dict[job_type]
+            if isinstance(job_class, str):
+                job_module = importlib.import_module(job_class)
+                job_class = getattr(job_module, job_type)
+            return job_class
         raise ValueError(
             "Unknown job type: ",
             class_name,
@@ -177,6 +177,40 @@ class JobFactory(PyironFactory):
 
             return wrapper
         else:
+            job_dyn_dict = get_template_classes()
+            if name in job_dyn_dict.keys():
+
+                def wrapper(job_name, delete_existing_job=False, delete_aborted_job=False):
+                    """
+                    Create one of the following jobs:
+                    - 'ExampleJob': example job just generating random number
+                    - 'SerialMaster': series of jobs run in serial
+                    - 'ParallelMaster': series of jobs run in parallel
+                    - 'ScriptJob': Python script or jupyter notebook job container
+                    - 'ListMaster': list of jobs
+
+                    Args:
+                        job_name (str): name of the job
+                        delete_existing_job (bool): delete an existing job - default false
+                        delete_aborted_job (bool): delete an existing and aborted job - default false
+
+                    Returns:
+                        GenericJob: job object depending on the job_type selected
+                    """
+                    job_name = _get_safe_job_name(job_name)
+                    return JobType(
+                        class_name=name,
+                        project=ProjectHDFio(
+                            project=self._project.copy(), file_name=job_name
+                        ),
+                        job_name=job_name,
+                        job_class_dict=job_dyn_dict,
+                        delete_existing_job=delete_existing_job,
+                        delete_aborted_job=delete_aborted_job,
+                    )
+
+                return wrapper
+
             raise AttributeError("no job class named '{}' defined".format(name))
 
 


### PR DESCRIPTION
Based on these changes I created a "low-code" example https://github.com/jan-janssen/pyiron-dynamic . In the example the developer only needs to create a `input.json` file for the default inputs and a `script.py` file for interfacing with the simulation code. The rest is handled by the functionality in `pyiron_dynamic`. That is less than 50 lines which include all the magic of dynamically generating classes on-the-fly. Currently these examples do not work on the queuing system, but if we integrate this functionality inside `pyiron_base` that should be no issue. @niklassiemer and @muh-hassani maybe the two of you can collect some feedback if this would address the needs of users from other disciplines.