### PR TITLE
Adding to install dialog

### DIFF
--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -115,7 +115,7 @@ def install_dialog(silently=False):
                 config_file_name="~/.pyiron",
                 zip_file="resources.tar.gz",
                 resource_directory="~/pyiron/resources",
-                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
+                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/latest/resources-0.0.18.tar.gz",
                 git_folder_name="resources",
             )
         else:

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -99,7 +99,7 @@ def install_dialog(input_by_user=True):
         user_input = None
     else:
         user_input = "yes"
-    
+
     if "PYIRONCONFIG" in os.environ.keys():
         config_file = os.environ["PYIRONCONFIG"]
     else:

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -98,7 +98,8 @@ def install_dialog(input_by_user=True):
     if input_by_user:
         user_input = None
     else:
-        user_input = 'yes'
+        user_input = "yes"
+    
     if "PYIRONCONFIG" in os.environ.keys():
         config_file = os.environ["PYIRONCONFIG"]
     else:

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -20,14 +20,11 @@ __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
-_resource_latest_tag = "0.0.18"
-
 
 def _download_resources(
     zip_file="resources.tar.gz",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
-                        f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/latest/download/resources.tar.gz",
     git_folder_name="resources",
 ):
     """
@@ -119,8 +116,7 @@ def install_dialog(silently=False):
                 config_file_name="~/.pyiron",
                 zip_file="resources.tar.gz",
                 resource_directory="~/pyiron/resources",
-                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
-                                    f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
+                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/latest/download/resources.tar.gz",
                 git_folder_name="resources",
             )
         else:
@@ -134,8 +130,7 @@ def install_pyiron(
     zip_file="resources.tar.gz",
     project_path="~/pyiron/projects",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
-                        f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/latest/download/resources.tar.gz",
     git_folder_name="resources",
 ):
     """

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -20,11 +20,14 @@ __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
+_resource_latest_tag = "0.0.18"
+
 
 def _download_resources(
     zip_file="resources.tar.gz",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
+                        f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
     git_folder_name="resources",
 ):
     """
@@ -45,6 +48,7 @@ def _download_resources(
     temp_directory = tempfile.gettempdir()
     temp_zip_file = os.path.join(temp_directory, zip_file)
     temp_extract_folder = os.path.join(temp_directory, git_folder_name)
+    print(f"url:{giturl_for_zip_file}")
     urllib2.urlretrieve(giturl_for_zip_file, temp_zip_file)
     if os.path.exists(user_directory):
         raise ValueError(
@@ -115,7 +119,8 @@ def install_dialog(silently=False):
                 config_file_name="~/.pyiron",
                 zip_file="resources.tar.gz",
                 resource_directory="~/pyiron/resources",
-                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/latest/resources-0.0.18.tar.gz",
+                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
+                                    f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
                 git_folder_name="resources",
             )
         else:
@@ -129,7 +134,8 @@ def install_pyiron(
     zip_file="resources.tar.gz",
     project_path="~/pyiron/projects",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/"
+                        f"{_resource_latest_tag}/resources-{_resource_latest_tag}.tar.gz",
     git_folder_name="resources",
 ):
     """

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -24,7 +24,7 @@ __date__ = "Sep 1, 2017"
 def _download_resources(
     zip_file="resources.tar.gz",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.17/resources-0.0.17.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
     git_folder_name="resources",
 ):
     """
@@ -111,7 +111,7 @@ def install_dialog():
                 config_file_name="~/.pyiron",
                 zip_file="resources.tar.gz",
                 resource_directory="~/pyiron/resources",
-                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.17/resources-0.0.17.tar.gz",
+                giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
                 git_folder_name="resources",
             )
         else:
@@ -125,7 +125,7 @@ def install_pyiron(
     zip_file="resources.tar.gz",
     project_path="~/pyiron/projects",
     resource_directory="~/pyiron/resources",
-    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.17/resources-0.0.17.tar.gz",
+    giturl_for_zip_file="https://github.com/pyiron/pyiron-resources/releases/download/0.0.18/resources-0.0.18.tar.gz",
     git_folder_name="resources",
 ):
     """

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -45,7 +45,6 @@ def _download_resources(
     temp_directory = tempfile.gettempdir()
     temp_zip_file = os.path.join(temp_directory, zip_file)
     temp_extract_folder = os.path.join(temp_directory, git_folder_name)
-    print(f"url:{giturl_for_zip_file}")
     urllib2.urlretrieve(giturl_for_zip_file, temp_zip_file)
     if os.path.exists(user_directory):
         raise ValueError(

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -94,8 +94,8 @@ def _write_config_file(
             os.makedirs(project_path)
 
 
-def install_dialog(input_by_user=True):
-    if input_by_user:
+def install_dialog(silently=False):
+    if not silently:
         user_input = None
     else:
         user_input = "yes"

--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -94,8 +94,11 @@ def _write_config_file(
             os.makedirs(project_path)
 
 
-def install_dialog():
-    user_input = None
+def install_dialog(input_by_user=True):
+    if input_by_user:
+        user_input = None
+    else:
+        user_input = 'yes'
     if "PYIRONCONFIG" in os.environ.keys():
         config_file = os.environ["PYIRONCONFIG"]
     else:


### PR DESCRIPTION
- I corrected the version of pyrion-resources to be downloaded. Now 0.0.18 is downloaded, instead of 0.0.17.
- I would like to remove the need for user's input in the `install_dialog`, if intended:
```python
pyiron_base.install_dialog(input_by_user=False)
# this does not ask the user for yes or no
pyiron_base.install_dialog()
# this asks the user for a yes/no 
``` 