### PR TITLE
Separate relocate_hdf

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -297,6 +297,12 @@ class JobCore(HasGroups):
         """
         self._hdf5 = project.copy()
 
+    def rewrite_hdf5(self):
+        self.project_hdf5.remove_group()
+        self.project_hdf5 = self.project_hdf5.__class__(
+            self.project, self.job_name, h5_path="/" + self.job_name
+        )
+
     @property
     def project(self):
         """

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -298,6 +298,10 @@ class JobCore(HasGroups):
         self._hdf5 = project.copy()
 
     def relocate_hdf5(self, h5_path=None):
+        """
+        Relocate the hdf file. This function is needed when the child job is
+        spawned by a parent job (cf. pyiron_base.jobs.master.generic)
+        """
         if h5_path is None:
             h5_path = "/" + self.job_name
         self.project_hdf5.remove_group()

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -297,10 +297,12 @@ class JobCore(HasGroups):
         """
         self._hdf5 = project.copy()
 
-    def rewrite_hdf5(self):
+    def relocate_hdf5(self, h5_path=None):
+        if h5_path is None:
+            h5_path = "/" + self.job_name
         self.project_hdf5.remove_group()
         self.project_hdf5 = self.project_hdf5.__class__(
-            self.project, self.job_name, h5_path="/" + self.job_name
+            self.project, self.job_name, h5_path=h5_path
         )
 
     @property

--- a/pyiron_base/jobs/master/generic.py
+++ b/pyiron_base/jobs/master/generic.py
@@ -237,10 +237,7 @@ class GenericMaster(GenericJob):
         del self._job_name_lst[i]
         with self.project_hdf5.open("input") as hdf5_input:
             hdf5_input["job_list"] = self._job_name_lst
-        job_to_return.project_hdf5.remove_group()
-        job_to_return.project_hdf5 = self.project_hdf5.__class__(
-            self.project, job_to_return.job_name, h5_path="/" + job_to_return.job_name
-        )
+        job_to_return.rewrite_hdf5()
         if isinstance(job_to_return, GenericMaster):
             for sub_job in job_to_return._job_object_dict.values():
                 self._child_job_update_hdf(parent_job=job_to_return, child_job=sub_job)

--- a/pyiron_base/jobs/master/generic.py
+++ b/pyiron_base/jobs/master/generic.py
@@ -237,7 +237,7 @@ class GenericMaster(GenericJob):
         del self._job_name_lst[i]
         with self.project_hdf5.open("input") as hdf5_input:
             hdf5_input["job_list"] = self._job_name_lst
-        job_to_return.rewrite_hdf5()
+        job_to_return.relocate_hdf5()
         if isinstance(job_to_return, GenericMaster):
             for sub_job in job_to_return._job_object_dict.values():
                 self._child_job_update_hdf(parent_job=job_to_return, child_job=sub_job)


### PR DESCRIPTION
Separate the rewriting of the hdf address, in order for other jobs to be able to intervene (e.g. the new SPHInX implementation that requires an extra loading of lazy mode for the input)