### PR TITLE
Remove redundant `_check_if_input_should_be_written()`

### DIFF
--- a/pyiron_base/jobs/job/template.py
+++ b/pyiron_base/jobs/job/template.py
@@ -49,6 +49,3 @@ class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
         self._python_only_job = True
-
-    def _check_if_input_should_be_written(self):
-        return False


### PR DESCRIPTION
Already in `pyiron_base/jobs/job/generic.py` this case is handled:

```
    def _check_if_input_should_be_written(self):
        if self._python_only_job:
            return False
        else:
            return not (
                self.server.run_mode.interactive
                or self.server.run_mode.interactive_non_modal
            )
```