### PR TITLE
Hotfix for pack/unpack: Add flag to include all files in jobs

### DIFF
--- a/pyiron_base/archiving/export_archive.py
+++ b/pyiron_base/archiving/export_archive.py
@@ -59,7 +59,16 @@ def compress_dir(archive_directory):
     rmtree(archive_directory)
 
 
-def copy_files_to_archive(directory_to_transfer, archive_directory, compressed=True):
+def copy_files_to_archive(directory_to_transfer, archive_directory, compressed=True, copy_all_files=False):
+    """
+    Create an archive of jobs in directory_to_transfer.
+
+    Args:
+        directory_to_transfer (str): project directory with jobs to export
+        archive_directory (str): name of the final archive; if no file ending is given .tar.gz is added automatically when needed
+        compressed (bool): if True compress archive_directory as a tarball; default True
+        copy_all_files (bool): if True include job output files in archive, otherwise just include .h5 files; default False
+    """
     if archive_directory[-7:] == ".tar.gz":
         archive_directory = archive_directory[:-7]
         if not compressed:
@@ -70,7 +79,10 @@ def copy_files_to_archive(directory_to_transfer, archive_directory, compressed=T
     else:
         directory_to_transfer = os.path.basename(directory_to_transfer[:-1])
     # print("directory to transfer: "+directory_to_transfer)
-    pfi = PyFileIndex(path=directory_to_transfer, filter_function=filter_function)
+    if not copy_all_files:
+        pfi = PyFileIndex(path=directory_to_transfer, filter_function=filter_function)
+    else:
+        pfi = PyFileIndex(path=directory_to_transfer)
     df_files = pfi.dataframe[~pfi.dataframe.is_directory]
 
     # Create directories

--- a/pyiron_base/archiving/export_archive.py
+++ b/pyiron_base/archiving/export_archive.py
@@ -59,7 +59,9 @@ def compress_dir(archive_directory):
     rmtree(archive_directory)
 
 
-def copy_files_to_archive(directory_to_transfer, archive_directory, compressed=True, copy_all_files=False):
+def copy_files_to_archive(
+    directory_to_transfer, archive_directory, compressed=True, copy_all_files=False
+):
     """
     Create an archive of jobs in directory_to_transfer.
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1535,19 +1535,19 @@ class Project(ProjectPath, HasGroups):
                 for entry in db_entry_in_old_format:
                     self.db.item_update({"project": self.project_path}, entry["id"])
 
-    def pack(self, destination_path, csv_file_name="export.csv", compress=True):
+    def pack(self, destination_path, csv_file_name="export.csv", compress=True, copy_all_files=False):
         """
-        by this funtion, the job table is exported to a csv file
-        and the project directory is copied and compressed (by default) to a file.
+        Export job table to a csv file and copy (and optionally compress) the project directory.
 
         Args:
-        destination_path (str) gives the ralative path, in which the project folder is copied and the compressed
-        csv_file_name (str) is the name of the csv file used to store the project table.
-        compress (boolian), if true, the function will compress the destination_path to a tar.gz file.
+            destination_path (str): gives the relative path, in which the project folder is copied and compressed
+            csv_file_name (str): is the name of the csv file used to store the project table.
+            compress (bool): if true, the function will compress the destination_path to a tar.gz file.
+            copy_all_files (bool):
         """
         directory_to_transfer = os.path.basename(self.path[:-1])
         export_archive.copy_files_to_archive(
-            directory_to_transfer, destination_path, compressed=compress
+            directory_to_transfer, destination_path, compressed=compress, copy_all_files=copy_all_files
         )
         df = export_archive.export_database(
             self, directory_to_transfer, destination_path

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1535,7 +1535,13 @@ class Project(ProjectPath, HasGroups):
                 for entry in db_entry_in_old_format:
                     self.db.item_update({"project": self.project_path}, entry["id"])
 
-    def pack(self, destination_path, csv_file_name="export.csv", compress=True, copy_all_files=False):
+    def pack(
+        self,
+        destination_path,
+        csv_file_name="export.csv",
+        compress=True,
+        copy_all_files=False,
+    ):
         """
         Export job table to a csv file and copy (and optionally compress) the project directory.
 
@@ -1547,7 +1553,10 @@ class Project(ProjectPath, HasGroups):
         """
         directory_to_transfer = os.path.basename(self.path[:-1])
         export_archive.copy_files_to_archive(
-            directory_to_transfer, destination_path, compressed=compress, copy_all_files=copy_all_files
+            directory_to_transfer,
+            destination_path,
+            compressed=compress,
+            copy_all_files=copy_all_files,
         )
         df = export_archive.export_database(
             self, directory_to_transfer, destination_path


### PR DESCRIPTION
Previously `pr.pack` only keeps the HDF5 files and not the files inside the job directory.  I've added a quick hack to allow exporting of all files.  This has the side effect of including all files in a project directory not just job related ones and is a bit sluggish.  However I'll need this functionality quickly and am unwilling to spend a great deal of effort to patch this in, when we are going to rewrite this functionality anyway.