### PR TITLE
Make it easier to store the run time

### DIFF
--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -772,8 +772,7 @@ class TableJob(GenericJob):
             os.path.join(self.working_directory, "pyirontable.csv"), index=False
         )
         self._save_output()
-        if self.job_id is not None:
-            self.project.db.item_update(self._runtime(), self.job_id)
+        self.run_time_to_db()
 
     def get_dataframe(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1353,6 +1353,13 @@ class GenericJob(JobCore):
         if self._executable is None:
             self.__obj_version__ = self._hdf5["VERSION"]
 
+    def run_time_to_db(self):
+        """
+        Internal helper function to store the run_time in the database
+        """
+        if self.job_id is not None:
+            self.project.db.item_update(self._runtime(), self.job_id)
+
     def _runtime(self):
         """
         Internal helper function to calculate runtime by substracting the starttime, from the stoptime.

--- a/pyiron_base/jobs/job/interactive.py
+++ b/pyiron_base/jobs/job/interactive.py
@@ -305,7 +305,7 @@ class InteractiveBase(GenericJob):
         self.project_hdf5.rewrite_hdf5()
         self.status.finished = True
         if not isinstance(self.project.db, FileTable):
-            self.project.db.item_update(self._runtime(), self._job_id)
+            self.run_time_to_db()
         else:
             self._hdf5["status"] = self.status.string
         self._interactive_library = None

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -192,8 +192,7 @@ def run_job_with_status_collect(job):
     """
     job.collect_output()
     job.collect_logfiles()
-    if job.job_id is not None:
-        job.project.db.item_update(job._runtime(), job.job_id)
+    job.run_time_to_db()
     if job.status.collect:
         if not job.convergence_check():
             job.status.not_converged = True
@@ -507,8 +506,7 @@ def execute_job_with_external_executable(job):
             job._logger.warning("Job aborted")
             job._logger.warning(e.output)
             job.status.aborted = True
-            if job.job_id is not None:
-                job.project.db.item_update(job._runtime(), job.job_id)
+            job.run_time_to_db()
             error_file = posixpath.join(job.project_hdf5.working_directory, "error.msg")
             with open(error_file, "w") as f:
                 f.write(e.output)

--- a/pyiron_base/jobs/master/flexible.py
+++ b/pyiron_base/jobs/master/flexible.py
@@ -106,7 +106,7 @@ class FlexibleMaster(GenericMaster):
                     break
         if ind == max_steps - 1 and self.is_finished():
             self.status.finished = True
-            self.project.db.item_update(self._runtime(), self.job_id)
+            self.run_time_to_db()
         else:
             self.status.suspended = True
 

--- a/pyiron_base/jobs/master/list.py
+++ b/pyiron_base/jobs/master/list.py
@@ -116,7 +116,7 @@ class ListMaster(GenericMaster):
                     self.submission_status.submit_next()
                     if len(self._job_name_lst) == 0:
                         self.status.finished = True
-                        self.project.db.item_update(self._runtime(), self.job_id)
+                        self.run_time_to_db()
                 else:
                     raise ValueError(
                         "This job ",


### PR DESCRIPTION
I keep the _run_time() function for the moment as it is still used in randomatomitics and sqs. Once those are updated we can make it an internal function.