### PR TITLE
Update maintenance.py

### DIFF
--- a/pyiron_base/project/maintenance.py
+++ b/pyiron_base/project/maintenance.py
@@ -65,7 +65,7 @@ class Maintenance:
             else:
                 try:
                     hash_ = repo.head.reference.commit.hexsha
-                except ValueError:
+                except (ValueError, TypeError):
                     hash_ = "Error while resolving sha"
             if hasattr(module, "__version__"):
                 version = module.__version__

--- a/pyiron_base/project/maintenance.py
+++ b/pyiron_base/project/maintenance.py
@@ -60,11 +60,13 @@ class Maintenance:
             module = importlib.import_module(name)
             try:
                 repo = Repo(os.path.dirname(os.path.dirname(module.__file__)))
-                hash_ = repo.head.reference.commit.hexsha
             except InvalidGitRepositoryError:
                 hash_ = "Not a repo"
-            except ValueError:
-                hash_ = "Error while resolving sha"
+            else:
+                try:
+                    hash_ = repo.head.reference.commit.hexsha
+                except ValueError:
+                    hash_ = "Error while resolving sha"
             if hasattr(module, "__version__"):
                 version = module.__version__
             else:

--- a/pyiron_base/project/maintenance.py
+++ b/pyiron_base/project/maintenance.py
@@ -63,6 +63,8 @@ class Maintenance:
                 hash_ = repo.head.reference.commit.hexsha
             except InvalidGitRepositoryError:
                 hash_ = "Not a repo"
+            except ValueError:
+                hash_ = "Error while resolving sha"
             if hasattr(module, "__version__"):
                 version = module.__version__
             else:

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -124,7 +124,7 @@ class TestProjectOperations(TestWithFilledProject):
 
     def test_maintenance_get_repository_status(self):
         df = self.project.maintenance.get_repository_status()
-        self.assertIn('pyiron_base', df.Module)
+        self.assertIn('pyiron_base', df.Module.values)
 
 
 class TestToolRegistration(TestWithProject):

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -122,6 +122,10 @@ class TestProjectOperations(TestWithFilledProject):
         self.assertIsInstance([val for val in self.project.iter_jobs(recursive=True, status="suspended",
                                                                      convert_to_object=True)][0], ToyJob)
 
+    def test_maintenance_get_repository_status(self):
+        df = self.project.maintenance.get_repository_status()
+        self.assertIn('pyiron_base', df.Module)
+
 
 class TestToolRegistration(TestWithProject):
     def setUp(self) -> None:


### PR DESCRIPTION
Currently, the `pr.maintenance.get_repository_status()` fails on the cluster since resolving the `SHA` for `pyiron_mpie` results in a `ValueError: SHA could not be resolved, git returned: b''`. Thus, I simply catch that error for now. 