### PR TITLE
Use JobType to carry the JOB_CLASS_DICT and add register method

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1486,22 +1486,9 @@ class GenericJob(JobCore):
             self._logger.info("busy master: {} {}".format(master_id, self.get_job_id()))
             del self
 
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        """Name of the JobType this class is to be registered with; None for do not register.
-        Behavior is not inherited"""
-        return cls.__name__
-
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        # If the _register_jobtype_name is not defined in the new class definition _itself_ it falls back to the
-        # default, i.e. to register the class with the class.__name__
-        if "_register_jobtype_name" not in cls.__dict__.keys():
-            register_name = cls.__name__
-        else:
-            # This one follows the method resolution order
-            register_name = cls._register_jobtype_name()
-        JobType.register_job_type(register_name, cls)
+        JobType.register_job_type(cls.__name__, cls)
 
 
 class GenericError(object):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -8,11 +8,8 @@ Generic Job class extends the JobCore class with all the functionality to run th
 from datetime import datetime
 import os
 import posixpath
-import multiprocessing
 from typing import Union
-
 import h5io
-from pyiron_base.job.wrapper import JobWrapper
 from pyiron_base.job.jobtype import JobType
 import signal
 import warnings
@@ -1499,7 +1496,7 @@ class GenericJob(JobCore):
         super().__init_subclass__(**kwargs)
         # If the _register_jobtype_name is not defined in the new class definition _itself_ it falls back to the
         # default, i.e. to register the class with the class.__name__
-        if '_register_jobtype_name' not in cls.__dict__.keys():
+        if "_register_jobtype_name" not in cls.__dict__.keys():
             register_name = cls.__name__
         else:
             # This one follows the method resolution order

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1486,6 +1486,7 @@ class GenericJob(JobCore):
             del self
 
     def __init_subclass__(cls, **kwargs):
+        """Auto register all subclasses of GenericJob as available JobType."""
         super().__init_subclass__(**kwargs)
         JobType.register(cls)
 

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -6,9 +6,14 @@ Generic Job class extends the JobCore class with all the functionality to run th
 """
 
 from datetime import datetime
-import h5io
 import os
 import posixpath
+import multiprocessing
+from typing import Union
+
+import h5io
+from pyiron_base.job.wrapper import JobWrapper
+from pyiron_base.job.jobtype import JobType
 import signal
 import warnings
 
@@ -1483,6 +1488,15 @@ class GenericJob(JobCore):
             project.db.set_job_status(job_id=master_id, status="busy")
             self._logger.info("busy master: {} {}".format(master_id, self.get_job_id()))
             del self
+
+    @staticmethod
+    def _register_jobtype_name() -> Union[str, None]:
+        """Name of the JobType this class is to be registered with; None for do not register."""
+        return None
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        JobType.register_job_type(cls._register_jobtype_name(), cls)
 
 
 class GenericError(object):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1492,7 +1492,7 @@ class GenericJob(JobCore):
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
         """Name of the JobType this class is to be registered with; None for do not register."""
-        return cls.__name__ 
+        return cls.__name__
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1487,7 +1487,7 @@ class GenericJob(JobCore):
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        JobType.register_job_type(cls.__name__, cls)
+        JobType.register(cls)
 
 
 class GenericError(object):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1491,12 +1491,20 @@ class GenericJob(JobCore):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        """Name of the JobType this class is to be registered with; None for do not register."""
+        """Name of the JobType this class is to be registered with; None for do not register.
+        Behavior is not inherited"""
         return cls.__name__
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        JobType.register_job_type(cls._register_jobtype_name(), cls)
+        # If the _register_jobtype_name is not defined in the new class definition _itself_ it falls back to the
+        # default, i.e. to register the class with the class.__name__
+        if '_register_jobtype_name' not in cls.__dict__.keys():
+            register_name = cls.__name__
+        else:
+            # This one follows the method resolution order
+            register_name = cls._register_jobtype_name()
+        JobType.register_job_type(register_name, cls)
 
 
 class GenericError(object):

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1489,10 +1489,10 @@ class GenericJob(JobCore):
             self._logger.info("busy master: {} {}".format(master_id, self.get_job_id()))
             del self
 
-    @staticmethod
-    def _register_jobtype_name() -> Union[str, None]:
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
         """Name of the JobType this class is to be registered with; None for do not register."""
-        return None
+        return cls.__name__ 
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -8,7 +8,6 @@ Generic Job class extends the JobCore class with all the functionality to run th
 from datetime import datetime
 import os
 import posixpath
-from typing import Union
 import h5io
 from pyiron_base.job.jobtype import JobType
 import signal

--- a/pyiron_base/job/interactive.py
+++ b/pyiron_base/job/interactive.py
@@ -4,6 +4,7 @@
 """
 InteractiveBase class extends the Generic Job class with all the functionality to run the job object interactivley.
 """
+from typing import Union
 
 import numpy as np
 from pyiron_base.job.generic import GenericJob
@@ -364,6 +365,13 @@ class InteractiveBase(GenericJob):
                     ]
                 else:
                     self._interactive_write_frequency = 1
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "InteractiveBase":
+            return None
+        else:
+            return cls.__name__
 
 
 class _WithInteractiveOpen:

--- a/pyiron_base/job/interactive.py
+++ b/pyiron_base/job/interactive.py
@@ -368,10 +368,7 @@ class InteractiveBase(GenericJob):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "InteractiveBase":
-            return None
-        else:
-            return cls.__name__
+        return None
 
 
 class _WithInteractiveOpen:

--- a/pyiron_base/job/interactive.py
+++ b/pyiron_base/job/interactive.py
@@ -4,10 +4,10 @@
 """
 InteractiveBase class extends the Generic Job class with all the functionality to run the job object interactivley.
 """
-from typing import Union
 
 import numpy as np
 from pyiron_base.job.generic import GenericJob
+from pyiron_base.job.jobtype import unregistered_jobtype
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
@@ -21,6 +21,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2018"
 
 
+@unregistered_jobtype
 class InteractiveBase(GenericJob):
     """
     InteractiveBase class extends the Generic Job class with all the functionality to run the job object interactively.
@@ -365,10 +366,6 @@ class InteractiveBase(GenericJob):
                     ]
                 else:
                     self._interactive_write_frequency = 1
-
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None
 
 
 class _WithInteractiveOpen:

--- a/pyiron_base/job/interactive.py
+++ b/pyiron_base/job/interactive.py
@@ -7,7 +7,7 @@ InteractiveBase class extends the Generic Job class with all the functionality t
 
 import numpy as np
 from pyiron_base.job.generic import GenericJob
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
@@ -21,7 +21,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2018"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class InteractiveBase(GenericJob):
     """
     InteractiveBase class extends the Generic Job class with all the functionality to run the job object interactively.

--- a/pyiron_base/job/interactivewrapper.py
+++ b/pyiron_base/job/interactivewrapper.py
@@ -4,6 +4,8 @@
 
 from datetime import datetime
 import warnings
+from typing import Union
+
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.master.generic import GenericMaster
@@ -158,3 +160,10 @@ class InteractiveWrapper(GenericMaster):
         return self._get_item_when_str(
             item=item, child_id_lst=child_id_lst, child_name_lst=child_name_lst
         )
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "InteractiveWrapper":
+            return None
+        else:
+            return cls.__name__

--- a/pyiron_base/job/interactivewrapper.py
+++ b/pyiron_base/job/interactivewrapper.py
@@ -163,7 +163,4 @@ class InteractiveWrapper(GenericMaster):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "InteractiveWrapper":
-            return None
-        else:
-            return cls.__name__
+        return None

--- a/pyiron_base/job/interactivewrapper.py
+++ b/pyiron_base/job/interactivewrapper.py
@@ -7,7 +7,7 @@ import warnings
 
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.generic import GenericJob
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 from pyiron_base.master.generic import GenericMaster
 
 __author__ = "Jan Janssen"
@@ -22,7 +22,7 @@ __status__ = "development"
 __date__ = "Jan 8, 2021"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class InteractiveWrapper(GenericMaster):
     def __init__(self, project, job_name):
         super(InteractiveWrapper, self).__init__(project, job_name)

--- a/pyiron_base/job/interactivewrapper.py
+++ b/pyiron_base/job/interactivewrapper.py
@@ -4,12 +4,11 @@
 
 from datetime import datetime
 import warnings
-from typing import Union
 
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.generic import GenericJob
+from pyiron_base.job.jobtype import unregistered_jobtype
 from pyiron_base.master.generic import GenericMaster
-from pyiron_base.generic.util import deprecate
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -23,6 +22,7 @@ __status__ = "development"
 __date__ = "Jan 8, 2021"
 
 
+@unregistered_jobtype
 class InteractiveWrapper(GenericMaster):
     def __init__(self, project, job_name):
         super(InteractiveWrapper, self).__init__(project, job_name)
@@ -160,7 +160,3 @@ class InteractiveWrapper(GenericMaster):
         return self._get_item_when_str(
             item=item, child_id_lst=child_id_lst, child_name_lst=child_name_lst
         )
-
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -101,17 +101,32 @@ class JobType(object):
     def register_job_type(cls, cls_name, _cls):
         if cls_name is None:
             return
-        elif cls_name not in cls._job_class_dict:
+        elif cls_name not in cls._job_class_dict and isinstance(_cls, str):
             cls._job_class_dict[cls_name] = _cls
         elif (
-            isinstance(cls._job_class_dict[cls_name], str)
-            and cls._job_class_dict[cls_name] + f".{cls_name}"
-            == repr(_cls).split("<class '")[-1].split("'>")[0]
+            cls_name in cls._job_class_dict
+            and isinstance(_cls, str)
+            and cls._job_class_dict[cls_name] == _cls
         ):
-            cls._job_class_dict[cls_name] = _cls
+            pass
+        elif cls_name not in cls._job_class_dict and not isinstance(_cls, str):
+            cls._job_class_dict[cls_name] = cls._get_class_path_str(_cls)
+        elif (
+            cls_name in cls._job_class_dict
+            and not isinstance(_cls, str)
+            and cls._job_class_dict[cls_name] == cls._get_class_path_str(_cls)
+        ):
+            pass
         else:
-            print(repr(_cls).split("<class '")[-1].split("'>")[0])
-            raise ValueError(f"A JobType with name {cls_name} is already defined!")
+            raise ValueError(
+                f"A JobType with name {cls_name} is already defined! New class = {repr(_cls)}, "
+                f"already registered class = {repr(cls._job_class_dict[cls_name])}."
+            )
+
+    @staticmethod
+    def _get_class_path_str(_cls):
+        full_path = repr(_cls).split("<class '")[-1].split("'>")[0]
+        return ".".join(full_path.split(".")[:-1])
 
     @staticmethod
     def convert_str_to_class(job_class_dict, class_name):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -41,12 +41,14 @@ class JobType(object):
     The JobTypeBase class creates a new object of a given class type.
     """
 
+    _job_class_dict = JOB_CLASS_DICT
+
     def __new__(
         cls,
         class_name,
         project,
         job_name,
-        job_class_dict,
+        job_class_dict=None,
         delete_existing_job=False,
         delete_aborted_job=False,
     ):
@@ -65,7 +67,7 @@ class JobType(object):
             GenericJob: object of type class_name
         """
         job_name = _get_safe_job_name(job_name)
-        cls.job_class_dict = job_class_dict
+        cls.job_class_dict = job_class_dict or cls._job_class_dict
         if isinstance(class_name, str):
             job_class = cls.convert_str_to_class(
                 job_class_dict=cls.job_class_dict, class_name=class_name
@@ -94,6 +96,15 @@ class JobType(object):
         if job.status.string in job_status_finished_lst:
             job.set_input_to_read_only()
         return job
+
+    @classmethod
+    def register_job_type(cls, cls_name, _cls):
+        if cls_name is None:
+            return
+        elif cls_name not in cls._job_class_dict:
+            cls._job_class_dict[cls_name] = _cls
+        else:
+            raise ValueError(f"A JobType with name {cls_name} is already defined!")
 
     @staticmethod
     def convert_str_to_class(job_class_dict, class_name):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -103,7 +103,14 @@ class JobType(object):
             return
         elif cls_name not in cls._job_class_dict:
             cls._job_class_dict[cls_name] = _cls
+        elif (
+            isinstance(cls._job_class_dict[cls_name], str)
+            and cls._job_class_dict[cls_name] + f".{cls_name}"
+            == repr(_cls).split("<class '")[-1].split("'>")[0]
+        ):
+            cls._job_class_dict[cls_name] = _cls
         else:
+            print(repr(_cls).split("<class '")[-1].split("'>")[0])
             raise ValueError(f"A JobType with name {cls_name} is already defined!")
 
     @staticmethod

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -99,14 +99,16 @@ class JobType:
         return job
 
     @classmethod
-    def un_register_job_type(cls, job_name):
+    def unregister(cls, job_name_or_class):
+      if insinstance(job_name_or_class, type):
+        job_name_or_class = job_name_or_class.__name__
         if job_name in cls._job_class_dict:
             del cls._job_class_dict[job_name]
         else:
             raise KeyError(f"No JobType with name '{job_name}' found.")
 
     @classmethod
-    def register_job_type(cls, cls_name, _cls):
+    def register(cls, job_class_or_module_str, job_name=None):
         if cls_name is None:
             return
         elif cls_name not in cls._job_class_dict and isinstance(_cls, str):
@@ -122,11 +124,11 @@ class JobType:
                 raise NotImplementedError(
                     "Currently, the given name has to match the class name."
                 )
-            cls._job_class_dict[cls_name] = cls._get_class_path_str(_cls)
+            cls._job_class_dict[cls_name] = _cls.__module__
         elif (
             cls_name in cls._job_class_dict
             and not isinstance(_cls, str)
-            and cls._job_class_dict[cls_name] == cls._get_class_path_str(_cls)
+            and cls._job_class_dict[cls_name] == _cls.__module__
         ):
             pass
         else:
@@ -135,10 +137,6 @@ class JobType:
                 f"already registered class = {repr(cls._job_class_dict[cls_name])}."
             )
 
-    @staticmethod
-    def _get_class_path_str(_cls):
-        full_path = repr(_cls).split("<class '")[-1].split("'>")[0]
-        return ".".join(full_path.split(".")[:-1])
 
     @staticmethod
     def convert_str_to_class(job_class_dict, class_name) -> Type["GenericJob"]:
@@ -170,11 +168,6 @@ class JobType:
             class_name,
             [job for job in list(job_class_dict.keys())],
         )
-
-
-def unregistered_jobtype(cls):
-    JobType.un_register_job_type(cls.__name__)
-    return cls
 
 
 class JobFactory(PyironFactory):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -100,6 +100,15 @@ class JobType:
 
     @classmethod
     def unregister(cls, job_name_or_class):
+        """Unregister job type from the exposed list of available job types
+
+        Args:
+            job_name_or_class(str/type): name of the job or job class
+
+        Returns:
+            None if a str is provided as job_name_or_class
+            job_name_or_class if a class is provided. Therefore, this method can be used as class decorator.
+        """
         _cls = None
         if isinstance(job_name_or_class, type):
             _cls = job_name_or_class
@@ -112,6 +121,13 @@ class JobType:
 
     @classmethod
     def register(cls, job_class_or_module_str: Union[type, str], job_name: str = None):
+        """Register job type from the exposed list of available job types
+
+        Args:
+            job_class_or_module_str(type/str/None): job class itself, string representation of the job class module as
+                provided by cls.__module__, or None for do not register.
+            job_name(str/None): Name of the job to register. Must match cls.__name__. Can be omitted for class input.
+        """
         if job_class_or_module_str is None:
             return
         elif isinstance(job_class_or_module_str, type):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -14,6 +14,7 @@ from pyiron_base.generic.util import Singleton
 from pyiron_base.generic.factory import PyironFactory
 from pyiron_base.job.jobstatus import job_status_finished_lst
 from pyiron_base.generic.dynamic import JOB_DYN_DICT, class_constructor
+from typing import Type
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -36,7 +37,7 @@ JOB_CLASS_DICT = {
 }
 
 
-class JobType(object):
+class JobType:
     """
     The JobTypeBase class creates a new object of a given class type.
     """
@@ -56,7 +57,7 @@ class JobType(object):
         The __new__() method allows to create objects from other classes - the class selected by class_name
 
         Args:
-            class_name (str): The specific class name of the class this object belongs to.
+            class_name (str/Type('GenericJob')): The specific class name of the class this object belongs to.
             project (Project): Project object (defines path where job will be created and stored)
             job_name (str): name of the job (must be unique within this project path)
             job_class_dict (dict): dictionary with the jobtypes to choose from.
@@ -129,7 +130,7 @@ class JobType(object):
         return ".".join(full_path.split(".")[:-1])
 
     @staticmethod
-    def convert_str_to_class(job_class_dict, class_name):
+    def convert_str_to_class(job_class_dict, class_name) -> Type["GenericJob"]:
         """
         convert the name of a class to the corresponding class object - only for pyiron internal classes.
 

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -111,6 +111,8 @@ class JobType:
         ):
             pass
         elif cls_name not in cls._job_class_dict and not isinstance(_cls, str):
+            if cls_name != _cls.__name__:
+                raise NotImplementedError("Currently, the given name has to match the class name.")
             cls._job_class_dict[cls_name] = cls._get_class_path_str(_cls)
         elif (
             cls_name in cls._job_class_dict

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -106,7 +106,7 @@ class JobType:
             del cls._job_class_dict[job_name_or_class]
         else:
             raise KeyError(f"No JobType with name '{job_name_or_class}' found.")
-        return cls
+        return job_name_or_class
 
     @classmethod
     def register(cls, job_class_or_module_str: Union[type, str], job_name: str = None):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -99,6 +99,13 @@ class JobType:
         return job
 
     @classmethod
+    def un_register_job_type(cls, job_name):
+        if job_name in cls._job_class_dict:
+            del cls._job_class_dict[job_name]
+        else:
+            raise KeyError(f"No JobType with name '{job_name}' found.")
+
+    @classmethod
     def register_job_type(cls, cls_name, _cls):
         if cls_name is None:
             return
@@ -163,6 +170,10 @@ class JobType:
             class_name,
             [job for job in list(job_class_dict.keys())],
         )
+
+
+def unregistered_jobtype(cls):
+    JobType.un_register_job_type(cls.__name__)
 
 
 class JobFactory(PyironFactory):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -100,7 +100,7 @@ class JobType:
 
     @classmethod
     def unregister(cls, job_name_or_class):
-        _cls = None 
+        _cls = None
         if isinstance(job_name_or_class, type):
             _cls = job_name_or_class
             job_name_or_class = job_name_or_class.__name__
@@ -109,6 +109,7 @@ class JobType:
         else:
             raise KeyError(f"No JobType with name '{job_name_or_class}' found.")
         return _cls
+
     @classmethod
     def register(cls, job_class_or_module_str: Union[type, str], job_name: str = None):
         if job_class_or_module_str is None:

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -100,14 +100,15 @@ class JobType:
 
     @classmethod
     def unregister(cls, job_name_or_class):
+        _cls = None 
         if isinstance(job_name_or_class, type):
+            _cls = job_name_or_class
             job_name_or_class = job_name_or_class.__name__
         if job_name_or_class in cls._job_class_dict:
             del cls._job_class_dict[job_name_or_class]
         else:
             raise KeyError(f"No JobType with name '{job_name_or_class}' found.")
-        return job_name_or_class
-
+        return _cls
     @classmethod
     def register(cls, job_class_or_module_str: Union[type, str], job_name: str = None):
         if job_class_or_module_str is None:

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -174,6 +174,7 @@ class JobType:
 
 def unregistered_jobtype(cls):
     JobType.un_register_job_type(cls.__name__)
+    return cls
 
 
 class JobFactory(PyironFactory):

--- a/pyiron_base/job/jobtype.py
+++ b/pyiron_base/job/jobtype.py
@@ -112,7 +112,9 @@ class JobType:
             pass
         elif cls_name not in cls._job_class_dict and not isinstance(_cls, str):
             if cls_name != _cls.__name__:
-                raise NotImplementedError("Currently, the given name has to match the class name.")
+                raise NotImplementedError(
+                    "Currently, the given name has to match the class name."
+                )
             cls._job_class_dict[cls_name] = cls._get_class_path_str(_cls)
         elif (
             cls_name in cls._job_class_dict

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -4,6 +4,7 @@
 """
 Template class to define jobs
 """
+from typing import Union
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.generic.object import HasStorage
@@ -43,6 +44,13 @@ class TemplateJob(GenericJob, HasStorage):
         GenericJob.from_hdf(self, hdf=hdf, group_name=group_name)
         HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name="")
 
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "TemplateJob":
+            return None
+        else:
+            return cls.__name__
+
 
 class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
@@ -51,3 +59,10 @@ class PythonTemplateJob(TemplateJob):
 
     def _check_if_input_should_be_written(self):
         return False
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "PythonTemplateJob":
+            return None
+        else:
+            return cls.__name__

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -46,10 +46,7 @@ class TemplateJob(GenericJob, HasStorage):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "TemplateJob":
-            return None
-        else:
-            return cls.__name__
+        return None
 
 
 class PythonTemplateJob(TemplateJob):
@@ -62,7 +59,4 @@ class PythonTemplateJob(TemplateJob):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "PythonTemplateJob":
-            return None
-        else:
-            return cls.__name__
+        return None

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -7,7 +7,7 @@ Template class to define jobs
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.generic.object import HasStorage
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -21,7 +21,7 @@ __status__ = "development"
 __date__ = "May 15, 2020"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
@@ -46,7 +46,7 @@ class TemplateJob(GenericJob, HasStorage):
         HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name="")
 
 
-@unregistered_jobtype
+@JobType.unregister
 class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -4,10 +4,10 @@
 """
 Template class to define jobs
 """
-from typing import Union
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.generic.object import HasStorage
+from pyiron_base.job.jobtype import unregistered_jobtype
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -21,6 +21,7 @@ __status__ = "development"
 __date__ = "May 15, 2020"
 
 
+@unregistered_jobtype
 class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
@@ -44,11 +45,8 @@ class TemplateJob(GenericJob, HasStorage):
         GenericJob.from_hdf(self, hdf=hdf, group_name=group_name)
         HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name="")
 
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None
 
-
+@unregistered_jobtype
 class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
@@ -56,7 +54,3 @@ class PythonTemplateJob(TemplateJob):
 
     def _check_if_input_should_be_written(self):
         return False
-
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -7,6 +7,8 @@ The GenericMaster is the template class for all meta jobs
 
 import inspect
 import textwrap
+from typing import Union
+
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
 
@@ -549,6 +551,13 @@ class GenericMaster(GenericJob):
             parent (:class:`.GenericJob`): job instance that this job was created from
         """
         self.ref_job = parent
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "GenericMaster":
+            return None
+        else:
+            return cls.__name__
 
 
 def get_function_from_string(function_str):

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -554,10 +554,7 @@ class GenericMaster(GenericJob):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "GenericMaster":
-            return None
-        else:
-            return cls.__name__
+        return None
 
 
 def get_function_from_string(function_str):

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -7,10 +7,10 @@ The GenericMaster is the template class for all meta jobs
 
 import inspect
 import textwrap
-from typing import Union
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
+from pyiron_base.job.jobtype import unregistered_jobtype
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -24,6 +24,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+@unregistered_jobtype
 class GenericMaster(GenericJob):
     """
     The GenericMaster is the template class for all meta jobs - meaning all jobs which contain multiple other jobs. It
@@ -551,10 +552,6 @@ class GenericMaster(GenericJob):
             parent (:class:`.GenericJob`): job instance that this job was created from
         """
         self.ref_job = parent
-
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None
 
 
 def get_function_from_string(function_str):

--- a/pyiron_base/master/generic.py
+++ b/pyiron_base/master/generic.py
@@ -10,7 +10,7 @@ import textwrap
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.job.jobstatus import job_status_finished_lst
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -24,7 +24,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class GenericMaster(GenericJob):
     """
     The GenericMaster is the template class for all meta jobs - meaning all jobs which contain multiple other jobs. It

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -4,6 +4,7 @@
 """
 The ListMaster behaves like a list, just for job objects.
 """
+from typing import Union
 
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.core import JobCore
@@ -368,3 +369,10 @@ class ListMaster(GenericMaster):
             int: length of the ListMaster
         """
         return len(self.child_ids + self._job_name_lst)
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "ListMaster":
+            return None
+        else:
+            return cls.__name__

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -371,4 +371,3 @@ class ListMaster(GenericMaster):
             int: length of the ListMaster
         """
         return len(self.child_ids + self._job_name_lst)
-

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -11,6 +11,7 @@ from pyiron_base.job.core import JobCore
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.master.generic import GenericMaster
 from pyiron_base.master.submissionstatus import SubmissionStatus
+from pyiron_base.job.jobtype import unregistered_jobtype
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -24,6 +25,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+@unregistered_jobtype
 class ListMaster(GenericMaster):
     """
     The ListMaster is the most simple MetaJob derived from the GenericMaster. It behaves like a Python list object. Jobs
@@ -370,6 +372,3 @@ class ListMaster(GenericMaster):
         """
         return len(self.child_ids + self._job_name_lst)
 
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -10,7 +10,7 @@ from pyiron_base.job.core import JobCore
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.master.generic import GenericMaster
 from pyiron_base.master.submissionstatus import SubmissionStatus
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -24,7 +24,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class ListMaster(GenericMaster):
     """
     The ListMaster is the most simple MetaJob derived from the GenericMaster. It behaves like a Python list object. Jobs

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -372,7 +372,4 @@ class ListMaster(GenericMaster):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "ListMaster":
-            return None
-        else:
-            return cls.__name__
+        return None

--- a/pyiron_base/master/list.py
+++ b/pyiron_base/master/list.py
@@ -4,7 +4,6 @@
 """
 The ListMaster behaves like a list, just for job objects.
 """
-from typing import Union
 
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.core import JobCore

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -7,6 +7,8 @@ The parallel master class is a metajob consisting of a list of jobs which are ex
 
 from collections import OrderedDict
 from datetime import datetime
+from typing import Union
+
 import numpy as np
 import pandas
 import multiprocessing
@@ -987,3 +989,10 @@ class JobGenerator(object):
         else:
             self._master.refresh_job_status()
             raise StopIteration()
+
+    @classmethod
+    def _register_jobtype_name(cls) -> Union[str, None]:
+        if cls.__name__ == "ParallelMaster":
+            return None
+        else:
+            return cls.__name__

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -992,7 +992,4 @@ class JobGenerator(object):
 
     @classmethod
     def _register_jobtype_name(cls) -> Union[str, None]:
-        if cls.__name__ == "ParallelMaster":
-            return None
-        else:
-            return cls.__name__
+        return None

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -17,7 +17,7 @@ from pyiron_base.master.generic import GenericMaster
 from pyiron_base.master.submissionstatus import SubmissionStatus
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.jobstatus import JobStatus
-from pyiron_base.job.jobtype import unregistered_jobtype
+from pyiron_base.job.jobtype import JobType
 from pyiron_base.state import state
 from pyiron_base.job.wrapper import job_wrapper_function
 from pyiron_base.generic.util import deprecate
@@ -34,7 +34,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@unregistered_jobtype
+@JobType.unregister
 class ParallelMaster(GenericMaster):
     """
     MasterJob that handles the creation and analysis of several parallel jobs (including master and

--- a/pyiron_base/master/parallel.py
+++ b/pyiron_base/master/parallel.py
@@ -7,7 +7,6 @@ The parallel master class is a metajob consisting of a list of jobs which are ex
 
 from collections import OrderedDict
 from datetime import datetime
-from typing import Union
 
 import numpy as np
 import pandas
@@ -18,6 +17,7 @@ from pyiron_base.master.generic import GenericMaster
 from pyiron_base.master.submissionstatus import SubmissionStatus
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.jobstatus import JobStatus
+from pyiron_base.job.jobtype import unregistered_jobtype
 from pyiron_base.state import state
 from pyiron_base.job.wrapper import job_wrapper_function
 from pyiron_base.generic.util import deprecate
@@ -34,6 +34,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+@unregistered_jobtype
 class ParallelMaster(GenericMaster):
     """
     MasterJob that handles the creation and analysis of several parallel jobs (including master and
@@ -989,7 +990,3 @@ class JobGenerator(object):
         else:
             self._master.refresh_job_status()
             raise StopIteration()
-
-    @classmethod
-    def _register_jobtype_name(cls) -> Union[str, None]:
-        return None

--- a/tests/generic/test_jobtype.py
+++ b/tests/generic/test_jobtype.py
@@ -1,0 +1,35 @@
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from pyiron_base._tests import PyironTestCase
+from pyiron_base import JobType
+
+
+class TestJobType(PyironTestCase):
+    def test_job_class_dict(self):
+        job_dict = JobType._job_class_dict
+
+        old_job_type_dict = {
+            "FlexibleMaster": "pyiron_base.master.flexible",
+            "ScriptJob": "pyiron_base.job.script",
+            "SerialMasterBase": "pyiron_base.master.serial",
+            "TableJob": "pyiron_base.table.datamining",
+            "WorkerJob": "pyiron_base.job.worker",
+        }
+
+        for key in old_job_type_dict:
+            self.assertIn(key, job_dict)
+            self.assertEqual(job_dict[key], old_job_type_dict[key])
+
+        excluded_jobs = [
+            "ListMaster",
+            "ParallelMaster",
+            "InteractiveBase",
+            "InteractiveWrapper",
+            "TemplateJob",
+            "PythonTemplateJob",
+            "GenericMaster",
+        ]
+        for key in excluded_jobs:
+            with self.subTest(key):
+                self.assertNotIn(key, old_job_type_dict)

--- a/tests/generic/test_jobtype.py
+++ b/tests/generic/test_jobtype.py
@@ -32,4 +32,4 @@ class TestJobType(PyironTestCase):
         ]
         for key in excluded_jobs:
             with self.subTest(key):
-                self.assertNotIn(key, old_job_type_dict)
+                self.assertNotIn(key, job_dict)

--- a/tests/job/test_jobtype.py
+++ b/tests/job/test_jobtype.py
@@ -5,17 +5,18 @@ from pyiron_base._tests import PyironTestCase
 from pyiron_base import JobType, GenericJob
 
 
+old_job_type_dict = {
+    "FlexibleMaster": "pyiron_base.master.flexible",
+    "ScriptJob": "pyiron_base.job.script",
+    "SerialMasterBase": "pyiron_base.master.serial",
+    "TableJob": "pyiron_base.table.datamining",
+    "WorkerJob": "pyiron_base.job.worker",
+}
+
+
 class TestJobType(PyironTestCase):
     def test_job_class_dict(self):
         job_dict = JobType._job_class_dict
-
-        old_job_type_dict = {
-            "FlexibleMaster": "pyiron_base.master.flexible",
-            "ScriptJob": "pyiron_base.job.script",
-            "SerialMasterBase": "pyiron_base.master.serial",
-            "TableJob": "pyiron_base.table.datamining",
-            "WorkerJob": "pyiron_base.job.worker",
-        }
 
         for key in old_job_type_dict:
             self.assertIn(key, job_dict)
@@ -37,8 +38,13 @@ class TestJobType(PyironTestCase):
     def test_convert_str_to_class(self):
         for job_type in JobType._job_class_dict:
             with self.subTest(job_type):
-                cls = JobType.convert_str_to_class(JobType._job_class_dict, job_type)
-                self.assertTrue(
-                    issubclass(cls, GenericJob),
-                    msg=f"{cls} is not a subclass of GenericJob",
-                )
+                try:
+                    cls = JobType.convert_str_to_class(JobType._job_class_dict, job_type)
+                except AttributeError:
+                    print(f"Could not receive {job_type} class from {JobType._job_class_dict[job_type]}.")
+                    self.assertNotIn(job_type, old_job_type_dict)
+                else:
+                    self.assertTrue(
+                        issubclass(cls, GenericJob),
+                        msg=f"{cls} is not a subclass of GenericJob",
+                    )

--- a/tests/job/test_jobtype.py
+++ b/tests/job/test_jobtype.py
@@ -38,4 +38,7 @@ class TestJobType(PyironTestCase):
         for job_type in JobType._job_class_dict:
             with self.subTest(job_type):
                 cls = JobType.convert_str_to_class(JobType._job_class_dict, job_type)
-                self.assertIsInstance(cls, GenericJob)
+                self.assertTrue(
+                    issubclass(cls, GenericJob),
+                    msg=f"{cls} is not a subclass of GenericJob",
+                )

--- a/tests/job/test_jobtype.py
+++ b/tests/job/test_jobtype.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from pyiron_base._tests import PyironTestCase
-from pyiron_base import JobType
+from pyiron_base import JobType, GenericJob
 
 
 class TestJobType(PyironTestCase):
@@ -33,3 +33,9 @@ class TestJobType(PyironTestCase):
         for key in excluded_jobs:
             with self.subTest(key):
                 self.assertNotIn(key, job_dict)
+
+    def test_convert_str_to_class(self):
+        for job_type in JobType._job_class_dict:
+            with self.subTest(job_type):
+                cls = JobType.convert_str_to_class(JobType._job_class_dict, job_type)
+                self.assertIsInstance(cls, GenericJob)


### PR DESCRIPTION
Just one idea I have floating around and mentioned in #627 
This could be used to get rid of the `JOB_CLASS_DICT` and ease implementing new classes for new developers, since they only would need to write the class itself without 'by-hand' registering the class.