### PR TITLE
Polish filetable

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -56,13 +56,13 @@ class FileTableSingleton(ABCMeta):
     _instances = {}
 
     def __call__(cls, index_from):
-        _path = os.path.abspath(os.path.expanduser(index_from))
-        if _path not in cls._instances:
-            cls._instances[_path] = super(FileTableSingleton, cls).__call__(
-                    index_from=_path,
-                    fileindex=cls._get_fileindex_if_theres_a_common_path(_path),
+        path = os.path.abspath(os.path.expanduser(index_from))
+        if path not in cls._instances:
+            cls._instances[path] = super(FileTableSingleton, cls).__call__(
+                    index_from=path,
+                    fileindex=cls._get_fileindex_if_theres_a_common_path(path),
                 )
-        return cls._instances[_path]
+        return cls._instances[path]
 
     def _get_fileindex_if_theres_a_common_path(cls, path):
         common_path = _get_most_common_path(

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -59,9 +59,9 @@ class FileTableSingleton(ABCMeta):
         path = os.path.abspath(os.path.expanduser(index_from))
         if path not in cls._instances:
             cls._instances[path] = super(FileTableSingleton, cls).__call__(
-                    index_from=path,
-                    fileindex=cls._get_fileindex_if_theres_a_common_path(path),
-                )
+                index_from=path,
+                fileindex=cls._get_fileindex_if_theres_a_common_path(path),
+            )
         return cls._instances[path]
 
     def _get_fileindex_if_theres_a_common_path(cls, path):

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -58,7 +58,7 @@ class FileTableSingleton(ABCMeta):
     def __call__(cls, index_from):
         path = os.path.abspath(os.path.expanduser(index_from))
         if path not in cls._instances:
-            cls._instances[path] = super(FileTableSingleton, cls).__call__(
+            cls._instances[path] = super().__call__(
                 index_from=path,
                 fileindex=cls._get_fileindex_if_theres_a_common_path(path),
             )

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -58,19 +58,20 @@ class FileTableSingleton(ABCMeta):
     def __call__(cls, index_from):
         _path = os.path.abspath(os.path.expanduser(index_from))
         if _path not in cls._instances:
-            common_path = _get_most_common_path(
-                path=_path, reference_paths=cls._instances.keys()
-            )
-            if common_path is not None:
-                cls._instances[_path] = super(FileTableSingleton, cls).__call__(
+            cls._instances[_path] = super(FileTableSingleton, cls).__call__(
                     index_from=_path,
-                    fileindex=cls._instances[common_path]._fileindex.open(_path),
-                )
-            else:
-                cls._instances[_path] = super(FileTableSingleton, cls).__call__(
-                    index_from=_path
+                    fileindex=cls._get_fileindex_if_theres_a_common_path(_path),
                 )
         return cls._instances[_path]
+
+    def _get_fileindex_if_theres_a_common_path(cls, path):
+        common_path = _get_most_common_path(
+            path=path, reference_paths=cls._instances.keys()
+        )
+        if common_path is not None:
+            return cls._instances[common_path]._fileindex.open(path)
+        else:
+            return None
 
 
 class FileTable(IsDatabase, metaclass=FileTableSingleton):

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -16,19 +16,24 @@ class TestFileTable(PyironTestCase):
     #       sibling file `test_database_file.py`. These are ancient magic and I'm not
     #       touching them right now. -Liam Huber
 
-    def test_re_initialization(self):
+    def setUp(self) -> None:
         here = dirname(abspath(__file__))
-        loc1 = join(here, "ft_test_loc1")
-        loc2 = join(here, "ft_test_loc2")
-        mkdir(loc1)
-        mkdir(loc2)
+        self.loc1 = join(here, "ft_test_loc1")
+        self.loc2 = join(here, "ft_test_loc2")
+        mkdir(self.loc1)
+        mkdir(self.loc2)
 
+    def tearDown(self) -> None:
+        rmdir(self.loc1)
+        rmdir(self.loc2)
+
+    def test_re_initialization(self):
         start = time()
-        ft = FileTable(loc1)
+        ft = FileTable(self.loc1)
         first_initialization = time() - start
 
         start = time()
-        ft_reinitialized = FileTable(loc1)
+        ft_reinitialized = FileTable(self.loc1)
         second_initialization = time() - start
 
         print([f"{t:.2e}" for t in [
@@ -49,11 +54,8 @@ class TestFileTable(PyironTestCase):
                 f"{second_initialization:.2e} for the second"
         )
 
-        another_ft = FileTable(loc2)
+        another_ft = FileTable(self.loc2)
         self.assertFalse(
             ft is another_ft,
             msg="New paths should create new FileTable instances"
         )
-
-        rmdir(loc1)
-        rmdir(loc2)


### PR DESCRIPTION
So this PR is 100% just nit resolutions.

@pmrv had some weird trouble with GitHub but let me know by e-mail his good insight into the trouble with [`TypeError: descriptor '__call__' of 'type' object needs an argument`](https://github.com/pyiron/pyiron_base/pull/1093#discussion_r1197082285) -- we have a nasty interaction of `classmethod` and `super` where we're passing types instead of instances. I played around with a MWE in a notebook for just a couple minutes and didn't find a good solution, but I realized we don't need to instantiate the new object in the class method anyhow, we just need to get a file index out of it (or not) and that's easy. So here I refactor away the if-else clause, which reeeeaaally is just a nit, but I still like it.

The other thing is that while I was doing this I ran into the situation that the filetable tests failed, and on re-running them they failed again because some folders they created already existed. So now we just pull out the creation/deletion to make sure that cleanup happens regardless of the test state. No more manually deleting local test folders for me!