### PR TITLE
Allow inverted matches in job queries

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -113,7 +113,7 @@ class IsDatabase(ABC):
                 )
         for key, val in kwargs.items():
             invert = False
-            if val[0] == "!":
+            if val is not None and val[0] == "!":
                 invert = True
                 val = val[1:]
             if val is None:

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -109,6 +109,10 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertEqual(len(self.project.job_table(recursive=True, job="*_1*")), 2)
         self.assertEqual(len(self.project.job_table(recursive=True, job="*_*")), 4)
         self.assertEqual(len(self.project.job_table(recursive=False, status="finished", job="toy_1")), 1)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="!finished")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True, status="!aborted")), 3)
+        self.assertEqual(len(self.project.job_table(recursive=True, job="!toy_1")), 2)
+        self.assertEqual(len(self.project.job_table(recursive=True, job="!toy_*")), 0)
         self.assertRaises(ValueError, self.project.job_table, gibberish=True)
 
     def test_get_iter_jobs(self):


### PR DESCRIPTION
I sometimes want to get jobs that are not matching a certain thing, like all not finished jobs, so with this you can do e.g. `job_table(status='!finished')`.  Works also with the other wildcards.