### PR TITLE
Better handling of custom IO for template job

### DIFF
--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -31,7 +31,7 @@ class TemplateJob(GenericJob, HasStorage):
 
     @property
     def _input_class(self) -> Type[DataContainer]:
-        """Children can overwrite this method to return some other child of DataContainer for custom behaviour"""
+        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour"""
         return DataContainer
 
     @property

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -36,7 +36,7 @@ class TemplateJob(GenericJob, HasStorage):
 
     @property
     def _output_class(self) -> Type[DataContainer]:
-        """Children can overwrite this method to return some other child of DataContainer for custom behaviour"""
+        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour"""
         return DataContainer
 
     @property

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -46,8 +46,21 @@ class TemplateJob(GenericJob, HasStorage):
     @input.setter
     def input(self, new_input):
         raise AttributeError(
-            "Input cannot be overwritten; to get custom output behaviour, override the `_input_class` property to "
-            "return your own custom class (which inherits from `DataContainer`)."
+            """
+            Input cannot be overwritten; to get custom input behaviour, override the `_input_class` property to return 
+            your own custom class (which inherits from `DataContainer`).
+            
+            Example:
+            >>> class MyInput(DataContainer):
+            >>>     def __init__(self, init=None, table_name=None, lazy=False, wrap_blacklist=()):
+            >>>         super().__init__(init=init, table_name=table_name, lazy=lazy, wrap_blacklist=wrap_blacklist)
+            >>>         self.foo = 42
+            >>>
+            >>> class MyJob(TemplateJob):
+            >>>     @property
+            >>>     def _input_class(self) -> MyInput:
+            >>>         return MyInput
+            """
         )
 
     @property
@@ -57,8 +70,21 @@ class TemplateJob(GenericJob, HasStorage):
     @output.setter
     def output(self, new_output):
         raise AttributeError(
-            "Output cannot be overwritten; to get custom output behaviour, override the `_output_class` property to "
-            "return your own custom class (which inherits from `DataContainer`)."
+            """
+            Output cannot be overwritten; to get custom output behaviour, override the `_output_class` property to return 
+            your own custom class (which inherits from `DataContainer`).
+
+            Example:
+            >>> class MyOutput(DataContainer):
+            >>>     def __init__(self, init=None, table_name=None, lazy=False, wrap_blacklist=()):
+            >>>         super().__init__(init=init, table_name=table_name, lazy=lazy, wrap_blacklist=wrap_blacklist)
+            >>>         self.bar = 'towel'
+            >>>
+            >>> class MyJob(TemplateJob):
+            >>>     @property
+            >>>     def _output_class(self) -> MyOutput:
+            >>>         return MyOutput
+            """
         )
 
     def to_hdf(self, hdf=None, group_name=None):

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -7,6 +7,8 @@ Template class to define jobs
 
 from pyiron_base.job.generic import GenericJob
 from pyiron_base.generic.object import HasStorage
+from pyiron_base.generic.datacontainer import DataContainer
+from typing import Type
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -24,16 +26,40 @@ class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
         HasStorage.__init__(self)
-        self.storage.create_group("input")
-        self.storage.create_group("output")
+        self.storage.input = self._input_class(table_name='input')
+        self.storage.output = self._output_class(table_name='output')
 
     @property
-    def input(self):
+    def _input_class(self) -> Type[DataContainer]:
+        """Children can overwrite this method to return some other child of DataContainer for custom behaviour"""
+        return DataContainer
+
+    @property
+    def _output_class(self) -> Type[DataContainer]:
+        """Children can overwrite this method to return some other child of DataContainer for custom behaviour"""
+        return DataContainer
+
+    @property
+    def input(self) -> Type[DataContainer]:
         return self.storage.input
 
+    @input.setter
+    def input(self, new_input):
+        raise AttributeError(
+            "Input cannot be overwritten; to get custom output behaviour, override the `_input_class` property to "
+            "return your own custom class (which inherits from `DataContainer`)."
+        )
+
     @property
-    def output(self):
+    def output(self) -> Type[DataContainer]:
         return self.storage.output
+
+    @output.setter
+    def output(self, new_output):
+        raise AttributeError(
+            "Output cannot be overwritten; to get custom output behaviour, override the `_output_class` property to "
+            "return your own custom class (which inherits from `DataContainer`)."
+        )
 
     def to_hdf(self, hdf=None, group_name=None):
         GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -26,8 +26,8 @@ class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
         HasStorage.__init__(self)
-        self.storage.input = self._input_class(table_name='input')
-        self.storage.output = self._output_class(table_name='output')
+        self.storage.input = self._input_class(table_name="input")
+        self.storage.output = self._output_class(table_name="output")
 
     @property
     def _input_class(self) -> Type[DataContainer]:

--- a/pyiron_base/job/template.py
+++ b/pyiron_base/job/template.py
@@ -31,12 +31,12 @@ class TemplateJob(GenericJob, HasStorage):
 
     @property
     def _input_class(self) -> Type[DataContainer]:
-        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour"""
+        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour."""
         return DataContainer
 
     @property
     def _output_class(self) -> Type[DataContainer]:
-        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour"""
+        """Children can overwrite this method to return some other child of `DataContainer` for custom behaviour."""
         return DataContainer
 
     @property

--- a/tests/job/test_template.py
+++ b/tests/job/test_template.py
@@ -1,0 +1,25 @@
+from pyiron_base._tests import TestWithCleanProject
+from pyiron_base.job.template import TemplateJob
+from pyiron_base.generic.datacontainer import DataContainer
+from pyiron_base.generic.hdfio import ProjectHDFio
+
+
+class TestTemplateJob(TestWithCleanProject):
+
+    def setUp(self) -> None:
+        super().setUp()
+        job_name = 'template_job'
+        self.job = TemplateJob(
+            ProjectHDFio(project=self.project.copy(), file_name=job_name),
+            job_name
+        )
+
+    def test_io(self):
+        self.assertIsInstance(self.job.input, DataContainer)
+        self.assertIsInstance(self.job.output, DataContainer)
+
+        with self.assertRaises(AttributeError):
+            self.job.input = 'foo'
+
+        with self.assertRaises(AttributeError):
+            self.job.output = 'bar'


### PR DESCRIPTION
Following up on a nice discussion of @yuyuanjingxuan's new solvation class at today's meeting. 

To make it easier for new developers to customize IO on children of `TemplateJob`, we now give a friendlier error message if the `input` or `output` fields are (attempted to be) overwritten. New properties allow setting input and output fields with custom children of `DataContainer`.