### PR TITLE
Fix pytable warning

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -793,9 +793,9 @@ class DatabaseAccess(IsDatabase):
             # ensures working with db entries, which are camel case
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")
-            tmp_values = col.values()
+            tmp_values = col._mapping.values()
             if (
-                col.values()[timestop_index] and col.values()[timestart_index]
+                col._mapping.values()[timestop_index] and col._mapping.values()[timestart_index]
             ) is not None:
                 # changes values
                 try:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -790,13 +790,12 @@ class DatabaseAccess(IsDatabase):
         # change the date of str datatype back into datetime object
         output_list = []
         for col_mapping in row:
-            col = dict(col_mapping)
             # ensures working with db entries, which are camel case
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")
-            tmp_values = col.values()
+            tmp_values = list(col.values())
             if (
-                col.values()[timestop_index] and col.values()[timestart_index]
+                tmp_values[timestop_index] and tmp_values[timestart_index]
             ) is not None:
                 # changes values
                 try:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -783,7 +783,7 @@ class DatabaseAccess(IsDatabase):
             result = self.conn.execute(text(sql_statement))
         else:
             result = self.conn.execute(text("select * from " + self.table_name))
-        row = result.mappings().all()
+        row = result.fetchall()
         if not self._keep_connection:
             self.conn.close()
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -789,7 +789,7 @@ class DatabaseAccess(IsDatabase):
 
         # change the date of str datatype back into datetime object
         output_list = []
-        for col_mapping in row:
+        for col in row:
             # ensures working with db entries, which are camel case
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -783,7 +783,7 @@ class DatabaseAccess(IsDatabase):
             result = self.conn.execute(text(sql_statement))
         else:
             result = self.conn.execute(text("select * from " + self.table_name))
-        row = result.fetchall()
+        row = result.mappings().all()
         if not self._keep_connection:
             self.conn.close()
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -783,7 +783,7 @@ class DatabaseAccess(IsDatabase):
             result = self.conn.execute(text(sql_statement))
         else:
             result = self.conn.execute(text("select * from " + self.table_name))
-        row = result.fetchall()
+        row = result.mappings().all()
         if not self._keep_connection:
             self.conn.close()
 
@@ -793,10 +793,9 @@ class DatabaseAccess(IsDatabase):
             # ensures working with db entries, which are camel case
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")
-            tmp_values = col._mapping.values()
+            tmp_values = col.values()
             if (
-                col._mapping.values()[timestop_index]
-                and col._mapping.values()[timestart_index]
+                col.values()[timestop_index] and col.values()[timestart_index]
             ) is not None:
                 # changes values
                 try:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -789,7 +789,8 @@ class DatabaseAccess(IsDatabase):
 
         # change the date of str datatype back into datetime object
         output_list = []
-        for col in row:
+        for col_mapping in row:
+            col = dict(col_mapping)
             # ensures working with db entries, which are camel case
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -795,7 +795,8 @@ class DatabaseAccess(IsDatabase):
             timestart_index = [item.lower() for item in col.keys()].index("timestart")
             tmp_values = col._mapping.values()
             if (
-                col._mapping.values()[timestop_index] and col._mapping.values()[timestart_index]
+                col._mapping.values()[timestop_index]
+                and col._mapping.values()[timestart_index]
             ) is not None:
                 # changes values
                 try:

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -794,9 +794,7 @@ class DatabaseAccess(IsDatabase):
             timestop_index = [item.lower() for item in col.keys()].index("timestop")
             timestart_index = [item.lower() for item in col.keys()].index("timestart")
             tmp_values = list(col.values())
-            if (
-                tmp_values[timestop_index] and tmp_values[timestart_index]
-            ) is not None:
+            if (tmp_values[timestop_index] and tmp_values[timestart_index]) is not None:
                 # changes values
                 try:
                     tmp_values[timestop_index] = datetime.strptime(


### PR DESCRIPTION
```
SADeprecationWarning: The LegacyRow.values() method is deprecated and will be removed in a future release.  Use the Row._mapping attribute, i.e., 'row._mapping.values()'. (deprecated since: 1.4) 69
  col.values()[timestop_index] and col.values()[timestart_index]
```