### PR TITLE
Only try to lock Traits objects

### DIFF
--- a/pyiron_base/storage/has_stored_traits.py
+++ b/pyiron_base/storage/has_stored_traits.py
@@ -309,20 +309,15 @@ class HasStoredTraits(HasTraits, HasStorage, ABC, metaclass=ABCTraitsMeta):
         """Recursively make all traits read-only."""
         self._read_only = True
         for sub in self.trait_values().values():
-            if not isinstance(sub, HasStoredTraits): continue
-            try:
+            if isinstance(sub, HasStoredTraits):
                 sub.lock()
-            except AttributeError:
-                pass
 
     def unlock(self):
         """Recursively make all traits both readable and writeable"""
         self._read_only = False
         for sub in self.trait_values().values():
-            try:
+            if isinstance(sub, HasStoredTraits):
                 sub.unlock()
-            except AttributeError:
-                pass
 
     def __setattr__(self, key, value):
         if key == "_read_only":

--- a/pyiron_base/storage/has_stored_traits.py
+++ b/pyiron_base/storage/has_stored_traits.py
@@ -309,6 +309,7 @@ class HasStoredTraits(HasTraits, HasStorage, ABC, metaclass=ABCTraitsMeta):
         """Recursively make all traits read-only."""
         self._read_only = True
         for sub in self.trait_values().values():
+            if not isinstance(sub, HasStoredTraits): continue
             try:
                 sub.lock()
             except AttributeError:


### PR DESCRIPTION
Previously we tried to duck-type this, but it doesn't play well with some exotic `__getattr__` overloads that I have.  I left the previous check in, though, because I wasn't sure if `lock()`ing can fail in other cases.