### PR TITLE
Set new job name when copying db entry

### DIFF
--- a/pyiron_base/jobs/job/util.py
+++ b/pyiron_base/jobs/job/util.py
@@ -37,6 +37,8 @@ def _copy_database_entry(new_job_core, job_copied_id, new_database_entry=True):
     if new_database_entry:
         db_entry = new_job_core.project.db.get_item_by_id(job_copied_id)
         if db_entry is not None:
+            db_entry["job"] = new_job_core.job_name
+            db_entry["subjob"] = new_job_core.project_hdf5.h5_path
             db_entry["project"] = new_job_core.project_hdf5.project_path
             db_entry["projectpath"] = new_job_core.project_hdf5.root_path
             db_entry["subjob"] = new_job_core.project_hdf5.h5_path

--- a/pyiron_base/jobs/job/util.py
+++ b/pyiron_base/jobs/job/util.py
@@ -41,7 +41,6 @@ def _copy_database_entry(new_job_core, job_copied_id, new_database_entry=True):
             db_entry["subjob"] = new_job_core.project_hdf5.h5_path
             db_entry["project"] = new_job_core.project_hdf5.project_path
             db_entry["projectpath"] = new_job_core.project_hdf5.root_path
-            db_entry["subjob"] = new_job_core.project_hdf5.h5_path
             del db_entry["id"]
             job_id = new_job_core.project.db.add_item_dict(db_entry)
             new_job_core.reset_job_id(job_id=job_id)

--- a/tests/job/test_copyto.py
+++ b/tests/job/test_copyto.py
@@ -62,6 +62,22 @@ class TestCopyTo(TestWithProject):
             )
         )
 
+    def test_copy_to_name(self):
+        """Regression test: copied jobs should have the updated name in the database.
+
+        The was a bug where copied jobs would have the new name on the filesystem but still the old name in the
+        database.
+        """
+        ham = self.project.create_job("ScriptJob", "copy_test")
+        ham.save()
+
+        new_ham = ham.copy_to(new_job_name="copy_test_new")
+        self.assertEqual(new_ham.name, "copy_test_new", "New job has wrong name.")
+        self.assertEqual(new_ham.name, new_ham.database_entry.job, "New job has wrong name in the database.")
+
+        ham.remove()
+        new_ham.remove()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -184,10 +184,6 @@ class TestGenericJob(TestWithFilledProject):
         # Completely new job name
         job_new = job.copy_to(new_job_name="template_new", input_only=False, new_database_entry=False)
         self.assertTrue(job_new.status.initialized)
-        # Check if new database entry implemented
-        _ = job.copy_to(new_job_name="template_last", input_only=False, new_database_entry=True)
-        df = self.project.job_table()
-        self.assertEqual(len(df[df.job == "template"]), 2)
         _ = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False,
                         delete_existing_job=True)
         df = self.project.job_table()


### PR DESCRIPTION
Previously the function kept the old job name, because it modifies the db_entry and didn't overwrite it.

That meant that when copying a job inside the same directory to a new name, it would keep the old name in the database which leads to all kinds of funny inconsistencies.