### PR TITLE
Add flag "auto_refresh_job_status" that allows

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -655,8 +655,14 @@ class Project(ProjectPath, HasGroups):
         full_table=False,
         element_lst=None,
         job_name_contains="",
+        auto_refresh_job_status=False,
         **kwargs: dict,
     ):
+        """
+        auto_refresh_job_status (bool): will automatically reload job status by calling refresh_job_status() upon calling job_table
+        """
+        if auto_refresh_job_status:
+            self.refresh_job_status()
         return self.db.job_table(
             sql_query=self.sql_query,
             user=self.user,


### PR DESCRIPTION
automatic refresh  of job status upon loading of pr.job_table(). To-do:
I will benchmark this with projects of different sizes to see cost, see if it's negligible.

If negligible, set it to True by default
(better for new users, and is more intuitive overall)