### PR TITLE
Making new job classes

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -9,3 +9,4 @@ Tutorials
 
    notebooks/pyiron_paper.ipynb
    notebooks/pythonjobtemplate.ipynb
+   ../../notebooks/custom_jobs.ipynb

--- a/notebooks/custom_jobs.ipynb
+++ b/notebooks/custom_jobs.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "307f9f08-9735-4cd3-88c1-a708418bab3a",
+   "metadata": {},
+   "source": [
+    "# Custom pyiron jobs\n",
+    "\n",
+    "While there are a variety of `pyiron_*` libraries provided and supported by the pyiron organization, you may not find exactly what you're looking for and might want to make custom extensions to pyiron.\n",
+    "Here, we will show how to create new pyiron jobs that perform custom calculations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f13de1cc-beb7-4a95-8ce4-559a2ad35754",
+   "metadata": {},
+   "source": [
+    "As with other times we use pyiron, we'll import a project and -- for this demo -- make sure that the working directory is totally clean:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9e930cb7-d72f-4f85-b7a4-a34d447f6760",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "301e4765e2a644bbbc8ffcd26dc16205",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pyiron_base import Project\n",
+    "pr = Project('tmp')\n",
+    "pr.remove_jobs(silently=True, recursive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eab6f74f-e956-4f2a-ae8f-eb872a4d4158",
+   "metadata": {},
+   "source": [
+    "## Python-only jobs\n",
+    "\n",
+    "The simplest type of new job is one that runs python code. These can inherit from the `PythonTemplateJob`.\n",
+    "\n",
+    "While all user-facing tools should be accessible directly from the `Project` instance, some developer tools need to be imported from their respective modules:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "605ddaa8-6e7c-453f-9694-d335e7cb9b3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyiron_base import PythonTemplateJob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5ab82c50-45f2-452f-8cfa-2ccc98a4bb32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class HelloWorldJob(PythonTemplateJob):\n",
+    "    \n",
+    "    def __init__(self, project, job_name):\n",
+    "        super().__init__(project, job_name) \n",
+    "        # Initial values can be added to input and output fields\n",
+    "        # This is advisable, as it makes the expected IO tab-completable\n",
+    "        self.input.num_exclamations = 1\n",
+    "        \n",
+    "        self.output.message = None\n",
+    "        \n",
+    "    # This is the function executed during normal operation (on `.run()`)\n",
+    "    def run_static(self):\n",
+    "        # It's good form to set the status to \"running\" when you start your calculation\n",
+    "        self.status.running = True\n",
+    "        \n",
+    "        # Do whatever computing you want and populate the output\n",
+    "        self.output.message = \"Hello world\" + \"!\" * self.input.num_exclamations\n",
+    "        \n",
+    "        # After computing, we need to manually invoke `to_hdf` to serialize the data\n",
+    "        self.to_hdf()\n",
+    "        # Everything in the `input` and `output` fields will get written to file\n",
+    "        \n",
+    "        # Don't forget to update the job status when you are finished\n",
+    "        self.status.finished = True\n",
+    "        # Normally, you will want to set the status to `finished`, but other \n",
+    "        # choices include:\n",
+    "        #     initialized, appended, created, submitted, running, aborted, \n",
+    "        #     collect, suspended, refresh, and busy\n",
+    "        # E.g., for a python-only job it may make sense to set the status \n",
+    "        # to `aborted` if a try/except clause runs to the exception."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2eb1f24b-e74d-4b44-969e-c8f1706119c4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The job hello was saved and received the ID: 332\n"
+     ]
+    }
+   ],
+   "source": [
+    "job = pr.create_job(job_type=HelloWorldJob, job_name=\"hello\")\n",
+    "job.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b81536f-5c0d-4e22-86d6-df65e207d3a1",
+   "metadata": {},
+   "source": [
+    "We can now access the output directly on our job instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "68dbc491-37f7-4661-b144-8f82308fb9f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello world!'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.output.message"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "724b1d23-73a1-4e33-bcd9-8287fa453a04",
+   "metadata": {},
+   "source": [
+    "And we can also see it serialized in the job's HDF file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d5b5c9a9-46b2-4879-a19f-b45e37c4e2e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/json": {
+       "message": "'Hello world!'"
+      },
+      "text/html": [
+       "<pre>DataContainer({\n",
+       "  \"message\": \"'Hello world!'\"\n",
+       "})</pre>"
+      ],
+      "text/plain": [
+       "DataContainer({'message': HDFStub({'groups': [], 'nodes': ['HDF_VERSION', 'NAME', 'OBJECT', 'READ_ONLY', 'TYPE', 'VERSION', 'message__index_0']}, message__index_0)})"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job['storage/output']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1d7cd86-3276-4dcc-91af-0cbb5abfda34",
+   "metadata": {},
+   "source": [
+    "Finally, we can de-serialize the job into a new object and see that we recover our input and output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "62d7b4c6-74d1-44d0-88d2-eb064106d973",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 Hello world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "loaded = pr.load(job.name)\n",
+    "print(\n",
+    "    loaded.input.num_exclamations,\n",
+    "    loaded.output.message\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52828149-64bf-4135-b07e-b7dace9db61e",
+   "metadata": {},
+   "source": [
+    "## Shell-based jobs\n",
+    "\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1395dc5f-35f9-47bb-81d2-3bc9072e0bf6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
A demo for creating and using custom jobs

- [x] Pure-python example
- [ ] Shell-based example (i.e. coupling to external codes, should include some file writing/reading)
- [ ] How to run these remotely (i.e. get them registered with your pyiron environment)

I'm also not sure the relative-path ToC tree pointing here will work, but we should find _some_ solution to duplicating the notebooks between /notebooks and /docs/source/notebooks...