### PR TITLE
HasStoredTraits: Use setitem instead of setattr

### DIFF
--- a/pyiron_base/storage/has_stored_traits.py
+++ b/pyiron_base/storage/has_stored_traits.py
@@ -294,7 +294,7 @@ class HasStoredTraits(HasTraits, HasStorage, ABC, metaclass=ABCTraitsMeta):
             self._read_only
         )  # read_only and _read_only are already used on DataContainer
         for k in self.traits().keys():
-            setattr(self.storage, k, getattr(self, k))
+            self.storage[k] = getattr(self, k)
         super()._to_hdf(hdf)
 
     def _from_hdf(self, hdf: ProjectHDFio, version: Optional[str] = None):


### PR DESCRIPTION
Previously the class puts its trait values into the underlying storage by doing

setattr(self.storage, key, value)

This creates problems when `key` clashes with a predefined method name, because DataContainer first resolves attribute names to predefined methods and attributes.  So if you define a trait with a conflicting name HasStoredTraits will then overwrite the method or attribute instead of writing to the container, which means this clashing value is not properly stored.

The solution is simply to use item access, because that never resolves to predefined methods and attributes like

self.storage[key] = value