### PR TITLE
Add subclass of HasStorage for easy input fields

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -9,6 +9,7 @@ from pyiron_base.interfaces.factory import PyironFactory
 from pyiron_base.storage.flattenedstorage import FlattenedStorage
 from pyiron_base.storage.hdfio import FileHDFio, ProjectHDFio
 from pyiron_base.storage.datacontainer import DataContainer
+from pyiron_base.storage.keyword import KeywordInput
 from pyiron_base.storage.inputlist import InputList
 from pyiron_base.storage.parameters import GenericParameters
 from pyiron_base.storage.filedata import load_file, FileDataTemplate, FileData

--- a/pyiron_base/storage/keyword.py
+++ b/pyiron_base/storage/keyword.py
@@ -1,0 +1,83 @@
+from pyiron_base.interfaces.object import HasStorage
+
+class KeywordInput(HasStorage):
+    """
+    Base class for keyword based input structures, that know how write themselves to HDF5.
+
+    Derive from this class and add a class level attribute `_defaults`, which can be any mapping from allowed keyword
+    names to their default values.
+
+    Example:
+
+    >>> from pyiron_base.storage.datacontainer import DataContainer
+    >>> class MyOptions(KeywordInput):
+    ...     '''
+    ...     Stores the options to my beautiful code.
+    ...
+    ...     Attributes:
+    ...         run_fast (bool): run fast or slow?
+    ...         foo_level (float): amount of foo-iness
+    ...     '''
+    ...
+    ...     _defaults = {
+    ...             'run_fast': False,
+    ...             'foo_level': .7,
+    ...             'suboptions': DataContainer({'bar': 23})
+    ...     }
+    >>> opt = MyOptions()
+    >>> opt.run_fast
+    False
+    >>> opt['foo_level'] = .1
+    >>> opt.foo_level
+    0.1
+    >>> opt['invalid_option']
+    Traceback (most recent call last):
+        ...
+    KeyError: 'invalid_option'
+    >>> opt.yet_another_option
+    Traceback (most recent call last):
+        ...
+    AttributeError: yet_another_option
+    >>> opt.suboptions.bar
+    23
+    >>> opt.suboptions.name = 'Donald'
+    >>> opt.suboptions
+    DataContainer({'bar': 23, 'name': 'Donald'})
+    """
+
+    _defaults = {}
+    _finalized = False
+
+    def __init__(self, *args, **kwargs):
+        if "group_name" not in kwargs:
+            kwargs["group_name"] = self.__class__.__name__.lower()
+        super().__init__(*args, **kwargs)
+        self._finalized = True
+        for k, v in self._defaults.items():
+            self.storage[k] = v
+
+    def __getitem__(self, name):
+        if name in self._defaults:
+            return self.storage[name]
+        else:
+            raise KeyError(name)
+
+    def __setitem__(self, name, value):
+        if name in self._defaults:
+            self.storage[name] = value
+        else:
+            raise KeyError(name)
+
+    def __getattr__(self, name):
+        if name in self._defaults:
+            return self.storage[name]
+        else:
+            raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if not self._finalized:
+            object.__setattr__(self, name, value)
+        elif name in self._defaults:
+            self.storage[name] = value
+        else:
+            raise AttributeError(name)


### PR DESCRIPTION
Instead of expanding #753 I've put together what I think is the simplest solution to the "verbosity" problem we've had over in [atomistics](https://github.com/pyiron/pyiron_atomistics/pull/799) (and elsewhere previously).

This defines a new subclass of `HasStorage`, `KeywordInput`, that should make it much easier to create this kind of code specific input classes.  I've opted let developers manually document options in the class docstring, because I've found generation of them a bit wonky.  In #753 we had also discussed type and range checking of values that would be nice to have, but since `GenericParameters` also doesn't have it, I think it's something we can bolt on later.  Especially this the HDF-layout is fixed now by `HasStorage` we'll have a lot of freedom in re-designing the input classes without backwards compatibility issues.

Since I've overridden `__setattr__` and I wanted to forbid modification of attributes after the class is initialized (so that users get an error if they misspell an option, e.g.), I had to introduce a little hack with `_finalize` variable.  It ain't pretty, but it works.