### PR TITLE
Do not initialize Executable when none saved in HDF

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1233,10 +1233,8 @@ class GenericJob(JobCore):
         if "import_directory" in self._hdf5.list_nodes():
             self._import_directory = self._hdf5["import_directory"]
         self._server.from_hdf(self._hdf5)
-        try:
+        if 'executable' in self._hdf5.list_groups():
             self.executable.from_hdf(self._hdf5)
-        except ValueError:
-            pass  # older versions of pyiron did not save executable information
         with self._hdf5.open("input") as hdf_input:
             if "generic_dict" in hdf_input.list_nodes():
                 generic_dict = hdf_input["generic_dict"]

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1234,7 +1234,7 @@ class GenericJob(JobCore):
         if "import_directory" in self._hdf5.list_nodes():
             self._import_directory = self._hdf5["import_directory"]
         self._server.from_hdf(self._hdf5)
-        if 'executable' in self._hdf5.list_groups():
+        if "executable" in self._hdf5.list_groups():
             self.executable.from_hdf(self._hdf5)
         with self._hdf5.open("input") as hdf_input:
             if "generic_dict" in hdf_input.list_nodes():

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -1193,7 +1193,8 @@ class GenericJob(JobCore):
         if self._import_directory is not None:
             self._hdf5["import_directory"] = self._import_directory
         self._server.to_hdf(self._hdf5)
-        self.executable.to_hdf(self._hdf5)
+        if self._executable is not None:
+            self.executable.to_hdf(self._hdf5)
         with self._hdf5.open("input") as hdf_input:
             generic_dict = {
                 "restart_file_list": self._restart_file_list,


### PR DESCRIPTION
The previous code first try'd to load saved executable information via

self.executable.from_hdf()

and then bailed if there was an error.  The problem is that just
accessing `self.executable` instantiates an `Executable` object on the
job even if it is a job, that does not need it, e.g. because it does not
require an external executable.  Due to the error this left the object
in an inconsistent state, unable to save itself again with `to_hdf()`.

Imo this shows that ideally we'd have at least one more `GenericJob` base class, that does not presume the need for an external executable, but that's for the future.
