### PR TITLE
setting ProjectData to be lazy by default

### DIFF
--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -43,9 +43,7 @@ class ProjectData(DataContainer):
         Args:
             project (pyiron_base.Project): The project instance the storage is attached to.
         """
-        super().__init__(*args, **kwargs)
-        # Projectdata should be lazy by default.
-        self._lazy = lazy
+        super().__init__(*args, lazy=lazy, **kwargs)
         self._project = project
 
     def read(self):

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -44,6 +44,8 @@ class ProjectData(DataContainer):
             project (pyiron_base.Project): The project instance the storage is attached to.
         """
         super().__init__(*args, **kwargs)
+        # Projectdata should be lazy by default.
+        self._lazy = True
         self._project = project
 
     def read(self):

--- a/pyiron_base/project/data.py
+++ b/pyiron_base/project/data.py
@@ -36,7 +36,7 @@ class ProjectData(DataContainer):
         object.__setattr__(instance, "_project", None)
         return instance
 
-    def __init__(self, *args, project=None, **kwargs):
+    def __init__(self, *args, project=None, lazy=True, **kwargs):
         """
         A data storage container which can store itself to/retrieve itself from file at the project level.
 
@@ -45,7 +45,7 @@ class ProjectData(DataContainer):
         """
         super().__init__(*args, **kwargs)
         # Projectdata should be lazy by default.
-        self._lazy = True
+        self._lazy = lazy
         self._project = project
 
     def read(self):


### PR DESCRIPTION
In order to improve performance, avoid unnecessary computations, and decrease memory requirements.
I have set the _lazy flag in ProjectData class to True so it is lazy by default.
closes #835 