### PR TITLE
Uniform database access to get child ids

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -142,18 +142,21 @@ class FileTable(IsDatabase, metaclass=Singleton):
         """
         if project is None:
             project = self._project
+        self.update()
         id_master = self.get_job_id(project=project, job_specifier=job_specifier)
         if id_master is None:
             return []
         else:
+            df_tmp = self._job_table[self._job_table.id == id_master]
+            working_directory = (df_tmp["project"] + df_tmp["job"] + "_hdf5/").values[0]
             if status is not None:
                 id_lst = self._job_table[
-                    (self._job_table.masterid == id_master)
+                    (self._job_table.project == working_directory)
                     & (self._job_table.status == status)
                 ].id.values
             else:
                 id_lst = self._job_table[
-                    (self._job_table.masterid == id_master)
+                    (self._job_table.project == working_directory)
                 ].id.values
             return sorted(id_lst)
 

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -281,14 +281,10 @@ class JobCore(HasGroups):
         Returns:
             list: list of child job ids
         """
-        id_master = self.job_id
-        if id_master is None:
-            return []
-        else:
-            id_l = self.project.db.get_items_dict(
-                {"masterid": str(id_master)}, return_all_columns=False
-            )
-            return sorted([job["id"] for job in id_l])
+        return self.project.get_child_ids(
+            job_specifier=self.job_name,
+            project=self.project.project_path
+        )
 
     @property
     def project_hdf5(self):

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -282,8 +282,7 @@ class JobCore(HasGroups):
             list: list of child job ids
         """
         return self.project.get_child_ids(
-            job_specifier=self.job_name,
-            project=self.project.project_path
+            job_specifier=self.job_name, project=self.project.project_path
         )
 
     @property


### PR DESCRIPTION
Always use the get_child_ids() function on the project level, as this one already implements interfaces to both, the SQL database as well as the file based database. In addition for the file based database filter based on the working directory rather than the master_id, as no master_id exists in the file based table.