### PR TITLE
Add warning file to working directories

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -96,6 +96,7 @@ class ToyJob(PythonTemplateJob):
         self.input.data_in = 100
 
     def write_input(self):
+        super().write_input()
         self.input.write(os.path.join(self.working_directory, "input.yml"))
 
     # Allow writing of the input file

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -756,9 +756,6 @@ class TableJob(GenericJob):
         if self.job_id is not None:
             self.project.db.item_update(self._runtime(), self.job_id)
 
-    def write_input(self):
-        pass
-
     def get_dataframe(self):
         """
 

--- a/pyiron_base/jobs/dynamic.py
+++ b/pyiron_base/jobs/dynamic.py
@@ -40,6 +40,7 @@ def _init_constructor_script(class_name, script_path, input_dict):
 
 def _get_write_input(script):
     def write_input(self):
+        super().write_input()
         script.write_input(
             working_directory=self.working_directory, input_dict=self.input.to_builtin()
         )

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -710,8 +710,6 @@ class JobCore(HasGroups):
             wd_content = os.listdir(new_job_core.working_directory)
             if len(wd_content) == 0:
                 os.rmdir(new_job_core.working_directory)
-            elif wd_content == ["WARN_pyiron_modified_content"]:
-                shutil.rmtree(new_job_core.working_directory)
             else:
                 raise RuntimeError(
                     f"Target directory for copy not empty! Content = {wd_content}."

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -707,10 +707,15 @@ class JobCore(HasGroups):
 
         # Copy files outside the HDF5 file
         if copy_files and os.path.exists(self.working_directory):
-            if len(os.listdir(new_job_core.working_directory)) == 0:
+            wd_content = os.listdir(new_job_core.working_directory)
+            if len(wd_content) == 0:
                 os.rmdir(new_job_core.working_directory)
+            elif wd_content == ["WARN_pyiron_modified_content"]:
+                shutil.rmtree(new_job_core.working_directory)
             else:
-                raise RuntimeError("Target directory for copy not empty!")
+                raise RuntimeError(
+                    f"Target directory for copy not empty! Content = {wd_content}."
+                )
             shutil.copytree(self.working_directory, new_job_core.working_directory)
         return new_job_core, file_project, hdf5_project, False
 

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -424,10 +424,10 @@ class GenericJob(JobCore):
         """
         if state.settings.configuration["write_work_dir_warnings"]:
             with open(
-                    os.path.join(
-                        self.working_directory, "WARN_pyiron_modified_content"
-                    ),
-                    "w",
+                os.path.join(
+                    self.working_directory, "WARNINGn_pyiron_modified_content"
+                ),
+                "w",
             ) as f:
                 f.write(
                     "Files in this directory are intended to be written and read by pyiron. \n\n"
@@ -535,7 +535,7 @@ class GenericJob(JobCore):
             copy_files=copy_files,
             delete_existing_job=delete_existing_job,
         )
-        print('DONE call JobCore._internal_copy_to')
+        print("DONE call JobCore._internal_copy_to")
         if reloaded:
             return new_job_core, file_project, hdf5_project, reloaded
 

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -422,9 +422,21 @@ class GenericJob(JobCore):
         Write the input files for the external executable. This method has to be implemented in the individual
         hamiltonians.
         """
-        raise NotImplementedError(
-            "write procedure must be defined for derived Hamilton!"
-        )
+        if state.settings.configuration["write_work_dir_warnings"]:
+            with open(
+                    os.path.join(
+                        self.working_directory, "WARN_pyiron_modified_content"
+                    ),
+                    "w",
+            ) as f:
+                f.write(
+                    "Files in this directory are intended to be written and read by pyiron. \n\n"
+                    "pyiron may transform user input to enhance performance, thus, use these files with care!\n"
+                    "Consult the log and/or the documentation to gain further information.\n\n"
+                    "To disable writing these warning files, specify \n"
+                    "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the "
+                    "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly)."
+                )
 
     def collect_output(self):
         """
@@ -523,6 +535,7 @@ class GenericJob(JobCore):
             copy_files=copy_files,
             delete_existing_job=delete_existing_job,
         )
+        print('DONE call JobCore._internal_copy_to')
         if reloaded:
             return new_job_core, file_project, hdf5_project, reloaded
 

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -425,7 +425,7 @@ class GenericJob(JobCore):
         if state.settings.configuration["write_work_dir_warnings"]:
             with open(
                 os.path.join(
-                    self.working_directory, "WARNINGn_pyiron_modified_content"
+                    self.working_directory, "WARNING_pyiron_modified_content"
                 ),
                 "w",
             ) as f:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -424,9 +424,7 @@ class GenericJob(JobCore):
         """
         if state.settings.configuration["write_work_dir_warnings"]:
             with open(
-                os.path.join(
-                    self.working_directory, "WARNING_pyiron_modified_content"
-                ),
+                os.path.join(self.working_directory, "WARNING_pyiron_modified_content"),
                 "w",
             ) as f:
                 f.write(

--- a/pyiron_base/jobs/master/flexible.py
+++ b/pyiron_base/jobs/master/flexible.py
@@ -214,12 +214,6 @@ class FlexibleMaster(GenericMaster):
                 self.status.refresh = True
                 self.run_if_refresh()
 
-    def write_input(self):
-        """
-        write_input is not implemented for FlexibleMaster jobs
-        """
-        pass
-
     def collect_output(self):
         """
         Collect output is not implemented for FlexibleMaster jobs

--- a/pyiron_base/jobs/master/list.py
+++ b/pyiron_base/jobs/master/list.py
@@ -281,6 +281,7 @@ class ListMaster(GenericMaster):
         Write the input files - for the ListMaster this only contains the execution mode, which is 'parallel' by
         default.
         """
+        super().write_input()
         self._input.write_file(file_name="input.inp", cwd=self.working_directory)
 
     def copy(self):

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -252,6 +252,7 @@ class ParallelMaster(GenericMaster):
         Write the input files - this contains the GenericInput of the ParallelMaster as well as reseting the submission
         status.
         """
+        super().write_input()
         self.submission_status.submitted_jobs = 0
         self.input.write_file(file_name="input.inp", cwd=self.working_directory)
 

--- a/pyiron_base/jobs/master/serial.py
+++ b/pyiron_base/jobs/master/serial.py
@@ -442,6 +442,7 @@ class SerialMasterBase(GenericMaster):
         """
         Write the input files - for the SerialMaster this only contains convergence goal.
         """
+        super().write_input()
         self._input.write_file(file_name="input.inp", cwd=self.working_directory)
 
     def __len__(self):

--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -326,6 +326,7 @@ class ScriptJob(GenericJob):
         """
         Copy the script to the working directory - only python scripts and jupyter notebooks are supported
         """
+        super().write_input()
         if self._script_path is not None:
             file_name = os.path.basename(self._script_path)
             shutil.copyfile(

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -87,6 +87,9 @@ class Settings(metaclass=Singleton):
         credentials_file / CREDENTIALS_FILE / CREDENTIALSFILE (str): Path to an additional credentials file holding
             credential information. If specified, the values in the credentials_file overwrite the values of other
             sources.
+        write_work_dir_warnings / WRITE_WORK_DIR_WARNINGS / PYIRONWRITEWORKDIRWARNINGS (bool): Whether to write
+            the working directory warning files to inform users about possibly modified content. (Default is True).
+
 
     Properties:
         configuration (dict): Global variables for configuring the pyiron experience.
@@ -165,6 +168,7 @@ class Settings(metaclass=Singleton):
                 "project_check_enabled": False,
                 "disable_database": False,
                 "credentials_file": None,
+                "write_work_dir_warnings": True,
             }
         )
 
@@ -189,6 +193,7 @@ class Settings(metaclass=Singleton):
             "PYIRONPROJECTCHECKENABLED": "project_check_enabled",
             "PYIRONDISABLE": "disable_database",
             "PYIRONCREDENTIALSFILE": "credentials_file",
+            "PYIRONWRITEWORKDIRWARNINGS": "write_work_dir_warnings"
         }
 
     @property
@@ -214,6 +219,7 @@ class Settings(metaclass=Singleton):
             "PROJECT_CHECK_ENABLED": "project_check_enabled",
             "DISABLE_DATABASE": "disable_database",
             "CREDENTIALS_FILE": "credentials_file",
+            "WRITE_WORK_DIR_WARNINGS": "write_work_dir_warnings",
         }
 
     @property

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -193,7 +193,7 @@ class Settings(metaclass=Singleton):
             "PYIRONPROJECTCHECKENABLED": "project_check_enabled",
             "PYIRONDISABLE": "disable_database",
             "PYIRONCREDENTIALSFILE": "credentials_file",
-            "PYIRONWRITEWORKDIRWARNINGS": "write_work_dir_warnings"
+            "PYIRONWRITEWORKDIRWARNINGS": "write_work_dir_warnings",
         }
 
     @property

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1296,6 +1296,17 @@ class ProjectHDFio(FileHDFio):
         """
         if not os.path.isdir(self.working_directory):
             os.makedirs(self.working_directory)
+            if state.settings.configuration['write_work_dir_warnings']:
+                with open(os.path.join(self.working_directory, "WARN_pyiron_modified_content"), 'w') as f:
+                    f.write(
+                        "Files in this directory are intended to be written and read by pyiron. \n\n"
+                        "pyiron may transform user input to enhance performance, thus, use these files with care!"
+                        "Consult the log and/or the documentation to gain further information."
+                        ""
+                        "To disable writing these warning files, specify "
+                        "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the "
+                        "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly)."
+                    )
 
     def import_class(self, class_name):
         """

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1296,21 +1296,6 @@ class ProjectHDFio(FileHDFio):
         """
         if not os.path.isdir(self.working_directory):
             os.makedirs(self.working_directory)
-            if state.settings.configuration["write_work_dir_warnings"]:
-                with open(
-                    os.path.join(
-                        self.working_directory, "WARN_pyiron_modified_content"
-                    ),
-                    "w",
-                ) as f:
-                    f.write(
-                        "Files in this directory are intended to be written and read by pyiron. \n\n"
-                        "pyiron may transform user input to enhance performance, thus, use these files with care!\n"
-                        "Consult the log and/or the documentation to gain further information.\n\n"
-                        "To disable writing these warning files, specify \n"
-                        "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the "
-                        "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly)."
-                    )
 
     def import_class(self, class_name):
         """

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1296,14 +1296,18 @@ class ProjectHDFio(FileHDFio):
         """
         if not os.path.isdir(self.working_directory):
             os.makedirs(self.working_directory)
-            if state.settings.configuration['write_work_dir_warnings']:
-                with open(os.path.join(self.working_directory, "WARN_pyiron_modified_content"), 'w') as f:
+            if state.settings.configuration["write_work_dir_warnings"]:
+                with open(
+                    os.path.join(
+                        self.working_directory, "WARN_pyiron_modified_content"
+                    ),
+                    "w",
+                ) as f:
                     f.write(
                         "Files in this directory are intended to be written and read by pyiron. \n\n"
-                        "pyiron may transform user input to enhance performance, thus, use these files with care!"
-                        "Consult the log and/or the documentation to gain further information."
-                        ""
-                        "To disable writing these warning files, specify "
+                        "pyiron may transform user input to enhance performance, thus, use these files with care!\n"
+                        "Consult the log and/or the documentation to gain further information.\n\n"
+                        "To disable writing these warning files, specify \n"
                         "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the "
                         "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly)."
                     )

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -113,7 +113,7 @@ class TestGenericJob(TestWithFilledProject):
             self.assertTrue(os.path.exists(ham.working_directory))
             with open(os.path.join(ham.working_directory, 'test_file'), 'w') as f:
                 f.write("Content")
-            self.assertEqual(
+            self.assertCountEqual(
                 ham.list_files(), ["test_file", "WARN_pyiron_modified_content"]
             )
         with self.subTest("Compress"):

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -238,7 +238,7 @@ class TestGenericJob(TestWithFilledProject):
                 job._create_working_directory()
                 job.write_input()
                 self.assertCountEqual(
-                    os.listdir(job.working_directory), ["input.yml", "WARN_pyiron_modified_content"]
+                    os.listdir(job.working_directory), ["input.yml", "WARNING_pyiron_modified_content"]
                 )
             with self.subTest("Suppress writing of warning file"):
                 job = self.project.create_job(ToyJob, "test_not_write_warning_file")
@@ -443,7 +443,7 @@ class TestGenericJob(TestWithFilledProject):
         self.assertEqual(
             len(wd_files),
             2,
-            "Only one input and the WARN_pyiron_modified_content file should "
+            "Only one input and the WARNING_pyiron_modified_content file should "
             "be present in the working directory",
         )
         self.assertEqual(

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -105,6 +105,7 @@ class TestGenericJob(TestWithFilledProject):
             self.assertTrue(os.path.isfile(ham.project_hdf5.file_name))
         with self.subTest('Add files to working directory'):
             ham.project_hdf5.create_working_directory()
+            self.assertEqual(ham.list_files(), ["WARN_pyiron_modified_content"])
             self.assertEqual(
                 "/".join([cwd, self.project_name, "job_single_debug_2_hdf5/job_single_debug_2"]),
                 ham.working_directory
@@ -112,7 +113,9 @@ class TestGenericJob(TestWithFilledProject):
             self.assertTrue(os.path.exists(ham.working_directory))
             with open(os.path.join(ham.working_directory, 'test_file'), 'w') as f:
                 f.write("Content")
-            self.assertEqual(ham.list_files(), ['test_file'])
+            self.assertEqual(
+                ham.list_files(), ["test_file", "WARN_pyiron_modified_content"]
+            )
         with self.subTest("Compress"):
             ham.compress()
             self.assertFalse(os.path.exists(os.path.join(ham.working_directory, 'test_file')))
@@ -367,7 +370,27 @@ class TestGenericJob(TestWithFilledProject):
         pass
 
     def test__create_working_directory(self):
-        pass
+        wd_warn_key = "write_work_dir_warnings"
+        previous_wd_warn_setting = self.project.state.settings.configuration[
+            wd_warn_key
+        ]
+        try:
+            with self.subTest("Writing warning file"):
+                self.project.state.settings.configuration[wd_warn_key] = True
+                job = self.project.create_job(ToyJob, "test_create_wd")
+                job._create_working_directory()
+                self.assertEqual(
+                    os.listdir(job.working_directory), ["WARN_pyiron_modified_content"]
+                )
+            with self.subTest("Suppress writing of warning file"):
+                job = self.project.create_job(ToyJob, "test_create_wd2")
+                self.project.state.settings.configuration[wd_warn_key] = False
+                job._create_working_directory()
+                self.assertEqual(os.listdir(job.working_directory), [])
+        finally:
+            self.project.state.settings.configuration[
+                wd_warn_key
+            ] = previous_wd_warn_setting
 
     def test__write_run_wrapper(self):
         pass
@@ -411,8 +434,15 @@ class TestGenericJob(TestWithFilledProject):
         self.assertEqual(wd_files[0], f"{job_restart.name}.tar.bz2", "Inconsistent name for the zipped file")
         job_restart.decompress()
         wd_files = job_restart.list_files()
-        self.assertEqual(len(wd_files), 1, "Only one input file should be present in the working directory")
-        self.assertEqual(wd_files[0], "input.yml", "Inconsistent name for the zipped file")
+        self.assertEqual(
+            len(wd_files),
+            2,
+            "Only one input and the WARN_pyiron_modified_content file should "
+            "be present in the working directory",
+        )
+        self.assertEqual(
+            wd_files[0], "input.yml", "Inconsistent name for the zipped file"
+        )
 
     def test_return_codes(self):
         """Jobs exiting with return codes other than job.executable.allowed_codes should be marked as 'aborted'"""


### PR DESCRIPTION
As discussed in the [pyiron meeting](https://github.com/orgs/pyiron/teams/pyiron/discussions/137/comments/1) this PR implements a writing of a warning file `WARN_pyiron_modified_content` with the content 
```
Files in this directory are intended to be written and read by pyiron. 

pyiron may transform user input to enhance performance, thus, use these files with care!
Consult the log and/or the documentation to gain further information.

To disable writing these warning files, specify 
WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the PYIRONWRITEWORKDIRWARNINGS environment variable accordingly).
```