### PR TITLE
Cleaner tests

### DIFF
--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -78,6 +78,7 @@ class TestWithProject(PyironTestCase, ABC):
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         cls.project.remove(enable=True)
         try:
             os.remove(os.path.join(cls.file_location, "pyiron.log"))
@@ -91,6 +92,7 @@ class TestWithCleanProject(TestWithProject, ABC):
     """
 
     def tearDown(self):
+        super().tearDown()
         self.project.remove_jobs(recursive=True, progress=False, silently=True)
 
 

--- a/pyiron_base/_tests.py
+++ b/pyiron_base/_tests.py
@@ -9,7 +9,7 @@ import doctest
 from io import StringIO
 import unittest
 import os
-from pyiron_base import PythonTemplateJob
+from pyiron_base import PythonTemplateJob, state
 from pyiron_base.project.generic import Project
 from abc import ABC
 from inspect import getfile
@@ -35,9 +35,14 @@ class PyironTestCase(unittest.TestCase, ABC):
 
     @classmethod
     def setUpClass(cls):
+        cls._initial_settings_configuration = state.settings.configuration.copy()
         if any([cls is c for c in _TO_SKIP]):
             raise unittest.SkipTest(f"{cls.__name__} tests, it's a base class")
         super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        state.update(cls._initial_settings_configuration)
 
     @property
     def docstring_module(self):

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -27,6 +27,15 @@ class TestPack(PyironTestCase):
             "\\", "/"
         )
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.pr.remove(enable=True)
+        uncompressed_pr = Project(cls.arch_dir)
+        uncompressed_pr.remove(enable=True, enforce=True)
+        os.remove('export.csv')
+
+
     def test_exportedCSV(self):
         # in the first test, the csv file from the packing function is read
         # and is compared with the return dataframe from export_database
@@ -56,6 +65,7 @@ class TestPack(PyironTestCase):
         self.pr.pack(destination_path=self.arch_dir_comp, compress=True)
         file_path = self.arch_dir_comp + ".tar.gz"
         self.assertTrue(os.path.exists(file_path))
+        os.remove(file_path)
 
     def test_content(self):
         # here we test the content of the archive_folder and

--- a/tests/archiving/test_export.py
+++ b/tests/archiving/test_export.py
@@ -13,6 +13,7 @@ class TestPack(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # this is used to create a folder/a compressed file, are not path
         cls.arch_dir = 'archive_folder'
         # this is used to create a folder/a compressed file, are not path

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -24,13 +24,26 @@ class TestUnpacking(PyironTestCase):
         cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
             "\\", "/"
         )
+        cls.imp_pr = Project('imported')
+
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.pr.remove(enable=True)
+        uncompressed_pr = Project(cls.arch_dir)
+        uncompressed_pr.remove(enable=True, enforce=True)
+        os.remove('export.csv')
+        os.remove(cls.arch_dir_comp + ".tar.gz")
+        cls.imp_pr.remove(enable=True)
 
     def setUp(self):
-        self.imp_pr = Project('imported')
+        super().setUp()
         self.imp_pr.remove_jobs(recursive=True, silently=True)
         self.imp_pr.unpack(origin_path=self.arch_dir_comp, compress=True)
 
     def tearDown(self):
+        super().tearDown()
         self.imp_pr.remove_jobs(recursive=True, silently=True)
 
     def test_import_csv(self):

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -11,6 +11,7 @@ from pyiron_base._tests import PyironTestCase, ToyJob
 class TestUnpacking(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # this is used to create a folder/a compressed file, are not path
         cls.arch_dir = 'archive_folder'
         # this is used to create a folder/a compressed file, are not path

--- a/tests/database/test_database_file.py
+++ b/tests/database/test_database_file.py
@@ -28,6 +28,7 @@ class TestDatabaseAccess(PyironTestCase):
         Set up whole class for testing
         Returns:
         """
+        super().setUpClass()
         # we assume everything working on sqlite, should also work on postgres in sqlalchemy
         cls.database = FileTable(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/database/test_no_database_project.py
+++ b/tests/database/test_no_database_project.py
@@ -16,7 +16,6 @@ class TestNoDatabaseProject(TestWithProject):
 
     @classmethod
     def tearDownClass(cls):
-        state.update()
         super().tearDownClass()
         
     def test_validate_database_is_disables(self):

--- a/tests/database/test_no_database_project.py
+++ b/tests/database/test_no_database_project.py
@@ -35,6 +35,7 @@ class TestNoDatabaseProject(TestWithProject):
         self.project.db.force_reset()
         df = self.project.job_table()
         self.assertEqual(len(df), 0)
+        job.remove()  # Clean up the orphaned job HDF
 
 
 if __name__ == "__main__":

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -82,6 +82,7 @@ def _check_full_hdf_values(self, hdf, group="content"):
 class TestFileHDFio(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
         cls.empty_hdf5 = FileHDFio(file_name=cls.current_dir + "/filehdfio_empty.h5")
         cls.full_hdf5 = FileHDFio(file_name=cls.current_dir + "/filehdfio_full.h5")
@@ -102,6 +103,7 @@ class TestFileHDFio(PyironTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
         os.remove(cls.current_dir + "/filehdfio_full.h5")
         os.remove(cls.current_dir + "/filehdfio_io.h5")

--- a/tests/generic/test_genericParameters.py
+++ b/tests/generic/test_genericParameters.py
@@ -16,6 +16,7 @@ class TestGenericParameters(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.generic_parameters_empty = GenericParameters(table_name="empty")
         cls.generic_parameters_str = GenericParameters(table_name="str")
         my_str = """\

--- a/tests/job/test_databaseproperties.py
+++ b/tests/job/test_databaseproperties.py
@@ -13,6 +13,7 @@ from pyiron_base._tests import PyironTestCase
 class TestDatabaseProperties(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.database_entry = {
             "id": 150,
             "parentid": None,

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -24,7 +24,19 @@ class ReturnCodeJob(GenericJob):
     def collect_output(self):
         pass
 
+
 class TestGenericJob(TestWithFilledProject):
+
+    @staticmethod
+    def _manually_remove_jobs(*args):
+        """
+        Jobs that get copied but not saved or who manually `_create_working_directory`
+        create HDF content that is otherwise not caught during project cleanup, so
+        manually remove these.
+        """
+        for job in args:
+            job.remove()
+
     def test_db_entry(self):
         ham = self.project.create.job.ScriptJob("job_single_debug")
         db_entry = ham.db_entry()
@@ -184,7 +196,7 @@ class TestGenericJob(TestWithFilledProject):
         # Completely new job name
         job_new = job.copy_to(new_job_name="template_new", input_only=False, new_database_entry=False)
         self.assertTrue(job_new.status.initialized)
-        _ = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False,
+        job_orphan = job.copy_to(new_job_name="template_copy", input_only=False, new_database_entry=False,
                         delete_existing_job=True)
         df = self.project.job_table()
         self.assertTrue("template_copy" not in df.job.values)
@@ -194,6 +206,8 @@ class TestGenericJob(TestWithFilledProject):
         job_copy = job.copy_template(project=parent_job._hdf5, new_job_name=new_job_name)
         self.assertEqual(job_copy.project_hdf5.path.split('/')[-2], parent_job.job_name)
         self.assertEqual(job_copy.job_name, new_job_name)
+
+        self._manually_remove_jobs(job_new, job_orphan, job_copy)
 
     # def test_sub_job_name(self):
     #     pass
@@ -236,12 +250,14 @@ class TestGenericJob(TestWithFilledProject):
                 self.assertCountEqual(
                     os.listdir(job.working_directory), ["input.yml", "WARNING_pyiron_modified_content"]
                 )
+                self._manually_remove_jobs(job)
             with self.subTest("Suppress writing of warning file"):
                 job = self.project.create_job(ToyJob, "test_not_write_warning_file")
                 job._create_working_directory()
                 self.project.state.settings.configuration[wd_warn_key] = False
                 job.write_input()
                 self.assertEqual(os.listdir(job.working_directory), ['input.yml'])
+                self._manually_remove_jobs(job)
         finally:
             self.project.state.settings.configuration[
                 wd_warn_key

--- a/tests/job/test_interactivewrapper.py
+++ b/tests/job/test_interactivewrapper.py
@@ -11,6 +11,7 @@ class TestInteractiveWrapper(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.file_location = os.path.dirname(os.path.abspath(__file__)).replace(
             "\\", "/"
         )

--- a/tests/job/test_jobtypechoice.py
+++ b/tests/job/test_jobtypechoice.py
@@ -11,6 +11,7 @@ class TestJobTypeChoice(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.jobtypechoice = JobTypeChoice()
 
     def test_dir(self):
@@ -54,6 +55,7 @@ class TestJobCreator(PyironTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.job_factory = JobFactory(project=None)
 
     def test_dir(self):

--- a/tests/project/test_genericPath.py
+++ b/tests/project/test_genericPath.py
@@ -12,6 +12,7 @@ from pyiron_base._tests import PyironTestCase
 class TestGenericPath(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace("\\", "/")
         cls.path_project = GenericPath(
             root_path=cls.current_dir, project_path="project/path/"

--- a/tests/project/test_projectPath.py
+++ b/tests/project/test_projectPath.py
@@ -31,6 +31,7 @@ class TestProjectPath(PyironTestCase):
     def tearDown(self) -> None:
         super().tearDown()
         state.settings.configuration.update(self.settings_configuration)
+        self.project_path.removedirs()
 
     def test_open(self):
         with self.project_path.open("test_open") as test_open:

--- a/tests/project/test_projectPath.py
+++ b/tests/project/test_projectPath.py
@@ -11,6 +11,7 @@ from pyiron_base.state import state
 class TestProjectPath(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         if os.name == "nt":
             cls.current_dir = os.path.dirname(os.path.abspath(__file__)).replace(
                 "\\", "/"
@@ -20,6 +21,7 @@ class TestProjectPath(PyironTestCase):
         cls.settings_configuration = state.settings.configuration.copy()
 
     def setUp(self) -> None:
+        super().setUp()
         state.settings.configuration["project_paths"] = [self.current_dir + "/"]
         state.settings.configuration["project_check_enabled"] = True
 
@@ -27,6 +29,7 @@ class TestProjectPath(PyironTestCase):
         self.project_path = self.project_path.open("test_project_path")
 
     def tearDown(self) -> None:
+        super().tearDown()
         state.settings.configuration.update(self.settings_configuration)
 
     def test_open(self):

--- a/tests/server/test_runmode.py
+++ b/tests/server/test_runmode.py
@@ -10,6 +10,7 @@ from pyiron_base._tests import PyironTestCase
 class TestRunmode(PyironTestCase):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.run_mode_default = Runmode()
         cls.run_mode_modal = Runmode()
         cls.run_mode_modal.mode = "modal"


### PR DESCRIPTION
Running tests on my local machine creates a bunch of garbage files. I want to clean them up automatically. 

I also get worried that sometimes tests mutate `state` and don't put it back how they found it.

The biggest thing here is to log `state.settings.configuration` in `PyironTestCase.setUpClass`, and then use it to update the state in `tearDownClass`. Beyond that it's just a bunch of making sure HDF crap gets deleted.

Note that adding a `tearDownClass` method caused a bunch of errors in children of `PyironTestCase` that defined `setUpClass` without ever calling super. I expect this to also be a problem in downstream repos that do the same thing, so this should stay "draft" until integration tests are run and those downstream problems are patched. (The `super` call will be completely innocuous in the downstream locations before we merge this, so we can patch them before merging, which is nice!)

EDIT: Ok, actually I'm pleasantly surprised; apparently none of the downstream repos we do integration testing against implement our testing classes and override `setUpClass` (at least not without calling `super`), so no further work is needed.