### PR TITLE
Allow for project_path to be relative

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -604,7 +604,9 @@ class FileTable(IsDatabase, metaclass=FileTableSingleton):
                     self._job_table.project.str.contains(project_path)
                 ]
             else:
-                return self._job_table[self._job_table.project == project_path]
+                return self._job_table[
+                    self._job_table.project.str.endswith(project_path)
+                ]
         else:
             return self._job_table
 


### PR DESCRIPTION
Closes #1103.

This allows `project_path` to be a relative path and the `project` column of the `job_table` to be absolute paths at the same time.