### PR TITLE
Avoid unnecessary copy in FlattenedStorage._from_hdf

### DIFF
--- a/pyiron_base/storage/flattenedstorage.py
+++ b/pyiron_base/storage/flattenedstorage.py
@@ -910,12 +910,12 @@ class FlattenedStorage(HasHDF):
 
     def _from_hdf(self, hdf, version=None):
         def read_array(name, hdf):
-            a = np.array(hdf[name])
+            a = np.asarray(hdf[name])
             if a.dtype.char == "S":
                 # if saved as bytes, we wrote this as an encoded unicode string, so manually decode here
                 # TODO: string arrays with shape != () not handled
-                a = np.array(
-                    [s.decode("utf8") for s in a],
+                a = np.fromiter(
+                    (s.decode("utf8") for s in a),
                     # itemsize of original a is four bytes per character, so divide by four to get
                     # length of the orignal stored unicode string; np.dtype('U1').itemsize is just a
                     # platform agnostic way of knowing how wide a unicode charater is for numpy


### PR DESCRIPTION
Using `np.asarray` and `np.fromiter` instead of `np.array` avoids double allocation of arrays and can save up to a factor 4 in run time for very large storages (>100k chunks). 

NB: It seems that the utf decoding is the next speed limiting factor.  The decoding step is currently needed because we use `dtype('U')` numpy arrays, which are wide unicode characters, whereas HDF5 natively only handles UTF-8 encoded strings.  So a possible optimization is to use `dtype('O')` arrays with python strings inside and put those into HDF5 directly.  Some testing would be required however to make sure this works with `h5io`. 