### PR TITLE
Pyiron Table Refactor

### DIFF
--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -317,17 +317,12 @@ class PyironTable(HasGroups):
         elif len(df_new_ids) > 0:
             self._df = df_new_ids
 
-    def convert_dict(self, input_dict):
-        return {key: self.str_to_value(value) for key, value in input_dict.items()}
-
     def refill_dict(self, diff_dict_lst):
         total_key_lst = self.total_lst_of_keys(diff_dict_lst)
-        for ind, sub_dict in enumerate(diff_dict_lst):
+        for sub_dict in diff_dict_lst:
             for key in total_key_lst:
                 if key not in sub_dict.keys():
-                    sub_dict[key] = self.EMPTY_STR
-                else:
-                    sub_dict[key] = self.str_to_value(sub_dict[key])
+                    sub_dict[key] = None
 
     def col_to_value(self, col_name):
         val_lst, key_lst, ind_lst = [], [], []
@@ -353,16 +348,6 @@ class PyironTable(HasGroups):
 
     def _list_groups(self):
         return list(set(self._df["col_0"]))
-
-    @staticmethod
-    def str_to_value(input_val):
-        if not isinstance(input_val, str):
-            return input_val
-        else:
-            try:
-                return eval(input_val)
-            except (TypeError, SyntaxError, NameError):
-                return input_val
 
     @staticmethod
     def _apply_function_on_job(funct, job):

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -202,18 +202,15 @@ class PyironTable:
     def filter_function(self, funct):
         self._filter_function = funct
 
+
     def create_table(
-        self, enforce_update=False, file=None, job_status_list=None
+        self, file, enforce_update=False, job_status_list=None
     ):
         skip_table_update = False
         filter_funct = self.filter_function
         if job_status_list is None:
             job_status_list = ["finished"]
         if self._is_file():
-            if file is None:
-                file = FileHDFio(
-                    file_name=self._project.path + self.name + ".h5", h5_path="/"
-                )
             (
                 temp_user_function_dict,
                 temp_system_function_dict,
@@ -650,8 +647,8 @@ class TableJob(GenericJob):
             self.project.db.item_update({"timestart": datetime.now()}, self.job_id)
         with self.project_hdf5.open("input") as hdf5_input:
             self._pyiron_table.create_table(
-                enforce_update=self._enforce_update,
                 file=hdf5_input,
+                enforce_update=self._enforce_update,
                 job_status_list=job_status_list,
             )
         self.to_hdf()

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -161,13 +161,6 @@ class PyironTable(HasGroups):
         return self._filter
 
     @property
-    def _file_name_csv(self):
-        if self._csv_file is None:
-            return self._project.path + self.name + ".csv"
-        else:
-            return self._csv_file
-
-    @property
     def _file_name_txt(self):
         return self._project.path + self.name + ".txt"
 
@@ -307,13 +300,6 @@ class PyironTable(HasGroups):
         elif len(df_new_ids) > 0:
             self._df = df_new_ids
 
-    def refill_dict(self, diff_dict_lst):
-        total_key_lst = self.total_lst_of_keys(diff_dict_lst)
-        for sub_dict in diff_dict_lst:
-            for key in total_key_lst:
-                if key not in sub_dict.keys():
-                    sub_dict[key] = None
-
     def col_to_value(self, col_name):
         val_lst, key_lst, ind_lst = [], [], []
         for ind, name in enumerate(self._df[col_name]):
@@ -338,21 +324,6 @@ class PyironTable(HasGroups):
 
     def _list_groups(self):
         return list(set(self._df["col_0"]))
-
-    @staticmethod
-    def _apply_function_on_job(funct, job):
-        try:
-            return funct(job)
-        except (ValueError, TypeError):
-            return {}
-
-    @staticmethod
-    def total_lst_of_keys(diff_dict_lst):
-        total_key_lst = []
-        for sub_dict in diff_dict_lst:
-            for key in sub_dict.keys():
-                total_key_lst.append(key)
-        return set(total_key_lst)
 
     def __getitem__(self, item, max_level=5):
         rename_dict = OrderedDict()
@@ -387,6 +358,13 @@ class PyironTable(HasGroups):
     def _is_file(self):
         return self._project is not None and os.path.isfile(self._file_name_csv)
 
+    @property
+    def _file_name_csv(self):
+        if self._csv_file is None:
+            return self._project.path + self.name + ".csv"
+        else:
+            return self._csv_file
+
     def _load_csv(self):
         # Legacy method to read tables written to csv
         self._df = pandas.read_csv(self._file_name_csv)
@@ -415,6 +393,13 @@ class PyironTable(HasGroups):
         filter_funct = self.db_filter_function
         return project_table[filter_funct(project_table)]["id"].tolist()
 
+    @staticmethod
+    def _apply_function_on_job(funct, job):
+        try:
+            return funct(job)
+        except (ValueError, TypeError):
+            return {}
+
     def _apply_list_of_functions_on_job(self, job, fucntion_lst):
         diff_dict = {}
         for funct in fucntion_lst:
@@ -440,6 +425,21 @@ class PyironTable(HasGroups):
             diff_dict_lst.append(diff_dict)
         self.refill_dict(diff_dict_lst)
         return pandas.DataFrame(diff_dict_lst)
+
+    @staticmethod
+    def total_lst_of_keys(diff_dict_lst):
+        total_key_lst = []
+        for sub_dict in diff_dict_lst:
+            for key in sub_dict.keys():
+                total_key_lst.append(key)
+        return set(total_key_lst)
+
+    def refill_dict(self, diff_dict_lst):
+        total_key_lst = self.total_lst_of_keys(diff_dict_lst)
+        for sub_dict in diff_dict_lst:
+            for key in total_key_lst:
+                if key not in sub_dict.keys():
+                    sub_dict[key] = None
 
     def _collect_job_update_lst(
         self, job_status_list, filter_funct, job_stored_ids=None

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -300,22 +300,6 @@ class PyironTable(HasGroups):
         elif len(df_new_ids) > 0:
             self._df = df_new_ids
 
-    def col_to_value(self, col_name):
-        val_lst, key_lst, ind_lst = [], [], []
-        for ind, name in enumerate(self._df[col_name]):
-            #             print ('name: ', ind, name)
-            #             if name == self.EMPTY_STR:
-            #                 continue
-            name = name.split("_")
-            ind_lst.append(ind)
-            key_lst.append(name[0])
-            val_lst.append(eval(".".join(name[1:])))
-        if len(set(key_lst)) == 1:
-            key = key_lst[0]
-            self._df[key] = val_lst
-        else:
-            raise ValueError("key not unique: {}".format(set(key_lst)))
-
     def get_dataframe(self):
         return self._df
 

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -227,7 +227,6 @@ class PyironTable:
     def create_table(
         self, file, enforce_update=False, job_status_list=None
     ):
-        filter_funct = self.filter_function
         if job_status_list is None:
             job_status_list = ["finished"]
 
@@ -253,7 +252,6 @@ class PyironTable:
 
         new_jobs = self._collect_job_update_lst(
             job_status_list=job_status_list,
-            filter_funct=filter_funct,
             job_stored_ids=self._get_job_ids() if not enforce_update else None
         )
         if len(new_jobs) > 0:
@@ -359,14 +357,13 @@ class PyironTable:
                     sub_dict[key] = None
 
     def _collect_job_update_lst(
-        self, job_status_list, filter_funct, job_stored_ids=None
+        self, job_status_list, job_stored_ids=None
     ):
         """
         Collect jobs to update the pyiron table
 
         Args:
             job_status_list (list): List of job status to consider
-            filter_funct (function): Filter function
             job_stored_ids (list/ None): List of already analysed job ids
 
         Returns:
@@ -387,7 +384,7 @@ class PyironTable:
                 job = self._project.inspect(job_id)
             except IndexError:  # In case the job was deleted while the pyiron table is running
                 job = None
-            if job is not None and job.status in job_status_list and filter_funct(job):
+            if job is not None and job.status in job_status_list and self.filter_function(job):
                 job_update_lst.append(job)
         return job_update_lst
 

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -459,6 +459,12 @@ class TableJob(GenericJob):
 
     @property
     def db_filter_function(self):
+        """
+        function: database level filter function
+
+        The function should accept a dataframe, the job table of :attr:`~.analysis_project` and return a bool index into
+        it.  Jobs where the index is `False` are excluced from the analysis.
+        """
         return self._pyiron_table.db_filter_function
 
     @db_filter_function.setter
@@ -467,6 +473,12 @@ class TableJob(GenericJob):
 
     @property
     def filter_function(self):
+        """
+        function: job level filter function
+
+        The function should accept a GenericJob or JobCore object and return a bool, if it returns `False` the job is
+        excluced from the analysis.
+        """
         return self._pyiron_table.filter_function
 
     @filter_function.setter
@@ -497,6 +509,7 @@ class TableJob(GenericJob):
         return self._pyiron_table
 
     @property
+    @deprecate("Use analysis_project instead!")
     def ref_project(self):
         return self.analysis_project
 
@@ -528,6 +541,9 @@ class TableJob(GenericJob):
 
     @property
     def convert_to_object(self):
+        """
+        bool: if `True` convert fully load jobs before passing them to functions, if `False` use inspect mode.
+        """
         return self._pyiron_table.convert_to_object
 
     @convert_to_object.setter
@@ -536,6 +552,9 @@ class TableJob(GenericJob):
 
     @property
     def enforce_update(self):
+        """
+        bool: if `True` re-evaluate all function on all jobs when :meth:`.update_table` is called.
+        """
         return self._enforce_update
 
     @enforce_update.setter
@@ -668,7 +687,10 @@ class TableJob(GenericJob):
     @deprecate(job_status_list="Use TableJob.job_status instead!")
     def update_table(self, job_status_list=None):
         """
-        Update the pyiron table object, add new columns if a new function was added or add new rows for new jobs
+        Update the pyiron table object, add new columns if a new function was added or add new rows for new jobs.
+
+        By default this function does not recompute already evaluated functions on already existing jobs.  To force a
+        complete re-evaluation set :attr:`~.enforce_update` to `True`.
 
         Args:
             job_status_list (list/None): List of job status which are added to the table by default ["finished"].
@@ -694,6 +716,7 @@ class TableJob(GenericJob):
 
     def get_dataframe(self):
         """
+        Returns aggregated results over all jobs.
 
         Returns:
             pandas.Dataframe

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -159,10 +159,6 @@ class PyironTable:
         return self._filter
 
     @property
-    def _file_name_txt(self):
-        return self._project.path + self.name + ".txt"
-
-    @property
     def name(self):
         """
         Name of the table. Takes the project name if not specified
@@ -205,14 +201,6 @@ class PyironTable:
     @filter_function.setter
     def filter_function(self, funct):
         self._filter_function = funct
-
-    def to_hdf(self):
-        file = FileHDFio(file_name=self._project.path + self.name + ".h5", h5_path="/")
-        self.add._to_hdf(file)
-
-    def from_hdf(self):
-        file = FileHDFio(file_name=self._project.path + self.name + ".h5", h5_path="/")
-        self.add._from_hdf(file)
 
     def create_table(
         self, enforce_update=False, file=None, job_status_list=None

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -405,7 +405,6 @@ class TableJob(GenericJob):
         super(TableJob, self).__init__(project, job_name)
         self.__version__ = "0.1"
         self.__hdf_version__ = "0.3.0"
-        self.__name__ = "TableJob"
         self._analysis_project = None
         self._pyiron_table = PyironTable(
             project=None,

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -227,11 +227,8 @@ class PyironTable:
         return new_user_functions, new_system_functions
 
     def create_table(
-        self, file, enforce_update=False, job_status_list=None
+        self, file, job_status_list, enforce_update=False
     ):
-        if job_status_list is None:
-            job_status_list = ["finished"]
-
         # if there's new keys, apply the *new* functions to the old jobs and name the resulting table `df_new_keys`
         # if there's new jobs, apply *all* functions to them and name the resulting table `df_new_ids`
 
@@ -633,7 +630,8 @@ class TableJob(GenericJob):
         Update the pyiron table object, add new columns if a new function was added or add new rows for new jobs
 
         Args:
-            job_status_list (list/None): List of job status which are added to the table by default ["finished"]
+            job_status_list (list/None): List of job status which are added to the table by default ["finished"].
+                                         Deprecated, use :attr:`.job_status` instead!
         """
         if job_status_list is None:
             job_status_list = self.job_status
@@ -642,8 +640,8 @@ class TableJob(GenericJob):
         with self.project_hdf5.open("input") as hdf5_input:
             self._pyiron_table.create_table(
                 file=hdf5_input,
-                enforce_update=self._enforce_update,
                 job_status_list=job_status_list,
+                enforce_update=self._enforce_update,
             )
         self.to_hdf()
         self._pyiron_table._df.to_csv(

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -226,9 +226,7 @@ class PyironTable:
             new_system_functions = []
         return new_user_functions, new_system_functions
 
-    def create_table(
-        self, file, job_status_list, enforce_update=False
-    ):
+    def create_table(self, file, job_status_list, enforce_update=False):
         """
         Create or update the table.
 
@@ -253,20 +251,22 @@ class PyironTable:
 
             if len(new_user_functions) > 0 or len(new_system_functions) > 0:
                 function_lst = [
-                        self.add._user_function_dict[k] for k in new_user_functions
+                    self.add._user_function_dict[k] for k in new_user_functions
                 ] + [
-                        funct for funct in self.add._system_function_lst
-                                    if funct.__name__ in new_system_functions
+                    funct
+                    for funct in self.add._system_function_lst
+                    if funct.__name__ in new_system_functions
                 ]
                 df_new_keys = self._iterate_over_job_lst(
-                    job_lst=map(self._project.inspect, self._get_job_ids()), function_lst=function_lst
+                    job_lst=map(self._project.inspect, self._get_job_ids()),
+                    function_lst=function_lst,
                 )
                 if len(df_new_keys) > 0:
-                    self._df = pandas.concat([self._df, df_new_keys], axis='columns')
+                    self._df = pandas.concat([self._df, df_new_keys], axis="columns")
 
         new_jobs = self._collect_job_update_lst(
             job_status_list=job_status_list,
-            job_stored_ids=self._get_job_ids() if not enforce_update else None
+            job_stored_ids=self._get_job_ids() if not enforce_update else None,
         )
         if len(new_jobs) > 0:
             df_new_ids = self._iterate_over_job_lst(
@@ -390,9 +390,7 @@ class PyironTable:
                 if key not in sub_dict.keys():
                     sub_dict[key] = None
 
-    def _collect_job_update_lst(
-        self, job_status_list, job_stored_ids=None
-    ):
+    def _collect_job_update_lst(self, job_status_list, job_stored_ids=None):
         """
         Collect jobs to update the pyiron table.
 
@@ -420,7 +418,11 @@ class PyironTable:
                 job = self._project.inspect(job_id)
             except IndexError:  # In case the job was deleted while the pyiron table is running
                 job = None
-            if job is not None and job.status in job_status_list and self.filter_function(job):
+            if (
+                job is not None
+                and job.status in job_status_list
+                and self.filter_function(job)
+            ):
                 job_update_lst.append(job)
         return job_update_lst
 
@@ -432,6 +434,7 @@ class PyironTable:
             HTML: Jupyter HTML object
         """
         return self._df._repr_html_()
+
 
 class TableJob(GenericJob):
     _system_function_lst = [get_job_id]
@@ -484,7 +487,9 @@ class TableJob(GenericJob):
         for s in status:
             valid = jobstatus.job_status_lst
             if s not in valid:
-                raise ValueError(f"'{s}' not a valid job status! Must be one of {valid}.")
+                raise ValueError(
+                    f"'{s}' not a valid job status! Must be one of {valid}."
+                )
         self._job_status = status
 
     @property

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -223,16 +223,6 @@ class PyironTable(HasGroups):
         file = FileHDFio(file_name=self._project.path + self.name + ".h5", h5_path="/")
         self.add._from_hdf(file)
 
-    def save(self, name=None):
-        self._name = name
-        self.to_hdf()
-        self._save_csv()
-
-    def load(self, name=None):
-        self._name = name
-        self.from_hdf()
-        self._load_csv()
-
     def create_table(
         self, enforce_update=False, level=3, file=None, job_status_list=None
     ):
@@ -397,10 +387,8 @@ class PyironTable(HasGroups):
     def _is_file(self):
         return self._project is not None and os.path.isfile(self._file_name_csv)
 
-    def _save_csv(self):
-        self._df.to_csv(self._file_name_csv, index=False)
-
     def _load_csv(self):
+        # Legacy method to read tables written to csv
         self._df = pandas.read_csv(self._file_name_csv)
 
     def _get_project_list(self, name, pr_len, level=3):


### PR DESCRIPTION
I got annoyed by the tables again, so I bit the bullet and cleaned up. 

Short list of changes:
1. missing values are no longer represented by `'-'`, but by `None`.  This has the advantage that it doesn't mess up the datatype of the pandas arrays.  (`'-'` forces `dtype=object`, but `None` doesn't)
2. string values are not coerced with `eval`.  `eval` is generally not nice, but I also lost data because of this, see commit messages
3. refactor of `create_table` and bug fixing so that updating the table inplace actually works now.
4. bunch of smaller rearragements and docstrings
5. There was a whole feature set `project_level`, but it was broken/disabled and I couldn't understand what the point was, so I axed it. If someone complains about it, we can re-add it.