### PR TITLE
Allow to `delete_existing_job` if it has no `job_id`

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -105,7 +105,9 @@ class ToyJob(PythonTemplateJob):
     # Check for valid input
     def validate_ready_to_run(self):
         if not isinstance(self.input.data_in, int):
-            raise ValueError(f"data_in in should be of type int, not {type(self.input.data_in)}.")
+            raise ValueError(
+                f"data_in in should be of type int, not {type(self.input.data_in)}."
+            )
 
     # This function is executed
     def run_static(self):

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -102,6 +102,11 @@ class ToyJob(PythonTemplateJob):
     def _check_if_input_should_be_written(self):
         return True
 
+    # Check for valid input
+    def validate_ready_to_run(self):
+        if not isinstance(self.input.data_in, int):
+            raise ValueError(f"data_in in should be of type int, not {type(self.input.data_in)}.")
+
     # This function is executed
     def run_static(self):
         self.status.running = True

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -707,13 +707,16 @@ class GenericJob(JobCore):
             status = self.status.string
             if run_mode is not None:
                 self.server.run_mode = run_mode
-            if delete_existing_job and self.job_id:
-                self._logger.info("run repair " + str(self.job_id))
+            if delete_existing_job:
                 status = "initialized"
-                master_id, parent_id = self.master_id, self.parent_id
-                self.remove(_protect_childs=False)
-                self.reset_job_id()
-                self.master_id, self.parent_id = master_id, parent_id
+                if self.job_id:
+                    self._logger.info("run repair " + str(self.job_id))
+                    master_id, parent_id = self.master_id, self.parent_id
+                    self.remove(_protect_childs=False)
+                    self.reset_job_id()
+                    self.master_id, self.parent_id = master_id, parent_id
+                else:
+                    self.remove(_protect_childs=False)
             if repair and self.job_id and not self.status.finished:
                 self._run_if_repair()
             elif status == "initialized":

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -6,7 +6,8 @@ import unittest
 import os
 from pyiron_base.generic.parameters import GenericParameters
 from pyiron_base.job.generic import GenericJob
-from pyiron_base._tests import TestWithFilledProject
+from pyiron_base._tests import TestWithFilledProject, ToyJob
+
 
 class ReturnCodeJob(GenericJob):
     def __init__(self, project, job_name):
@@ -139,9 +140,13 @@ class TestGenericJob(TestWithFilledProject):
             ham.decompress()
             self.assertTrue(os.path.exists(os.path.join(ham.working_directory, 'test_file')))
         with self.subTest("test remove"):
+            self.assertTrue(os.path.isfile("/".join([cwd, self.project_name, "job_single_move_2.h5"])))
             ham.project_hdf5.remove_file()
-            self.assertFalse(os.path.isfile("/".join([cwd, self.project_name, "job_single_debug_2.h5"])))
+            self.assertFalse(os.path.isfile("/".join([cwd, self.project_name, "job_single_move_2.h5"])))
             self.assertFalse(os.path.isfile(ham.project_hdf5.file_name))
+            self.assertTrue(os.path.exists(os.path.join(ham.working_directory, 'test_file')))
+            ham.remove()
+            self.assertFalse(os.path.exists(os.path.join(ham.working_directory, 'test_file')))
 
     def test_move(self):
         pr_a = self.project.open("project_a")

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -275,6 +275,28 @@ class TestGenericJob(TestWithFilledProject):
     def test_run_if_finished(self):
         pass
 
+    def test_run_with_delete_existing_job_for_aborted_jobs(self):
+        job = self.project.create_job(ToyJob, 'rerun_aborted')
+        with self.subTest("Drop to aborted if validate_ready_to_run fails"):
+            job.input.data_in = 'some_str'
+            self.assertRaises(ValueError, job.run)
+            self.assertTrue(job.status.aborted)
+            self.assertIsNone(job.job_id)
+        with self.subTest("run without delete_existing_job does not change anything."):
+            job.run()
+            self.assertTrue(job.status.aborted)
+        with self.subTest("changing input and run(delete_existing_job=True) should run"):
+            job.input.data_in = 10
+            job.run(delete_existing_job=True)
+            self.assertIsInstance(job.job_id, int)
+            self.assertEqual(job.output.data_out, 11)
+            self.assertTrue(job.status.finished)
+        with self.subTest("changing input and run(delete_existing_job=True) should run also for finished jobs"):
+            job.input.data_in = 15
+            job.run(delete_existing_job=True)
+            self.assertEqual(job.output.data_out, 16)
+            self.assertTrue(job.status.finished)
+
     def test_suspend(self):
         pass
 


### PR DESCRIPTION
The `validate_ready_to_run()` raises an `ValueError` or `pass`es. However, with #770 it is quite odd since
```python
from pyiron_atomistics import Project

pr = Project('ToBeRemoved')
job = pr.create.job.Lammps('lmp')
job.run()
>>> ValueError: This job does not contain a valid structure: lmp
```
and afterwards
```python
job.structure =  pr.create.structure.bulk('Al')
job.run(delete_existing_job=True)
```
does only `return None`.

_Originally posted by @niklassiemer in https://github.com/pyiron/pyiron_base/issues/782#issuecomment-1167405124_

This is caused by the unassigned `job_id`. With these changes the above code snipped works for me - Tests missing.