### PR TITLE
Allow external tags in `DataContainer`

### DIFF
--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -835,7 +835,11 @@ class DataContainer(MutableMapping, HasGroups, HasHDF):
             def normalize_key(name):
                 # split a dataset/group name into the position in the list and
                 # the key
-                k, i = name.split("__index_", maxsplit=1)
+                if "__index_" in name:
+                    k, i = name.split("__index_", maxsplit=1)
+                else:
+                    k = name
+                    i = -1
                 i = int(i)
                 if k == "":
                     return i, i


### PR DESCRIPTION
The main reason that the master jobs currently cannot use `DataContainer` is because they contain child jobs in their HDF files. I would like to suggest this change, because maybe it would allow the transition from the current implementation to the unified input structure (cf. [this comment](https://github.com/pyiron/pyiron_base/pull/974#discussion_r1084340423)) easier.

And obviously this should be removed as soon as we get rid of this input/output chaos.