### PR TITLE
disable auto-registration

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1491,11 +1491,6 @@ class GenericJob(JobCore):
             self._logger.info("busy master: {} {}".format(master_id, self.get_job_id()))
             del self
 
-    def __init_subclass__(cls, **kwargs):
-        """Auto register all subclasses of GenericJob as available JobType."""
-        super().__init_subclass__(**kwargs)
-        JobType.register(cls, _autoregister=True)
-
 
 class GenericError(object):
     def __init__(self, job):

--- a/pyiron_base/jobs/job/interactive.py
+++ b/pyiron_base/jobs/job/interactive.py
@@ -21,7 +21,6 @@ __status__ = "production"
 __date__ = "Sep 1, 2018"
 
 
-@JobType.unregister
 class InteractiveBase(GenericJob):
     """
     InteractiveBase class extends the Generic Job class with all the functionality to run the job object interactively.

--- a/pyiron_base/jobs/job/jobtype.py
+++ b/pyiron_base/jobs/job/jobtype.py
@@ -126,7 +126,6 @@ class JobType:
         job_class_or_module_str: Union[type, str],
         job_name: str = None,
         overwrite=False,
-        _autoregister=False,
     ):
         """Register job type from the exposed list of available job types
 
@@ -163,16 +162,10 @@ class JobType:
             and job_name in cls._job_class_dict
             and cls_module_str != cls._job_class_dict[job_name]
         ):
-            info_text = (
+            ValueError(
                 f"A JobType with name '{job_name}' is already defined! New class = '{cls_module_str}', "
                 f"already registered class = '{cls._job_class_dict[job_name]}'."
             )
-            if _autoregister:
-                state.logger.info(
-                    info_text + " Not replaced since attempted by auto-registration!"
-                )
-            else:
-                raise ValueError(info_text)
         else:
             cls._job_class_dict[job_name] = cls_module_str
 

--- a/pyiron_base/jobs/job/template.py
+++ b/pyiron_base/jobs/job/template.py
@@ -21,7 +21,6 @@ __status__ = "development"
 __date__ = "May 15, 2020"
 
 
-@JobType.unregister
 class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
@@ -46,7 +45,6 @@ class TemplateJob(GenericJob, HasStorage):
         HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name="")
 
 
-@JobType.unregister
 class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)

--- a/pyiron_base/jobs/master/generic.py
+++ b/pyiron_base/jobs/master/generic.py
@@ -24,7 +24,6 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@JobType.unregister
 class GenericMaster(GenericJob):
     """
     The GenericMaster is the template class for all meta jobs - meaning all jobs which contain multiple other jobs. It

--- a/pyiron_base/jobs/master/interactivewrapper.py
+++ b/pyiron_base/jobs/master/interactivewrapper.py
@@ -22,7 +22,6 @@ __status__ = "development"
 __date__ = "Jan 8, 2021"
 
 
-@JobType.unregister
 class InteractiveWrapper(GenericMaster):
     def __init__(self, project, job_name):
         super(InteractiveWrapper, self).__init__(project, job_name)

--- a/pyiron_base/jobs/master/list.py
+++ b/pyiron_base/jobs/master/list.py
@@ -24,7 +24,6 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@JobType.unregister
 class ListMaster(GenericMaster):
     """
     The ListMaster is the most simple MetaJob derived from the GenericMaster. It behaves like a Python list object. Jobs

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -34,7 +34,6 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-@JobType.unregister
 class ParallelMaster(GenericMaster):
     """
     MasterJob that handles the creation and analysis of several parallel jobs (including master and

--- a/tests/job/test_jobtype.py
+++ b/tests/job/test_jobtype.py
@@ -55,41 +55,29 @@ class TestJobType(PyironTestCase):
 
     def test_register(self):
         job_class_list_no_error = [
-            ('job1', 'pyiron_module.sub_module'),
-            ('job2', 'pyiron_module.sub_module'),
-            ('job3', 'pyiron_module.sub_module'),
-            ('job1', 'pyiron_module.sub_module'),
-            ('job_atomistics', 'pyiron_atomistics.sub_module'),
-            ('job_atomistics', 'pyiron.sub_module'),
+            ("job1", "pyiron_module.sub_module"),
+            ("job2", "pyiron_module.sub_module"),
+            ("job3", "pyiron_module.sub_module"),
+            ("job1", "pyiron_module.sub_module"),
+            ("job_atomistics", "pyiron_atomistics.sub_module"),
+            ("job_atomistics", "pyiron.sub_module"),
         ]
         for job_type in job_class_list_no_error:
             with self.subTest(job_type[1]):
                 JobType.register(job_type[1], job_type[0])
                 self.assertIn(job_type[0], JobType._job_class_dict)
 
-        self.assertRaises(ValueError, JobType.register, 'pyiron_module.other_sub_module', 'job1')
-        self.assertEqual(JobType._job_class_dict['job1'], 'pyiron_module.sub_module')
+        self.assertRaises(
+            ValueError, JobType.register, ("pyiron_module.other_sub_module", "job1")
+        )
+        self.assertEqual(JobType._job_class_dict["job1"], "pyiron_module.sub_module")
 
-        with self.subTest('overwrite'):
-            JobType.register('pyiron_module.other_sub_module', 'job1', overwrite=True)
-            self.assertEqual(JobType._job_class_dict['job1'], 'pyiron_module.other_sub_module')
-
-        with self.subTest('auto_register'):
-            JobType.register('not.a.module', 'job2', _autoregister=True)
-            self.assertEqual(JobType._job_class_dict['job2'], 'pyiron_module.sub_module')
-
-        with self.subTest('genericJob'):
-            class JobClass(GenericJob):
-                pass
-            self.assertIn('JobClass', JobType._job_class_dict)
-            self.assertEqual(JobType._job_class_dict['JobClass'], self.__module__)
-
-        with self.subTest('auto_register genericJob'):
-            class job2(GenericJob):
-                pass
-            self.assertEqual(JobType._job_class_dict['job2'], 'pyiron_module.sub_module')
+        with self.subTest("overwrite"):
+            JobType.register("pyiron_module.other_sub_module", "job1", overwrite=True)
+            self.assertEqual(
+                JobType._job_class_dict["job1"], "pyiron_module.other_sub_module"
+            )
 
         # Cleanup
-        for job in ['job1', 'job2', 'job3', 'job_atomistics', 'JobClass']:
+        for job in ["job1", "job2", "job3", "job_atomistics"]:
             JobType.unregister(job)
-


### PR DESCRIPTION
Disabled auto-Registration of `GenericJob` subclasses.
Replaces #804