### PR TITLE
Raise an error if `run` is called for an aborted job

### DIFF
--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -742,7 +742,9 @@ class GenericJob(JobCore):
                     run_again=run_again,
                 )
             elif status == "aborted":
-                raise ValueError("Running an aborted job with `delete_existing_job=False` is meaningless.")
+                raise ValueError(
+                    "Running an aborted job with `delete_existing_job=False` is meaningless."
+                )
         except Exception:
             self.drop_status_to_aborted()
             raise

--- a/pyiron_base/job/generic.py
+++ b/pyiron_base/job/generic.py
@@ -741,6 +741,8 @@ class GenericJob(JobCore):
                     delete_existing_job=delete_existing_job,
                     run_again=run_again,
                 )
+            elif status == "aborted":
+                raise ValueError("Running an aborted job with `delete_existing_job=False` is meaningless.")
         except Exception:
             self.drop_status_to_aborted()
             raise

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -282,8 +282,8 @@ class TestGenericJob(TestWithFilledProject):
             self.assertRaises(ValueError, job.run)
             self.assertTrue(job.status.aborted)
             self.assertIsNone(job.job_id)
-        with self.subTest("run without delete_existing_job does not change anything."):
-            job.run()
+        with self.subTest("run without delete_existing_job raises a RuntimeError."):
+            self.assertRaises(ValueError, job.run)
             self.assertTrue(job.status.aborted)
         with self.subTest("changing input and run(delete_existing_job=True) should run"):
             job.input.data_in = 10

--- a/tests/job/test_script.py
+++ b/tests/job/test_script.py
@@ -39,7 +39,7 @@ class TestScriptJob(TestWithCleanProject):
         with open(self.simple_script, 'w') as f:
             f.write("print(42)")
         self.job.script_path = self.simple_script
-        self.job.run()
+        self.job.run(delete_existing_job=True)
 
     def test_project_data(self):
         self.project.data.in_ = 6


### PR DESCRIPTION
closes #770 
If we want to raise an error in this case. We could also just warn?