### PR TITLE
Fix ridiculous typo

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -925,7 +925,7 @@ class JobCore(HasGroups):
 
         for container_path, data_path in successive_path_splits(name_lst):
             try:
-                group = self._hdf5[item]
+                group = self._hdf5[container_path]
                 if (
                     isinstance(group, ProjectHDFio)
                     and "NAME" in group


### PR DESCRIPTION
When loading a path from HDF and trying to load any datacontainers, instead using the split path it repeatedly tried the same full path.