### PR TITLE
Add clearer error message in DataContainer.from_hdf

### DIFF
--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -815,8 +815,10 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
                     k, i = name.split("__index_", maxsplit=1)
                     i = int(i)
                 except ValueError:
-                    raise ValueError(f"Could not parse item name {name} in HDF group {hdf.h5_path}. "
-                                     "Was this group really written by a DataContainer?") from None
+                    raise ValueError(
+                        f"Could not parse item name {name} in HDF group {hdf.h5_path}. "
+                        "Was this group really written by a DataContainer?"
+                    ) from None
                 if k == "":
                     return i, i
                 else:

--- a/pyiron_base/generic/datacontainer.py
+++ b/pyiron_base/generic/datacontainer.py
@@ -811,8 +811,12 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
             def normalize_key(name):
                 # split a dataset/group name into the position in the list and
                 # the key
-                k, i = name.split("__index_", maxsplit=1)
-                i = int(i)
+                try:
+                    k, i = name.split("__index_", maxsplit=1)
+                    i = int(i)
+                except ValueError:
+                    raise ValueError(f"Could not parse item name {name} in HDF group {hdf.h5_path}. "
+                                     "Was this group really written by a DataContainer?") from None
                 if k == "":
                     return i, i
                 else:


### PR DESCRIPTION
When trying to read a DataContainer from a HDf group where none was
stored before (potentially due to an unrelated coding error), this would
usually fail with a cryptic error from normalize_key.  This patch
intercepts that error and re-raises a new one with a clearer error
message.