### PR TITLE
Add a function that retries some operation until no exception is thrown

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -454,7 +454,7 @@ class DatabaseAccess(IsDatabase):
             _create_table,
             error=OperationalError,
             msg="Database busy with too many connections.",
-            atmost=10,
+            at_most=10,
             delay=0.1,
             delay_factor=2,
         )

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -29,6 +29,7 @@ from sqlalchemy.exc import OperationalError, DatabaseError
 from threading import Thread, Lock
 from queue import SimpleQueue, Empty as QueueEmpty
 from pyiron_base.database.tables import HistoricalTable
+from pyiron_base.utils.error import retry
 
 __author__ = "Murat Han Celik"
 __copyright__ = (
@@ -445,9 +446,18 @@ class DatabaseAccess(IsDatabase):
             raise ValueError("Connection to database failed: " + str(except_msg))
 
         self._chem_formula_lim_length = 50
-        self.__reload_db()
-        self.simulation_table = HistoricalTable(str(table_name), self.metadata)
-        self.metadata.create_all()
+        # too many jobs trying to talk to the database can cause this too fail.
+        def _create_table():
+            self.__reload_db()
+            self.simulation_table = HistoricalTable(str(table_name), self.metadata)
+            self.metadata.create_all()
+        retry(_create_table,
+                error=OperationalError,
+                msg="Database busy with too many connections.",
+                atmost=10,
+                delay=0.1,
+                delay_factor=2
+        )
         self._view_mode = False
 
     def _get_view_mode(self):

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -387,7 +387,7 @@ class AutorestoredConnection:
         return retry(
             lambda: self.execute_once(*args, **kwargs),
             error=OperationalError,
-            msg=f"Database connection failed with operational error.",
+            msg="Database connection failed with operational error.",
             delay=5,
         )
 
@@ -443,12 +443,13 @@ class DatabaseAccess(IsDatabase):
             raise ValueError("Connection to database failed: " + str(except_msg))
 
         self._chem_formula_lim_length = 50
-        # too many jobs trying to talk to the database can cause this too fail.
+
         def _create_table():
             self.__reload_db()
             self.simulation_table = HistoricalTable(str(table_name), self.metadata)
             self.metadata.create_all()
 
+        # too many jobs trying to talk to the database can cause this too fail.
         retry(
             _create_table,
             error=OperationalError,

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -358,41 +358,39 @@ class AutorestoredConnection:
         self._logger = logger
         self._timeout = timeout
 
+    def execute_once(self, *args, **kwargs):
+        with self._lock:
+            if self._conn is None or self._conn.closed:
+                self._conn = self.engine.connect()
+                if self._timeout > 0:
+                    # only log reconnections when we keep the connection alive between requests otherwise we'll spam
+                    # the log
+                    if self._conn is None:
+                        self._logger.info(
+                            "Reconnecting to DB; connection did not exist."
+                        )
+                    else:
+                        self._logger.info(
+                            "Reconnecting to DB; connection was closed."
+                        )
+                    if self._watchdog is not None:
+                        # in case connection is dead, but watchdog is still up, something else killed the connection,
+                        # make the watchdog quit, then making a new one
+                        self._watchdog.kill()
+                    self._watchdog = ConnectionWatchDog(
+                        self._conn, self._lock, timeout=self._timeout
+                    )
+                    self._watchdog.start()
+            if self._timeout > 0:
+                self._watchdog.kick()
+            return self._conn.execute(*args, **kwargs)
+
     def execute(self, *args, **kwargs):
-        while True:
-            try:
-                with self._lock:
-                    if self._conn is None or self._conn.closed:
-                        self._conn = self.engine.connect()
-                        if self._timeout > 0:
-                            # only log reconnections when we keep the connection alive between requests otherwise we'll spam
-                            # the log
-                            if self._conn is None:
-                                self._logger.info(
-                                    "Reconnecting to DB; connection not existing."
-                                )
-                            else:
-                                self._logger.info(
-                                    "Reconnecting to DB; connection closed."
-                                )
-                            if self._watchdog is not None:
-                                # in case connection is dead, but watchdog is still up, something else killed the connection,
-                                # make the watchdog quit, then making a new one
-                                self._watchdog.kill()
-                            self._watchdog = ConnectionWatchDog(
-                                self._conn, self._lock, timeout=self._timeout
-                            )
-                            self._watchdog.start()
-                    if self._timeout > 0:
-                        self._watchdog.kick()
-                    result = self._conn.execute(*args, **kwargs)
-                    break
-            except OperationalError as e:
-                print(
-                    f"Database connection failed with operational error {e}, waiting 5s, then re-trying."
-                )
-                time.sleep(5)
-        return result
+        return retry(lambda: self.execute_once(*args, **kwargs),
+                error=OperationalError,
+                msg=f"Database connection failed with operational error.",
+                delay=5
+        )
 
     def close(self):
         if self._conn is not None:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -370,9 +370,7 @@ class AutorestoredConnection:
                             "Reconnecting to DB; connection did not exist."
                         )
                     else:
-                        self._logger.info(
-                            "Reconnecting to DB; connection was closed."
-                        )
+                        self._logger.info("Reconnecting to DB; connection was closed.")
                     if self._watchdog is not None:
                         # in case connection is dead, but watchdog is still up, something else killed the connection,
                         # make the watchdog quit, then making a new one
@@ -386,10 +384,11 @@ class AutorestoredConnection:
             return self._conn.execute(*args, **kwargs)
 
     def execute(self, *args, **kwargs):
-        return retry(lambda: self.execute_once(*args, **kwargs),
-                error=OperationalError,
-                msg=f"Database connection failed with operational error.",
-                delay=5
+        return retry(
+            lambda: self.execute_once(*args, **kwargs),
+            error=OperationalError,
+            msg=f"Database connection failed with operational error.",
+            delay=5,
         )
 
     def close(self):
@@ -449,12 +448,14 @@ class DatabaseAccess(IsDatabase):
             self.__reload_db()
             self.simulation_table = HistoricalTable(str(table_name), self.metadata)
             self.metadata.create_all()
-        retry(_create_table,
-                error=OperationalError,
-                msg="Database busy with too many connections.",
-                atmost=10,
-                delay=0.1,
-                delay_factor=2
+
+        retry(
+            _create_table,
+            error=OperationalError,
+            msg="Database busy with too many connections.",
+            atmost=10,
+            delay=0.1,
+            delay_factor=2,
         )
         self._view_mode = False
 

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1477,12 +1477,14 @@ class ProjectHDFio(FileHDFio):
 
 def read_hdf5(fname, title="h5io", slash="ignore", _counter=0):
     return retry(
-            lambda: h5io.read_hdf5(
-                fname=fname, title=title, slash=slash,
-            ),
-            error=BlockingIOError,
-            msg=f"Two or more processes tried to access the file {fname}.",
-            delay=1,
+        lambda: h5io.read_hdf5(
+            fname=fname,
+            title=title,
+            slash=slash,
+        ),
+        error=BlockingIOError,
+        msg=f"Two or more processes tried to access the file {fname}.",
+        delay=1,
     )
 
 
@@ -1496,16 +1498,17 @@ def write_hdf5(
     use_json=False,
     _counter=0,
 ):
-    retry(lambda: h5io.write_hdf5(
-                        fname=fname,
-                        data=data,
-                        overwrite=overwrite,
-                        compression=compression,
-                        title=title,
-                        slash=slash,
-                        use_json=use_json,
-          ),
-          error=BlockingIOError,
-          msg=f"Two or more processes tried to access the file {fname}.",
-          delay=1,
+    retry(
+        lambda: h5io.write_hdf5(
+            fname=fname,
+            data=data,
+            overwrite=overwrite,
+            compression=compression,
+            title=title,
+            slash=slash,
+            use_json=use_json,
+        ),
+        error=BlockingIOError,
+        msg=f"Two or more processes tried to access the file {fname}.",
+        delay=1,
     )

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1485,7 +1485,7 @@ def read_hdf5(fname, title="h5io", slash="ignore"):
         error=BlockingIOError,
         msg=f"Two or more processes tried to access the file {fname}.",
         at_most=10,
-        delay=1
+        delay=1,
     )
 
 
@@ -1511,5 +1511,5 @@ def write_hdf5(
         error=BlockingIOError,
         msg=f"Two or more processes tried to access the file {fname}.",
         at_most=10,
-        delay=1
+        delay=1,
     )

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1475,7 +1475,7 @@ class ProjectHDFio(FileHDFio):
         return self._project.__class__(path=self.file_path)
 
 
-def read_hdf5(fname, title="h5io", slash="ignore", _counter=0):
+def read_hdf5(fname, title="h5io", slash="ignore"):
     return retry(
         lambda: h5io.read_hdf5(
             fname=fname,
@@ -1484,7 +1484,8 @@ def read_hdf5(fname, title="h5io", slash="ignore", _counter=0):
         ),
         error=BlockingIOError,
         msg=f"Two or more processes tried to access the file {fname}.",
-        delay=1,
+        at_most=10,
+        delay=1
     )
 
 
@@ -1496,7 +1497,6 @@ def write_hdf5(
     title="h5io",
     slash="error",
     use_json=False,
-    _counter=0,
 ):
     retry(
         lambda: h5io.write_hdf5(
@@ -1510,5 +1510,6 @@ def write_hdf5(
         ),
         error=BlockingIOError,
         msg=f"Two or more processes tried to access the file {fname}.",
-        delay=1,
+        at_most=10,
+        delay=1
     )

--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -112,7 +112,7 @@ def retry(
         msg: str,
         atmost: Optional[int] = None,
         delay: float = 1.0,
-        delay_factor: float = 1
+        delay_factor: float = 1.0
 ) -> T:
     """
     Try to call `func` until it no longer raises `error`.

--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -106,13 +106,15 @@ class ImportAlarm:
 
 
 T = TypeVar("T")
+
+
 def retry(
-        func: Callable[[], T],
-        error: Union[Type[Exception], Tuple[Type[Exception], ...]],
-        msg: str,
-        atmost: Optional[int] = None,
-        delay: float = 1.0,
-        delay_factor: float = 1.0
+    func: Callable[[], T],
+    error: Union[Type[Exception], Tuple[Type[Exception], ...]],
+    msg: str,
+    atmost: Optional[int] = None,
+    delay: float = 1.0,
+    delay_factor: float = 1.0,
 ) -> T:
     """
     Try to call `func` until it no longer raises `error`.
@@ -143,7 +145,9 @@ def retry(
         try:
             return func()
         except error as e:
-            logger.warn(f"{msg} Trying again in {delay}s. Tried {i + 1} times so far...")
+            logger.warn(
+                f"{msg} Trying again in {delay}s. Tried {i + 1} times so far..."
+            )
             time.sleep(delay)
             delay *= delay_factor
             # e drops out of the namespace after the except clause ends, so

--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -111,7 +111,7 @@ def retry(
     func: Callable[[], T],
     error: Union[Type[Exception], Tuple[Type[Exception], ...]],
     msg: str,
-    atmost: Optional[int] = None,
+    at_most: Optional[int] = None,
     delay: float = 1.0,
     delay_factor: float = 1.0,
 ) -> T:
@@ -124,22 +124,22 @@ def retry(
         func (callable): function to call, should take no arguments
         error (Exception or tuple thereof): any exceptions to be caught
         msg (str): messing to be written to the log if `error` occurs.
-        atmost (int, optional): retry at most this many times, None means retry
+        at_most (int, optional): retry at most this many times, None means retry
                                 forever
         delay (float): time to wait between retries in seconds
         delay_factor (float): multiply `delay` between retries by this factor
 
     Raises:
-        `error`: if `atmost` is exceeded the last error is re-raised
+        `error`: if `at_most` is exceeded the last error is re-raised
         Exception: any exception raised by `func` that does not match `error`
 
     Returns:
         object: whatever is returned by `func`
     """
-    if atmost is None:
+    if at_most is None:
         tries = count()
     else:
-        tries = range(atmost)
+        tries = range(at_most)
     for i in tries:
         try:
             return func()

--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -8,7 +8,6 @@ In order to be accessible from anywhere in pyiron, they *must* remain free of an
 """
 import functools
 from itertools import count
-from math import inf
 import time
 from typing import Callable, TypeVar, Type, Tuple, Optional, Union
 import warnings

--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -7,7 +7,13 @@ Utility functions used in pyiron.
 In order to be accessible from anywhere in pyiron, they *must* remain free of any imports from pyiron!
 """
 import functools
+from itertools import count
+from math import inf
+import time
+from typing import Callable, TypeVar, Type, Tuple, Optional, Union
 import warnings
+
+from pyiron_base.state.logger import logger
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -97,3 +103,51 @@ class ImportAlarm:
         else:
             # unrelated error during import, re-raise
             return False
+
+
+T = TypeVar("T")
+def retry(
+        func: Callable[[], T],
+        error: Union[Type[Exception], Tuple[Type[Exception], ...]],
+        msg: str,
+        atmost: Optional[int] = None,
+        delay: float = 1.0,
+        delay_factor: float = 1
+) -> T:
+    """
+    Try to call `func` until it no longer raises `error`.
+
+    Any other exception besides `error` is still raised.
+
+    Args:
+        func (callable): function to call, should take no arguments
+        error (Exception or tuple thereof): any exceptions to be caught
+        msg (str): messing to be written to the log if `error` occurs.
+        atmost (int, optional): retry at most this many times, None means retry
+                                forever
+        delay (float): time to wait between retries in seconds
+        delay_factor (float): multiply `delay` between retries by this factor
+
+    Raises:
+        `error`: if `atmost` is exceeded the last error is re-raised
+        Exception: any exception raised by `func` that does not match `error`
+
+    Returns:
+        object: whatever is returned by `func`
+    """
+    if atmost is None:
+        tries = count()
+    else:
+        tries = range(atmost)
+    for i in tries:
+        try:
+            return func()
+        except error as e:
+            logger.warn(f"{msg} Trying again in {delay}s. Tried {i + 1} times so far...")
+            time.sleep(delay)
+            delay *= delay_factor
+            # e drops out of the namespace after the except clause ends, so
+            # assign it here to a dummy variable so that we can re-raise it
+            # in case the error persists
+            err = e
+    raise err from None

--- a/tests/utils/test_error.py
+++ b/tests/utils/test_error.py
@@ -44,4 +44,4 @@ class TestRetry(unittest.TestCase):
                 ValueError,
                 msg="retry did re-raise exception after insufficient tries!"
         ):
-            retry(func, error=ValueError, msg="", atmost=2, delay=1e-6)
+            retry(func, error=ValueError, msg="", at_most=2, delay=1e-6)

--- a/tests/utils/test_error.py
+++ b/tests/utils/test_error.py
@@ -1,0 +1,47 @@
+import unittest
+
+from pyiron_base.utils.error import retry
+
+class TestRetry(unittest.TestCase):
+
+    def test_return_value(self):
+        """retry should return the exact value that the function returns."""
+        def func():
+            return 42
+
+        self.assertEqual(func(), retry(func, error=ValueError, msg=""),
+                         "retry returned a different value!")
+
+    def test_unrelated_exception(self):
+        """retry should not catch exception that are not explicitely passed."""
+        def func():
+            raise ValueError()
+        with self.assertRaises(
+                ValueError,
+                msg="retry caught an exception it was not supposed to!"
+        ):
+            retry(func, error=TypeError, msg="")
+    def test_exception(self):
+        """retry should catch explicitely passed exceptions."""
+        class Func():
+            """Small helper to simulate a stateful function."""
+            def __init__(self):
+                self.n = 0
+            def __call__(self):
+                self.n += 1
+                if self.n < 4:
+                    raise ValueError(self.n)
+                else:
+                    return self.n
+        func = Func()
+        try:
+            ret = retry(func, error=ValueError, msg="", delay=1e-6)
+        except ValueError:
+            self.fail("retry did not catch exception!")
+
+        func = Func()
+        with self.assertRaises(
+                ValueError,
+                msg="retry did re-raise exception after insufficient tries!"
+        ):
+            retry(func, error=ValueError, msg="", atmost=2, delay=1e-6)

--- a/tests/utils/test_error.py
+++ b/tests/utils/test_error.py
@@ -35,7 +35,7 @@ class TestRetry(unittest.TestCase):
                     return self.n
         func = Func()
         try:
-            ret = retry(func, error=ValueError, msg="", delay=1e-6)
+            retry(func, error=ValueError, msg="", delay=1e-6)
         except ValueError:
             self.fail("retry did not catch exception!")
 


### PR DESCRIPTION
We used logic like this in the database and in HDF ( #884 ).  I've applied to one more location where the `DatabaseAccess` object tries to create the database tables, because that can cause the database to return an error as well if a lot of jobs try to do it simultaneously.