### PR TITLE
Move signal catching to separate module and refactor

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -161,9 +161,6 @@ class GenericJob(JobCore):
         self.interactive_cache = None
         self.error = GenericError(job=self)
 
-        for sig in intercepted_signals:
-            signal.signal(sig, self.signal_intercept)
-
     @property
     def version(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -12,6 +12,7 @@ import signal
 import warnings
 
 from pyiron_base.state import state
+from pyiron_base.state.signal import catch_signals
 from pyiron_base.jobs.job.extension.executable import Executable
 from pyiron_base.jobs.job.extension.jobstatus import JobStatus
 from pyiron_base.jobs.job.core import (
@@ -61,13 +62,6 @@ __maintainer__ = "Jan Janssen"
 __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
-
-intercepted_signals = [
-    signal.SIGINT,
-    signal.SIGTERM,
-    signal.SIGABRT,
-]  # , signal.SIGQUIT]
-
 
 # Modular Docstrings
 _doc_str_generic_job_attr = (
@@ -679,62 +673,57 @@ class GenericJob(JobCore):
             run_mode (str): ['modal', 'non_modal', 'queue', 'manual'] overwrites self.server.run_mode
             run_again (bool): Same as delete_existing_job (deprecated)
         """
-        if run_again:
-            delete_existing_job = True
-        try:
-            self._logger.info(
-                "run {}, status: {}".format(self.job_info_str, self.status)
-            )
-            status = self.status.string
-            if run_mode is not None:
-                self.server.run_mode = run_mode
-            if delete_existing_job:
-                status = "initialized"
-                if self.job_id:
-                    self._logger.info("run repair " + str(self.job_id))
-                    master_id, parent_id = self.master_id, self.parent_id
-                    self.remove(_protect_childs=False)
-                    self.reset_job_id()
-                    self.master_id, self.parent_id = master_id, parent_id
-                else:
-                    self.remove(_protect_childs=False)
-            if repair and self.job_id and not self.status.finished:
-                self._run_if_repair()
-            elif status == "initialized":
-                self._run_if_new(debug=debug)
-            elif status == "created":
-                self._run_if_created()
-            elif status == "submitted":
-                run_job_with_status_submitted(job=self)
-            elif status == "running":
-                self._run_if_running()
-            elif status == "collect":
-                self._run_if_collect()
-            elif status == "suspend":
-                self._run_if_suspended()
-            elif status == "refresh":
-                self.run_if_refresh()
-            elif status == "busy":
-                self._run_if_busy()
-            elif status == "finished":
-                run_job_with_status_finished(
-                    job=self,
-                    delete_existing_job=delete_existing_job,
-                    run_again=run_again,
+        with catch_signals(self.signal_intercept):
+            if run_again:
+                delete_existing_job = True
+            try:
+                self._logger.info(
+                    "run {}, status: {}".format(self.job_info_str, self.status)
                 )
-            elif status == "aborted":
-                raise ValueError(
-                    "Running an aborted job with `delete_existing_job=False` is meaningless."
-                )
-        except Exception:
-            self.drop_status_to_aborted()
-            raise
-        except KeyboardInterrupt:
-            self.drop_status_to_aborted()
-            raise
-        except SystemExit:
-            self.drop_status_to_aborted()
-            raise
+                status = self.status.string
+                if run_mode is not None:
+                    self.server.run_mode = run_mode
+                if delete_existing_job:
+                    status = "initialized"
+                    if self.job_id:
+                        self._logger.info("run repair " + str(self.job_id))
+                        master_id, parent_id = self.master_id, self.parent_id
+                        self.remove(_protect_childs=False)
+                        self.reset_job_id()
+                        self.master_id, self.parent_id = master_id, parent_id
+                    else:
+                        self.remove(_protect_childs=False)
+                if repair and self.job_id and not self.status.finished:
+                    self._run_if_repair()
+                elif status == "initialized":
+                    self._run_if_new(debug=debug)
+                elif status == "created":
+                    self._run_if_created()
+                elif status == "submitted":
+                    run_job_with_status_submitted(job=self)
+                elif status == "running":
+                    self._run_if_running()
+                elif status == "collect":
+                    self._run_if_collect()
+                elif status == "suspend":
+                    self._run_if_suspended()
+                elif status == "refresh":
+                    self.run_if_refresh()
+                elif status == "busy":
+                    self._run_if_busy()
+                elif status == "finished":
+                    run_job_with_status_finished(
+                        job=self,
+                        delete_existing_job=delete_existing_job,
+                        run_again=run_again,
+                    )
+                elif status == "aborted":
+                    raise ValueError(
+                        "Running an aborted job with `delete_existing_job=False` is meaningless."
+                    )
+            except Exception:
+                self.drop_status_to_aborted()
+                raise
 
     def run_if_modal(self):
         """
@@ -1199,15 +1188,15 @@ class GenericJob(JobCore):
             h5_dict["groups"] += self._list_ext_childs()
         return h5_dict
 
-    def signal_intercept(self, sig, frame):
+    def signal_intercept(self, sig):
         """
+        Abort the job and log signal that caused it.
+
+        Expected to be called from
+        :func:`pyiron_base.state.signal.catch_signals`.
 
         Args:
-            sig:
-            frame:
-
-        Returns:
-
+            sig (int): the signal that triggered the abort
         """
         try:
             self._logger.info(

--- a/pyiron_base/state/signal.py
+++ b/pyiron_base/state/signal.py
@@ -11,6 +11,19 @@ intercepted_signals = [
 
 @contextlib.contextmanager
 def catch_signals(cleanup):
+    """
+    Context manager to catch signals.
+
+    During the `with` statement a signal handler is installed to catch SIGINT,
+    SIGTERM and SIGABRT.  On exit from the statement the default handlers from
+    the operating system are reinstalled.  The handler first calles the given
+    `cleanup` function and then either raises KeyboardInterrupt (on SIGINT) or
+    calls `sys.exit` (on SIGTERM/SIGABRT).
+
+    Raises:
+        KeyboardInterrupt: received SIGINT
+        SystemExit: received SIGTERM or SIGABRT
+    """
     def handler(sig, frame):
         cleanup(sig)
         if sig == signal.SIGINT:

--- a/pyiron_base/state/signal.py
+++ b/pyiron_base/state/signal.py
@@ -8,6 +8,7 @@ intercepted_signals = [
     signal.SIGABRT,
 ]  # , signal.SIGQUIT]
 
+
 @contextlib.contextmanager
 def catch_signals(cleanup):
     def handler(sig, frame):

--- a/pyiron_base/state/signal.py
+++ b/pyiron_base/state/signal.py
@@ -1,0 +1,26 @@
+import contextlib
+import signal
+import sys
+
+intercepted_signals = [
+    signal.SIGINT,
+    signal.SIGTERM,
+    signal.SIGABRT,
+]  # , signal.SIGQUIT]
+
+@contextlib.contextmanager
+def catch_signals(cleanup):
+    def handler(sig, frame):
+        cleanup(sig)
+        if sig == signal.SIGINT:
+            raise KeyboardInterrupt()
+        elif sig in (signal.SIGTERM, signal.SIGABRT):
+            sys.exit(128 & sig)
+
+    for sig in intercepted_signals:
+        signal.signal(sig, handler)
+
+    try:
+        yield
+    finally:
+        signal.signal(sig, signal.SIG_DFL)

--- a/pyiron_base/state/signal.py
+++ b/pyiron_base/state/signal.py
@@ -23,4 +23,5 @@ def catch_signals(cleanup):
     try:
         yield
     finally:
-        signal.signal(sig, signal.SIG_DFL)
+        for sig in intercepted_signals:
+            signal.signal(sig, signal.SIG_DFL)


### PR DESCRIPTION
The previous implementation also had the problem that it
1. never dropped the signal intercept, but installed it on first initialization of any job, even if the job then doesn't actually run,
2. didn't propagate the signal after it set the job to 'aborted', i.e. trying to interrupt notebooks when no job is running didn't actually interrupt the process
3. kept re-installing the same handler on every job instantiation.  It's not that expensive, but it can cost a few percent of run time, depending on the size of the jobs.

This new implementation only installs the handler during a functions `run()` method call with a context manager and raises KeyboardInterrupt or calls sys.exit as appropriate.