### PR TITLE
Always store children in working directory of Master

### DIFF
--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -223,7 +223,9 @@ class ParallelMaster(GenericMaster):
         """
         if len(self._job_name_lst) > 0:
             self._ref_job = self.pop(-1)
-            self._ref_job.job_name = self.job_name + "_" + self._ref_job.job_name
+            job_name = self.job_name + "_" + self._ref_job.job_name
+            self._ref_job.job_name = job_name
+            self._ref_job.project_hdf5 = self.child_hdf(job_name)
             if self._job_id is not None and self._ref_job._master_id is None:
                 self._ref_job.master_id = self.job_id
 


### PR DESCRIPTION
For interactive jobs, in contrast to regular jobs, the child jobs were previously stored on the same level as the master job. With this fix these child jobs are also stored in the working directory of the master jobs.