### PR TITLE
Fix formatting strings in server debug messages

### DIFF
--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -183,19 +183,13 @@ class Server:  # add the option to return the job id and the hold id to the serv
                 )
                 if cores != self.cores:
                     self._cores = cores
-                    state.logger.debug(
-                        "Updated the number of cores to: {}".format(cores)
-                    )
+                    state.logger.debug("Updated the number of cores to: %i", cores)
                 if run_time_max != self.run_time:
                     self._run_time = run_time_max
-                    state.logger.debug(
-                        "Updated the run time limit to: {}".format(run_time_max)
-                    )
+                    state.logger.debug("Updated the run time limit to: %i", run_time_max)
                 if memory_max != self.memory_limit:
                     self._memory_limit = memory_max
-                    state.logger.debug(
-                        "Updated the memory limit to: {}".format(memory_max)
-                    )
+                    state.logger.debug("Updated the memory limit to: %i", memory_max)
                 self._active_queue = new_scheduler
                 self.run_mode = "queue"
             else:
@@ -259,7 +253,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
             )[0]
             if cores != new_cores:
                 self._cores = cores
-                state.logger.debug("Updated the number of cores to: ", cores)
+                state.logger.debug("Updated the number of cores to: %i", cores)
             else:
                 self._cores = new_cores
         else:
@@ -296,7 +290,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
             )[1]
             if run_time_max != new_run_time:
                 self._run_time = run_time_max
-                state.logger.debug("Updated the run time limit to: ", run_time_max)
+                state.logger.debug("Updated the run time limit to: %i", run_time_max)
             else:
                 self._run_time = new_run_time
         else:
@@ -317,7 +311,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
             )[2]
             if memory_max != limit:
                 self._memory_limit = memory_max
-                state.logger.debug("Updated the memory limit to: ", memory_max)
+                state.logger.debug("Updated the memory limit to: %i", memory_max)
             else:
                 self._memory_limit = limit
         else:

--- a/pyiron_base/server/generic.py
+++ b/pyiron_base/server/generic.py
@@ -186,7 +186,9 @@ class Server:  # add the option to return the job id and the hold id to the serv
                     state.logger.debug("Updated the number of cores to: %i", cores)
                 if run_time_max != self.run_time:
                     self._run_time = run_time_max
-                    state.logger.debug("Updated the run time limit to: %i", run_time_max)
+                    state.logger.debug(
+                        "Updated the run time limit to: %i", run_time_max
+                    )
                 if memory_max != self.memory_limit:
                     self._memory_limit = memory_max
                     state.logger.debug("Updated the memory limit to: %i", memory_max)


### PR DESCRIPTION
Previously this was inconsistent (.format-style vs. %-style) and
sometimes completely missing, which lead to errors from the logging
module.