### PR TITLE
Set maxtasksperchild for worker class

### DIFF
--- a/pyiron_base/jobs/worker.py
+++ b/pyiron_base/jobs/worker.py
@@ -135,6 +135,7 @@ class WorkerJob(PythonTemplateJob):
         self.input.sleep_interval = 10
         self.input.child_runtime = 0
         self.input.queue_limit_factor = 2
+        self.input.maxtasksperchild = 1
         self._python_only_job = True
 
     @property
@@ -194,7 +195,7 @@ class WorkerJob(PythonTemplateJob):
         active_job_ids, res_lst = [], []
         process = psutil.Process(os.getpid())
         number_tasks = int(self.server.cores / self.cores_per_job)
-        with Pool(processes=number_tasks) as pool:
+        with Pool(processes=number_tasks, maxtasksperchild=self.input.maxtasksperchild) as pool:
             while True:
                 # Check the database if there are more calculation to execute
                 df = pr.job_table()

--- a/pyiron_base/jobs/worker.py
+++ b/pyiron_base/jobs/worker.py
@@ -195,7 +195,9 @@ class WorkerJob(PythonTemplateJob):
         active_job_ids, res_lst = [], []
         process = psutil.Process(os.getpid())
         number_tasks = int(self.server.cores / self.cores_per_job)
-        with Pool(processes=number_tasks, maxtasksperchild=self.input.maxtasksperchild) as pool:
+        with Pool(
+            processes=number_tasks, maxtasksperchild=self.input.maxtasksperchild
+        ) as pool:
             while True:
                 # Check the database if there are more calculation to execute
                 df = pr.job_table()


### PR DESCRIPTION
This hopefully fixes the memory overflow. The default setting is 1, which is slow but should us minimal amount of memory. Higher numbers might be faster but also more risky. The python default is None, which keeps the processes alive until pool is closed.