### PR TITLE
Clean overwritting of DataContainers in HDF

### DIFF
--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -211,8 +211,10 @@ class HasHDF(ABC):
             group_name if group_name is not None else self._get_hdf_group_name()
         )
         with _WithHDF(hdf, group_name) as hdf:
-            if group_name is None \
-                    and (len(hdf.list_nodes()) > 0 or len(hdf.list_dirs())) > 0:
+            if (
+                group_name is None
+                and (len(hdf.list_nodes()) > 0 or len(hdf.list_dirs())) > 0
+            ):
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
             self._store_type_to_hdf(hdf)

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -23,6 +23,8 @@ class _WithHDF:
     __slots__ = ("_hdf", "_group_name")
 
     def __init__(self, hdf, group_name=None):
+        if group_name in hdf.list_nodes():
+            raise ValueError(f"{group_name} is a node and not a group!")
         self._hdf = hdf
         self._group_name = group_name
 
@@ -209,7 +211,8 @@ class HasHDF(ABC):
             group_name if group_name is not None else self._get_hdf_group_name()
         )
         with _WithHDF(hdf, group_name) as hdf:
-            if len(hdf.list_dirs()) > 0 and group_name is None:
+            if group_name is None \
+                    and (len(hdf.list_nodes()) > 0 or len(hdf.list_dirs())) > 0:
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
             self._store_type_to_hdf(hdf)

--- a/pyiron_base/interfaces/object.py
+++ b/pyiron_base/interfaces/object.py
@@ -27,14 +27,26 @@ __date__ = "Mar 23, 2021"
 class HasStorage(HasHDF, ABC):
     """
     A base class for objects that use HDF5 data serialization via the `DataContainer` class.
+
+    Unless you know what you are doing sub classes should pass the `group_name` argument to :meth:`~.__init__` or
+    override :meth:`~.get_hdf_group_name()` to force a default name for the HDF group the object should write itself to.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, group_name=None, **kwargs):
+        """
+
+        Args:
+            group_name (str): default name of the HDF group where the whole object should be written to.
+        """
         self._storage = DataContainer(table_name="storage")
+        self._group_name = group_name
 
     @property
     def storage(self) -> DataContainer:
         return self._storage
+
+    def _get_hdf_group_name(self) -> str:
+        return self._group_name
 
     def _to_hdf(self, hdf: ProjectHDFio):
         self.storage.to_hdf(hdf=hdf)

--- a/pyiron_base/jobs/job/template.py
+++ b/pyiron_base/jobs/job/template.py
@@ -25,7 +25,7 @@ __date__ = "May 15, 2020"
 class TemplateJob(GenericJob, HasStorage):
     def __init__(self, project, job_name):
         GenericJob.__init__(self, project, job_name)
-        HasStorage.__init__(self)
+        HasStorage.__init__(self, group_name="")
         self.storage.create_group("input")
         self.storage.create_group("output")
 
@@ -39,11 +39,11 @@ class TemplateJob(GenericJob, HasStorage):
 
     def to_hdf(self, hdf=None, group_name=None):
         GenericJob.to_hdf(self, hdf=hdf, group_name=group_name)
-        HasStorage.to_hdf(self, hdf=self.project_hdf5, group_name="")
+        HasStorage.to_hdf(self, hdf=self.project_hdf5)
 
     def from_hdf(self, hdf=None, group_name=None):
         GenericJob.from_hdf(self, hdf=hdf, group_name=group_name)
-        HasStorage.from_hdf(self, hdf=self.project_hdf5, group_name="")
+        HasStorage.from_hdf(self, hdf=self.project_hdf5)
 
 
 @JobType.unregister

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -800,6 +800,10 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
             if hasattr(v, "to_hdf") and not isinstance(
                 v, (pandas.DataFrame, pandas.Series)
             ):
+                # if v will be written as a group, but a node of the same name k exists already in the file, h5py will
+                # complain, so delete it first
+                if k in hdf.list_nodes():
+                    del hdf[k]
                 v.to_hdf(hdf=hdf, group_name=k)
             else:
                 # if the value doesn't know how to serialize itself, assume

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -916,7 +916,7 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
         if not self._lazy and not recursive:
             return
 
-        # values are loaded from HDF once they are accessed via __getitem__, which is implicetly called by values()
+        # values are loaded from HDF once they are accessed via __getitem__, which is implicitly called by values()
         for v in self.values():
             if recursive and isinstance(v, DataContainer):
                 v._force_load()

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -260,7 +260,7 @@ class FileHDFio(HasGroups, MutableMapping):
         h5io.write_hdf5(
             self.file_name,
             value,
-            title=posixpath.join(self.h5_path, key),
+            title=self._get_h5_path(key),
             overwrite="update",
             use_json=use_json,
         )
@@ -275,7 +275,7 @@ class FileHDFio(HasGroups, MutableMapping):
         if self.file_exists:
             try:
                 with open_hdf5(self.file_name, mode="a") as store:
-                    del store[key]
+                    del store[self._get_h5_path(key)]
             except (AttributeError, KeyError):
                 pass
 
@@ -531,7 +531,7 @@ class FileHDFio(HasGroups, MutableMapping):
         Returns:
             FileHDFio: FileHDFio object pointing to the new group
         """
-        full_name = posixpath.join(self.h5_path, name)
+        full_name = self._get_h5_path(name)
         with open_hdf5(self.file_name, mode="a") as h:
             try:
                 h.create_group(full_name, track_order=track_order)
@@ -570,7 +570,7 @@ class FileHDFio(HasGroups, MutableMapping):
         if h5_rel_path.strip() == ".":
             h5_rel_path = ""
         if h5_rel_path.strip() != "":
-            new_h5_path.h5_path = posixpath.join(new_h5_path.h5_path, h5_rel_path)
+            new_h5_path.h5_path = self._get_h5_path(h5_rel_path)
         new_h5_path.history.append(h5_rel_path)
 
         return new_h5_path

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -649,6 +649,18 @@ class TestDataContainer(TestWithCleanProject):
         except Exception as e:
             self.fail(f"to_hdf raised \"{e}\"!")
 
+    def test_overwrite_with_node(self):
+        """Writing to HDF second time after replacing a group by a node should not raise an error."""
+        d = DataContainer({"test": {"foo": 42}})
+        d.to_hdf(hdf=self.hdf, group_name="overwrite")
+        del d.test
+        d.create_group("test")
+        d.test = 42
+        try:
+            d.to_hdf(hdf=self.hdf, group_name="overwrite")
+        except Exception as e:
+            self.fail(f"to_hdf raised \"{e}\"!")
+
 class TestInputList(PyironTestCase):
 
     def test_deprecation_warning(self):

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -39,7 +39,13 @@ class TestDataContainer(TestWithCleanProject):
             ]}
         ], table_name="input")
         cls.pl["tail"] = DataContainer([2, 4, 8])
-        cls.hdf = cls.project.create_hdf(cls.project.path, "test")
+
+    def setUp(self):
+        self.hdf = self.project.create_hdf(self.project.path, "test")
+
+    def tearDown(self):
+        self.hdf.remove_file()
+        self.hdf = None
 
     # Init tests
     def test_init_none(self):
@@ -397,7 +403,7 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue("READ_ONLY" in self.hdf["read_only_f"].list_nodes(), "read-only parameter not saved in HDF")
         self.assertEqual(
             self.pl.read_only,
-            self.hdf[self.pl.table_name]["READ_ONLY"],
+            self.hdf["read_only_f"]["READ_ONLY"],
             "read-only parameter not correctly written to HDF"
         )
 
@@ -460,6 +466,7 @@ class TestDataContainer(TestWithCleanProject):
     def test_hdf_empty_group(self):
         """Writing a list without table_name or group_name should only work if the HDF group is empty."""
         l = DataContainer([1, 2, 3])
+        self.hdf["dummy"] = True
         with self.assertRaises(ValueError, msg="No exception when writing to full hdf group."):
             l.to_hdf(self.hdf)
         h = self.hdf.create_group("empty_group")

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -637,6 +637,17 @@ class TestDataContainer(TestWithCleanProject):
         self.assertTrue(not isinstance(ll._store[0], HDFStub),
                         "Loaded value not stored back into container!")
 
+    def test_overwrite_with_group(self):
+        """Writing to HDF second time after replacing a node by a group should not raise an error."""
+        d = DataContainer({"test": 42})
+        d.to_hdf(hdf=self.hdf, group_name="overwrite")
+        del d.test
+        d.create_group("test")
+        d.test.foo = 42
+        try:
+            d.to_hdf(hdf=self.hdf, group_name="overwrite")
+        except Exception as e:
+            self.fail(f"to_hdf raised \"{e}\"!")
 
 class TestInputList(PyironTestCase):
 

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -661,6 +661,30 @@ class TestDataContainer(TestWithCleanProject):
         except Exception as e:
             self.fail(f"to_hdf raised \"{e}\"!")
 
+    def test_overwrite_no_dangling_items(self):
+        """Writing to HDF a second time should leave only items in HDF that are currently in the container."""
+        d = self.pl.copy()
+        d.to_hdf(self.hdf)
+        del d[len(d) - 1]
+        d.to_hdf(self.hdf)
+        items = [k for k in self.hdf[d.table_name].list_nodes() if "__index_" in k] \
+              + [k for k in self.hdf[d.table_name].list_groups() if "__index_" in k]
+        self.assertEqual(len(d), len(items),
+                         "Number of items in HDF does not match length of container!")
+
+    def test_overwrite_ordering(self):
+        """Writing to HDF a second time with different item order should not leave other items in the HDF."""
+        d = self.pl.copy()
+        d.to_hdf(self.hdf)
+        d = DataContainer(list(reversed(list(d.values()))),
+                          table_name=d.table_name)
+        d.to_hdf(self.hdf)
+        items = [k for k in self.hdf[d.table_name].list_nodes() if "__index_" in k] \
+              + [k for k in self.hdf[d.table_name].list_groups() if "__index_" in k]
+        self.assertEqual(len(d), len(items),
+                         "Number of items in HDF does not match length of container!")
+
+
 class TestInputList(PyironTestCase):
 
     def test_deprecation_warning(self):

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -287,6 +287,14 @@ class TestFileHDFio(PyironTestCase):
         self.to_be_removed_hdf.remove_file()
         self.assertFalse(os.path.isfile(path))
 
+    def test_delitem(self):
+        """After deleting an entry, it should not be accessible anymore."""
+        with self.full_hdf5.open("content") as opened_hdf:
+            opened_hdf["dummy"] = 42
+            del opened_hdf["dummy"]
+            self.assertNotIn("dummy", opened_hdf.list_nodes(), msg="Entry still in HDF after del!")
+
+
     def test_get_from_table(self):
         pass
 


### PR DESCRIPTION
As mentioned in #818 there were some bugs in `DataContainer._to_hdf`:
1. when overwriting a node with a group and writing to HDF an error was thrown
2. when deleting elements from a container and writing to HDF the old data stuck around in the HDF
3. when overwriting in a different order, spurious datasets/groups could be left in the HDF

This PR fixes all of them and adds regression tests.  I've also found a separate bug in `FileHDFio` where the `__delitem__` didn't work at all.

@samwaseda Please double check, if this fixes the error.

Closes #818 .