### PR TITLE
ignore non-pyiron HDF5 files

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -58,7 +58,7 @@ class FileTable(IsDatabase, metaclass=Singleton):
         fileindex = fileindex.iloc[fileindex.path.values.argsort()]
         job_lst = []
         for path, mtime in zip(fileindex.path, fileindex.mtime):
-            try:
+            try:  # Ignore HDF5 files which are not created by pyiron
                 job_dict = self.get_extract(path, mtime)
             except ValueError:
                 pass

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -68,7 +68,9 @@ class FileTable(IsDatabase, metaclass=Singleton):
                     job_dict["project"][:-1] + job_dict["subjob"] + "_hdf5/"
                 )
                 if job_dict["project"] in working_dir_lst:
-                    job_dict["masterid"] = working_dir_lst.index(job_dict["project"]) + 1
+                    job_dict["masterid"] = (
+                        working_dir_lst.index(job_dict["project"]) + 1
+                    )
                 else:
                     job_dict["masterid"] = None
                 job_lst.append(job_dict)


### PR DESCRIPTION
As VASP and LAMMPS both started to use HDF5 files, these can lead to confusion for pyiron without database. With this pull request those files are now ignored. 