### PR TITLE
job_table: Check for str before checking for character

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -114,7 +114,7 @@ class IsDatabase(ABC):
                 )
         for key, val in kwargs.items():
             invert = False
-            if val is not None and val[0] == "!":
+            if isinstance(val, str) and val[0] == "!":
                 invert = True
                 val = val[1:]
             if val is None:


### PR DESCRIPTION
When implementing inverted matches, the current code just indexes the given value as if it was a string, but that breaks if the value is a number or so (e.g. when searching with `job_table(master_id=...)`).