### PR TITLE
File table not singleton

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -47,10 +47,10 @@ table_columns = {
 
 
 class FileTable(IsDatabase):
-    def __init__(self, project):
+    def __init__(self, path):
         self._fileindex = None
         self._job_table = None
-        self._project = os.path.abspath(project)
+        self._project = os.path.abspath(path)
         self._columns = list(table_columns.keys())
         self.force_reset()
 

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -11,7 +11,6 @@ import numpy as np
 import os
 import pandas
 from pyfileindex import PyFileIndex
-from pyiron_base.interfaces.singleton import Singleton
 from pyiron_base.database.generic import IsDatabase
 from pyiron_base.storage.helper_functions import read_hdf5, write_hdf5
 
@@ -47,7 +46,7 @@ table_columns = {
 }
 
 
-class FileTable(IsDatabase, metaclass=Singleton):
+class FileTable(IsDatabase):
     def __init__(self, project):
         self._fileindex = None
         self._job_table = None

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -741,7 +741,7 @@ class GenericJob(JobCore):
         if state.database.database_is_disabled:
             self.project.db.update()
         else:
-            ft = FileTable(project=self.project_hdf5.path + "_hdf5/")
+            ft = FileTable(path=self.project_hdf5.path + "_hdf5/")
             df = ft.job_table(
                 sql_query=None,
                 user=state.settings.login_user,

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -122,6 +122,7 @@ class Project(ProjectPath, HasGroups):
         self._inspect_mode = False
         self._data = None
         self._creator = Creator(project=self)
+        self._file_table = None
 
         self.job_type = JobTypeChoice()
 
@@ -136,7 +137,16 @@ class Project(ProjectPath, HasGroups):
         if not state.database.database_is_disabled:
             return state.database.database
         else:
-            return FileTable(project=self.path)
+            return self.file_table
+
+    @property
+    def file_table(self):
+        if not state.database.database_is_disabled:
+            return None
+        else:
+            if self._file_table is None:
+                self._file_table = FileTable(project=self.path)
+            return self._file_table
 
     @property
     def maintenance(self):

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -145,7 +145,7 @@ class Project(ProjectPath, HasGroups):
             return None
         else:
             if self._file_table is None:
-                self._file_table = FileTable(project=self.path)
+                self._file_table = FileTable(path=self.path)
             return self._file_table
 
     @property

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -15,14 +15,14 @@ class TestFileTable(TestWithFilledProject):
         pr = self.project
         sub_pr = self.project.open(self.project.list_groups()[0])
 
-        ft0 = FileTable(project=pr.path)
+        ft0 = FileTable(path=pr.path)
         self.assertEqual(
             ft0._project,
             abspath(pr.path),
             msg="Path should be collected on instantiation"
         )
 
-        ft1 = FileTable(project=sub_pr.path)
+        ft1 = FileTable(path=sub_pr.path)
         self.assertEqual(
             ft1._project,
             abspath(sub_pr.path),

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -11,7 +11,7 @@ from pyiron_base.database.filetable import FileTable
 
 class TestFileTable(TestWithFilledProject):
 
-    def test_re_instantiation(self):
+    def test_instantiation(self):
         pr = self.project
         sub_pr = self.project.open(self.project.list_groups()[0])
 

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from os.path import abspath
+
+from pyiron_base._tests import TestWithFilledProject
+
+from pyiron_base.database.filetable import FileTable
+
+
+class TestFileTable(TestWithFilledProject):
+
+    def test_re_instantiation(self):
+        pr = self.project
+        sub_pr = self.project.open(self.project.list_groups()[0])
+
+        ft0 = FileTable(project=pr.path)
+        self.assertEqual(
+            ft0._project,
+            abspath(pr.path),
+            msg="Path should be collected on instantiation"
+        )
+
+        ft1 = FileTable(project=sub_pr.path)
+        self.assertEqual(
+            ft1._project,
+            abspath(sub_pr.path),
+            msg="Path should be collected on instantiation"
+        )
+        self.assertNotEqual(
+            ft0._project,
+            ft1._project,
+            msg="Separate instances should get their own paths"
+        )


### PR DESCRIPTION
Just don't make the darned thing a singleton.

Projects get an if-clause so they only instantiate (and thus index) one instance per instance.

Closes #1073 

In competition with #1074.

Something like this is necessary for #951.