### PR TITLE
Reindex file table

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -7,6 +7,7 @@ File based database interface
 
 import datetime
 from collections.abc import Iterable
+from typing import Optional
 import numpy as np
 import os
 import pandas
@@ -48,7 +49,7 @@ table_columns = {
 
 
 class FileTable(IsDatabase, metaclass=UpdatableSingleton):
-    def __init__(self, path=None):
+    def __init__(self, path: Optional[str] = None):
         try:
             if path is not None and os.path.abspath(path) != self._project:
                 # Only re-index if you receive a new location

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -48,16 +48,16 @@ table_columns = {
 
 
 class FileTable(IsDatabase, metaclass=UpdatableSingleton):
-    def __init__(self, project=None):
+    def __init__(self, path=None):
         try:
-            if project is not None and os.path.abspath(project) != self._project:
+            if path is not None and os.path.abspath(path) != self._project:
                 # Only re-index if you receive a new location
-                self._project = os.path.abspath(project)
+                self._project = os.path.abspath(path)
                 self.force_reset()
         except AttributeError:
             # On the first instantiation, self._project (and other attributes) don't
             # exist yet! So run this:
-            if project is None:
+            if path is None:
                 raise TypeError(
                     "On first instantiation of FileTable, the project argument cannot "
                     "be None"
@@ -65,7 +65,7 @@ class FileTable(IsDatabase, metaclass=UpdatableSingleton):
             self._fileindex = None
             self._job_table = None
             self._columns = list(table_columns.keys())
-            self._project = os.path.abspath(project)
+            self._project = os.path.abspath(path)
             self.force_reset()
 
     def add_item_dict(self, par_dict):

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -57,6 +57,11 @@ class FileTable(IsDatabase, metaclass=UpdatableSingleton):
         except AttributeError:
             # On the first instantiation, self._project (and other attributes) don't
             # exist yet! So run this:
+            if project is None:
+                raise TypeError(
+                    "On first instantiation of FileTable, the project argument cannot "
+                    "be None"
+                )
             self._fileindex = None
             self._job_table = None
             self._columns = list(table_columns.keys())

--- a/pyiron_base/interfaces/singleton.py
+++ b/pyiron_base/interfaces/singleton.py
@@ -34,3 +34,48 @@ class Singleton(ABCMeta):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+class UpdatableSingleton(ABCMeta):
+    """
+    Like the `Singeton` class, but will re-run `__init__` on each instantiation.
+
+    This means that subsequent reinitializations have access to the existing state of
+    the object, against which comparisons can be made.
+
+    Examples)
+    >>> class Foo(metaclass=UpdatableSingleton):
+    ...      def __init__(self, x=None):
+    ...         try:
+    ...             if x is not None and x != self.x:
+    ...                 self.x = x
+    ...                 self.y = self.compute_y(x)
+    ...         except AttributeError:
+    ...             self.x = x
+    ...             self.y = self.compute_y(x)
+    ...
+    ...     def compute_y(self, x):
+    ...         # Imagine this was expensive and we wanted to avoid it
+    ...         return x**2 if x is not None else None
+    >>>
+    >>> foo = Foo(5)
+    >>> print(foo.x, foo.y)
+    ... 5 25
+    >>> bar = Foo(6)
+    >>> print(foo.x, foo.y, bar.x, bar.y)
+    ... 6 36 6 36
+    >>> # A singleton, but with updated values!
+    >>> baz = Foo()
+    >>> print(foo.x, foo.y, bar.x, bar.y)
+    ... 6 36
+    >>> # And we wrote Foo so it was easy to recover the object with its existing state
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(UpdatableSingleton, cls).__call__(*args, **kwargs)
+        else:
+            cls._instances[cls].__init__(*args, **kwargs)
+        return cls._instances[cls]

--- a/pyiron_base/interfaces/singleton.py
+++ b/pyiron_base/interfaces/singleton.py
@@ -75,7 +75,9 @@ class UpdatableSingleton(ABCMeta):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(UpdatableSingleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super(UpdatableSingleton, cls).__call__(
+                *args, **kwargs
+            )
         else:
             cls._instances[cls].__init__(*args, **kwargs)
         return cls._instances[cls]

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -741,7 +741,7 @@ class GenericJob(JobCore):
         if state.database.database_is_disabled:
             self.project.db.update()
         else:
-            ft = FileTable(project=self.project_hdf5.path + "_hdf5/")
+            ft = FileTable(path=self.project_hdf5.path + "_hdf5/")
             df = ft.job_table(
                 sql_query=None,
                 user=state.settings.login_user,

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -136,7 +136,7 @@ class Project(ProjectPath, HasGroups):
         if not state.database.database_is_disabled:
             return state.database.database
         else:
-            return FileTable(project=self.path)
+            return FileTable(path=self.path)
 
     @property
     def maintenance(self):

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from os.path import abspath
+
+from pyiron_base._tests import TestWithFilledProject
+
+from pyiron_base.database.filetable import FileTable
+
+
+class TestFileTable(TestWithFilledProject):
+
+    def test_re_instantiation(self):
+        pr = self.project
+        sub_pr = self.project.open(self.project.list_groups()[0])
+
+        ft0 = FileTable(path=pr.path)
+        self.assertEqual(
+            ft0._project,
+            abspath(pr.path),
+            msg="Path should be collected on instantiation"
+        )
+
+        ft1 = FileTable(path=sub_pr.path)
+        self.assertEqual(
+            ft1._project,
+            abspath(sub_pr.path),
+            msg="Path should be collected on instantiation"
+        )
+        self.assertEqual(
+            ft1._project,
+            abspath(sub_pr.path),
+            msg="Singleton behaviour means old instance should get updated"
+        )
+
+        ft2 = FileTable()
+        self.assertEqual(
+            ft2._project,
+            abspath(sub_pr.path),
+            msg="FileTable should allow recovery of current state by passing None"
+        )


### PR DESCRIPTION
I introduce a new singleton class that re-runs `__init__` on each instantiation, and use it to make `FileTable` re-index itself iff it is being instantiated with a new location.

Closes #1073 

Necessary for #951 to get passing tests