### PR TITLE
Remove working directory warnings

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -158,6 +158,7 @@ class GenericJob(JobCore):
         self._process = None
         self._compress_by_default = False
         self._python_only_job = False
+        self._write_work_dir_warnings = True
         self.interactive_cache = None
         self.error = GenericError(job=self)
 
@@ -378,7 +379,7 @@ class GenericJob(JobCore):
         Write the input files for the external executable. This method has to be implemented in the individual
         hamiltonians.
         """
-        if state.settings.configuration["write_work_dir_warnings"]:
+        if state.settings.configuration["write_work_dir_warnings"] and self._write_work_dir_warnings and not self._python_only_job:
             with open(
                 os.path.join(self.working_directory, "WARNING_pyiron_modified_content"),
                 "w",

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -379,7 +379,11 @@ class GenericJob(JobCore):
         Write the input files for the external executable. This method has to be implemented in the individual
         hamiltonians.
         """
-        if state.settings.configuration["write_work_dir_warnings"] and self._write_work_dir_warnings and not self._python_only_job:
+        if (
+            state.settings.configuration["write_work_dir_warnings"]
+            and self._write_work_dir_warnings
+            and not self._python_only_job
+        ):
             with open(
                 os.path.join(self.working_directory, "WARNING_pyiron_modified_content"),
                 "w",

--- a/pyiron_base/jobs/job/template.py
+++ b/pyiron_base/jobs/job/template.py
@@ -48,3 +48,4 @@ class PythonTemplateJob(TemplateJob):
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
         self._python_only_job = True
+        self._write_work_dir_warnings = False

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -246,6 +246,8 @@ class TestGenericJob(TestWithFilledProject):
                 self.project.state.settings.configuration[wd_warn_key] = True
                 job = self.project.create_job(ToyJob, "test_write_warning_file")
                 job._create_working_directory()
+                job._python_only_job = False
+                job._write_work_dir_warnings = True
                 job.write_input()
                 self.assertCountEqual(
                     os.listdir(job.working_directory), ["input.yml", "WARNING_pyiron_modified_content"]
@@ -460,12 +462,11 @@ class TestGenericJob(TestWithFilledProject):
             wd_files = job_restart.list_files()
             self.assertEqual(
                 len(wd_files),
-                2,
-                "Only one input and the WARNING_pyiron_modified_content file should "
-                "be present in the working directory",
+                1,
+                "Only one input file should be present in the working directory",
             )
             self.assertCountEqual(
-                wd_files, ["input.yml", "WARNING_pyiron_modified_content"]
+                wd_files, ["input.yml"]
             )
         finally:
             self.project.state.settings.configuration[


### PR DESCRIPTION
At least for pure python jobs as those do not write input and output files, but rather just call `run_static()`. In addition the developer of a traditional job which writes input and output files can be removed by setting `job._write_work_dir_warinings = False` .