### PR TITLE
Allow none credentials and sql_view config settings

### DIFF
--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -378,17 +378,15 @@ class Settings(metaclass=Singleton):
         return config if len(config) > 0 else None
 
     def _add_credentials_from_file(self, config: dict) -> Dict:
-        if "credentials_file" not in config or config["credentials_file"] is None:
-            return config
-        else:
+        if "credentials_file" in config and config["credentials_file"] is not None:
             credential_file = config["credentials_file"]
 
-        if not os.path.isfile(credential_file):
-            raise FileNotFoundError(credential_file)
-        credentials = (
-            self._parse_config_file(credential_file, self.file_credential_map) or {}
-        )
-        config.update(credentials)
+            if not os.path.isfile(credential_file):
+                raise FileNotFoundError(credential_file)
+            credentials = (
+                self._parse_config_file(credential_file, self.file_credential_map) or {}
+            )
+            config.update(credentials)
         return config
 
     def _get_config_from_file(self) -> Union[Dict, None]:

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -337,7 +337,7 @@ class Settings(metaclass=Singleton):
     @staticmethod
     def _validate_viewer_configuration(config: Dict) -> None:
         key_group = ["sql_view_table_name", "sql_view_user", "sql_view_user_key"]
-        present = [k in config.keys() for k in key_group]
+        present = [k in config.keys() and config[k] is not None for k in key_group]
         if any(present):
             if not all(present):
                 raise ValueError(

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -378,7 +378,7 @@ class Settings(metaclass=Singleton):
         return config if len(config) > 0 else None
 
     def _add_credentials_from_file(self, config: dict) -> Dict:
-        if "credentials_file" not in config:
+        if "credentials_file" not in config or config["credentials_file"] is None:
             return config
         else:
             credential_file = config["credentials_file"]

--- a/tests/state/test_settings.py
+++ b/tests/state/test_settings.py
@@ -44,7 +44,8 @@ class TestSettings(TestCase):
             if "PYIRON" in k:
                 self.env.pop(k)
 
-    def test_default_works(self):
+    @staticmethod
+    def test_default_works():
         s.update(s.default_configuration)
 
     def test_validate_sql_configuration_completeness(self):

--- a/tests/state/test_settings.py
+++ b/tests/state/test_settings.py
@@ -44,6 +44,9 @@ class TestSettings(TestCase):
             if "PYIRON" in k:
                 self.env.pop(k)
 
+    def test_default_works(self):
+        s.update(s.default_configuration)
+
     def test_validate_sql_configuration_completeness(self):
         s._validate_sql_configuration(
             {


### PR DESCRIPTION
This used to fail: `from pyiron_base import state; state.update(state.default_configuration)`. Now it doesn't.

The issue is that for the credentials file and sql_view arguments we had a bunch of checks to see whether the config item *existed* but never checked to see if it was just `None`. Here being `None` is equivalent to not existing.

Closes #954.