### PR TITLE
Faster install test

### DIFF
--- a/pyiron_base/state/install.py
+++ b/pyiron_base/state/install.py
@@ -141,7 +141,9 @@ def install_pyiron(
         zip_file (str): name of the compressed file
         project_path (str): the location where pyiron is going to store the pyiron projects
         resource_directory (str): the location where the resouces (executables, potentials, ...) for pyiron are stored.
-        giturl_for_zip_file (str): url for the zipped resources file on github
+        giturl_for_zip_file (str/None): url for the zipped resources file on github.
+            (Default points to pyiron's github resource repository. If None, leaves the
+            resources directory *empty*.)
         git_folder_name (str): name of the extracted folder
     """
     _write_config_file(
@@ -149,9 +151,12 @@ def install_pyiron(
         project_path=project_path,
         resource_path=resource_directory,
     )
-    _download_resources(
-        zip_file=zip_file,
-        resource_directory=resource_directory,
-        giturl_for_zip_file=giturl_for_zip_file,
-        git_folder_name=git_folder_name,
-    )
+    if giturl_for_zip_file is not None:
+        _download_resources(
+            zip_file=zip_file,
+            resource_directory=resource_directory,
+            giturl_for_zip_file=giturl_for_zip_file,
+            git_folder_name=git_folder_name,
+        )
+    else:
+        os.mkdir(resource_directory)

--- a/tests/state/test_install.py
+++ b/tests/state/test_install.py
@@ -30,6 +30,7 @@ class TestInstall(PyironTestCase):
                 config_file_name=os.path.join(self.execution_path, "config"),
                 resource_directory=os.path.join(self.execution_path, "resources"),
                 project_path=os.path.join(self.execution_path, "project"),
+                giturl_for_zip_file=None,
         )
 
         with open(os.path.join(self.execution_path, "config"), "r") as f:


### PR DESCRIPTION
I added the ability to pass `pyiron_base.state.install.install_pyiron(giturl_for_zip_file=None)`, which still creates an (empty!) `resources/` directory, but doesn't download anything. Downloading the zipped resources directory from github is what was taking so much time. `tests/state/test_install.py` now takes ~3s instead of ~30s.