### PR TITLE
Add support for additional arguments in the queue scripts

### DIFF
--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -94,7 +94,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._send_to_db = False
         self._structure_id = None
         self._accept_crash = False
-        self._additional_arguments = {}
+        self.additional_arguments = {}
 
     @property
     def send_to_db(self):
@@ -398,10 +398,6 @@ class Server:  # add the option to return the job id and the hold id to the serv
         """
         return self.view_queues()
 
-    @property
-    def additional_arguments(self):
-        return self._additional_arguments
-
     @staticmethod
     def list_queues():
         """
@@ -449,7 +445,8 @@ class Server:  # add the option to return the job id and the hold id to the serv
         hdf_dict["run_time"] = self.run_time
         hdf_dict["memory_limit"] = self.memory_limit
         hdf_dict["accept_crash"] = self.accept_crash
-        hdf_dict.update(self._additional_arguments)
+        if len(self._additional_arguments) > 0:
+            hdf_dict["additional_arguments"] = self.additional_arguments
 
         if group_name is not None:
             with hdf.open(group_name) as hdf_group:
@@ -491,24 +488,9 @@ class Server:  # add the option to return the job id and the hold id to the serv
             self._accept_crash = hdf_dict["accept_crash"] == 1
         if "threads" in hdf_dict.keys():
             self._threads = hdf_dict["threads"]
+        if "additional_arguments" in hdf_dict.keys():
+            self.additional_arguments = hdf_dict["additional_arguments"]
         self._new_hdf = hdf_dict["new_h5"] == 1
-        options_used = [
-            "user",
-            "host",
-            "run_mode",
-            "queue",
-            "qid",
-            "structure_id",
-            "cores",
-            "run_time",
-            "memory_limit",
-            "accept_crash",
-            "threads",
-            "new_h5",
-        ]
-        for k, v in hdf_dict.items():
-            if k not in options_used:
-                self._additional_arguments[k] = v
 
     def db_entry(self):
         """

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -445,7 +445,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         hdf_dict["run_time"] = self.run_time
         hdf_dict["memory_limit"] = self.memory_limit
         hdf_dict["accept_crash"] = self.accept_crash
-        if len(self._additional_arguments) > 0:
+        if len(self.additional_arguments) > 0:
             hdf_dict["additional_arguments"] = self.additional_arguments
 
         if group_name is not None:

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -449,8 +449,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         hdf_dict["run_time"] = self.run_time
         hdf_dict["memory_limit"] = self.memory_limit
         hdf_dict["accept_crash"] = self.accept_crash
-        for k, v in self._additional_arguments.items():
-            hdf_dict[k] = v
+        hdf_dict.update(self._additional_arguments)
 
         if group_name is not None:
             with hdf.open(group_name) as hdf_group:

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -94,6 +94,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._send_to_db = False
         self._structure_id = None
         self._accept_crash = False
+        self._additional_arguments = {}
 
     @property
     def send_to_db(self):
@@ -397,6 +398,10 @@ class Server:  # add the option to return the job id and the hold id to the serv
         """
         return self.view_queues()
 
+    @property
+    def additional_arguments(self):
+        return self._additional_arguments
+
     @staticmethod
     def list_queues():
         """
@@ -444,6 +449,8 @@ class Server:  # add the option to return the job id and the hold id to the serv
         hdf_dict["run_time"] = self.run_time
         hdf_dict["memory_limit"] = self.memory_limit
         hdf_dict["accept_crash"] = self.accept_crash
+        for k, v in self._additional_arguments.items():
+            hdf_dict[k] = v
 
         if group_name is not None:
             with hdf.open(group_name) as hdf_group:
@@ -486,6 +493,13 @@ class Server:  # add the option to return the job id and the hold id to the serv
         if "threads" in hdf_dict.keys():
             self._threads = hdf_dict["threads"]
         self._new_hdf = hdf_dict["new_h5"] == 1
+        options_used = [
+            "user", "host", "run_mode", "queue", "qid", "structure_id", "cores",
+            "run_time", "memory_limit", "accept_crash", "threads", "new_h5"
+        ]
+        for k, v in hdf_dict.items():
+            if k not in options_used:
+                self._additional_arguments[k] = v
 
     def db_entry(self):
         """

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -494,8 +494,18 @@ class Server:  # add the option to return the job id and the hold id to the serv
             self._threads = hdf_dict["threads"]
         self._new_hdf = hdf_dict["new_h5"] == 1
         options_used = [
-            "user", "host", "run_mode", "queue", "qid", "structure_id", "cores",
-            "run_time", "memory_limit", "accept_crash", "threads", "new_h5"
+            "user",
+            "host",
+            "run_mode",
+            "queue",
+            "qid",
+            "structure_id",
+            "cores",
+            "run_time",
+            "memory_limit",
+            "accept_crash",
+            "threads",
+            "new_h5",
         ]
         for k, v in hdf_dict.items():
             if k not in options_used:

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -391,6 +391,7 @@ def run_job_with_runmode_queue(job):
         run_time_max=job.server.run_time,
         memory_max=job.server.memory_limit,
         command=command,
+        **job.server.additional_arguments
     )
     if que_id is not None:
         job.server.queue_id = que_id


### PR DESCRIPTION
Example: 
```
job.server.additional_arguments["account"] = "my_account"
job.server.additional_arguments["exclude"] = "node-85,node-86,node-87"
```

And in your queue template: 
```
#!/bin/bash
#SBATCH --output=time.out
#SBATCH --job-name={{job_name}}
#SBATCH --chdir={{working_directory}}
#SBATCH --get-user-env=L
#SBATCH --partition=slurm
{%- if account %}
#SBATCH --account={{account}}
{%- endif %}
{%- if exclude %}
#SBATCH --exclude={{exclude}}
{%- endif %}
{%- if run_time_max %}
#SBATCH --time={{ [1, run_time_max // 60]|max }}
{%- endif %}
{%- if memory_max %}
#SBATCH --mem={{memory_max}}G
{%- endif %}
#SBATCH --cpus-per-task={{cores}}

{{command}}
```

These additional arguments should be propagated. 