### PR TITLE
Do not try to double write objects that define to_hdf

### DIFF
--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -240,12 +240,14 @@ class FileHDFio(HasGroups, MutableMapping):
             key (str): key to store the data
             value (pandas.DataFrame, pandas.Series, dict, list, float, int): basically any kind of data is supported
         """
-        use_json = True
         if hasattr(value, "to_hdf") & (
             not isinstance(value, (pandas.DataFrame, pandas.Series))
         ):
             value.to_hdf(self, key)
-        elif (
+            return
+
+        use_json = True
+        if (
             isinstance(value, (list, np.ndarray))
             and len(value) > 0
             and isinstance(value[0], (list, np.ndarray))


### PR DESCRIPTION
`ProjecHDFio` checks whether values to be written define a `to_hdf` method and call it correctly, but then the conditional falls through and `h5py` is then called to write the same value again.  Which obviously fails.  This just adds an early return to avoid this.