### PR TITLE
Implement run_mode flux based on the flux python interface

### DIFF
--- a/pyiron_base/jobs/job/extension/server/runmode.py
+++ b/pyiron_base/jobs/job/extension/server/runmode.py
@@ -26,6 +26,7 @@ run_mode_lst = [
     "thread",
     "worker",
     "srun",
+    "flux",
     "interactive",
     "interactive_non_modal",
 ]

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -693,7 +693,7 @@ class GenericJob(JobCore):
                 elif status == "initialized":
                     self._run_if_new(debug=debug)
                 elif status == "created":
-                    self._run_if_created()
+                    return self._run_if_created()
                 elif status == "submitted":
                     run_job_with_status_submitted(job=self)
                 elif status == "running":

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -38,6 +38,7 @@ from pyiron_base.jobs.job.runfunction import (
     run_job_with_runmode_interactive_non_modal,
     run_job_with_runmode_queue,
     run_job_with_runmode_srun,
+    run_job_with_runmode_flux,
     execute_job_with_external_executable,
 )
 from pyiron_base.jobs.job.util import (
@@ -840,6 +841,13 @@ class GenericJob(JobCore):
         calculation to separate nodes in a SLURM based HPC cluster.
         """
         run_job_with_runmode_srun(job=self)
+
+    def run_if_flux(self):
+        """
+        The run if flux function is called by run to execute the simulation using flux, this allows distributing
+        calculation to separate nodes in a flux based HPC cluster.
+        """
+        return run_job_with_runmode_flux(job=self)
 
     def run_if_manually(self, _manually_print=True):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -701,7 +701,7 @@ class GenericJob(JobCore):
                 if repair and self.job_id and not self.status.finished:
                     self._run_if_repair()
                 elif status == "initialized":
-                    self._run_if_new(debug=debug)
+                    return self._run_if_new(debug=debug)
                 elif status == "created":
                     return self._run_if_created()
                 elif status == "submitted":
@@ -1230,7 +1230,7 @@ class GenericJob(JobCore):
         Args:
             debug (bool): Debug Mode
         """
-        run_job_with_status_initialized(job=self, debug=debug)
+        return run_job_with_status_initialized(job=self, debug=debug)
 
     def _run_if_created(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -159,6 +159,7 @@ class GenericJob(JobCore):
         self._process = None
         self._compress_by_default = False
         self._python_only_job = False
+        self._flux_executor = None
         self.interactive_cache = None
         self.error = GenericError(job=self)
 
@@ -213,6 +214,15 @@ class GenericJob(JobCore):
         """
         self._executable_activate()
         self._executable.executable_path = exe
+
+    @property
+    def flux_executor(self):
+        return self._flux_executor
+
+    @flux_executor.setter
+    def flux_executor(self, exe):
+        self.server.run_mode.flux = True
+        self._flux_executor = exe
 
     @property
     def server(self):
@@ -847,7 +857,7 @@ class GenericJob(JobCore):
         The run if flux function is called by run to execute the simulation using flux, this allows distributing
         calculation to separate nodes in a flux based HPC cluster.
         """
-        return run_job_with_runmode_flux(job=self)
+        return run_job_with_runmode_flux(job=self, executor=self._flux_executor)
 
     def run_if_manually(self, _manually_print=True):
         """

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -17,12 +17,10 @@ from pyiron_base.state import state
 try:
     import flux.job
 
-    flux_installed = True
     import_alarm = ImportAlarm()
 except ImportError:
-    flux_installed = False
     import_alarm = ImportAlarm(
-        "job.server.run_mode.flux requires the flux-framework with python bindings."
+        message="job.server.run_mode.flux requires the flux-framework with python bindings."
     )
 
 

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -457,7 +457,7 @@ def run_job_with_runmode_srun(job):
     )
 
 
-def run_job_with_runmode_flux(job):
+def run_job_with_runmode_flux(job, executor):
     if not flux_available:
         raise ModuleNotFoundError(
             "No module named 'flux'. No linux you can install flux via conda."
@@ -498,8 +498,7 @@ python -m pyiron_base.cli wrapper -p {{working_directory}} -f {{file_name}}{{h5_
     )
     jobspec.cwd = job.project_hdf5.working_directory
     jobspec.environment = dict(os.environ)
-    exe = flux.job.FluxExecutor()
-    return exe.submit(jobspec)
+    return executor.submit(jobspec)
 
 
 def run_time_decorator(func):

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -86,7 +86,7 @@ def run_job_with_status_initialized(job, debug=False):
         print("job exists already and therefore was not created!")
     else:
         job.save()
-        job.run()
+        return job.run()
 
 
 def run_job_with_status_created(job):

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -16,11 +16,14 @@ from pyiron_base.state import state
 
 try:
     import flux.job
+
     flux_installed = True
     import_alarm = ImportAlarm()
 except ImportError:
     flux_installed = False
-    import_alarm = ImportAlarm("job.server.run_mode.flux requires the flux-framework with python bindings.")
+    import_alarm = ImportAlarm(
+        "job.server.run_mode.flux requires the flux-framework with python bindings."
+    )
 
 
 """
@@ -462,7 +465,8 @@ def run_job_with_runmode_srun(job):
 @import_alarm
 def run_job_with_runmode_flux(job):
     if not state.database.database_is_disabled:
-        executable_template = Template("""\
+        executable_template = Template(
+            """\
 #!/bin/bash
 python -m pyiron_base.cli wrapper -p {{working_directory}} -j {{job_id}}
 """
@@ -473,7 +477,8 @@ python -m pyiron_base.cli wrapper -p {{working_directory}} -j {{job_id}}
         )
         job_name = "pi_" + str(job.job_id)
     else:
-        executable_template = Template("""\
+        executable_template = Template(
+            """\
 #!/bin/bash
 python -m pyiron_base.cli wrapper -p {{working_directory}} -f {{file_name}}{{h5_path}}
 """
@@ -481,7 +486,7 @@ python -m pyiron_base.cli wrapper -p {{working_directory}} -f {{file_name}}{{h5_
         exeuctable_str = executable_template.render(
             working_directory=job.working_directory,
             file_name=job.project_hdf5.file_name,
-            h5_path=job.project_hdf5.h5_path
+            h5_path=job.project_hdf5.h5_path,
         )
         job_name = job.job_name
 

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -15,6 +15,7 @@ from pyiron_base.state import state
 
 try:
     import flux.job
+
     flux_available = True
 except ImportError:
     flux_available = False
@@ -459,8 +460,8 @@ def run_job_with_runmode_srun(job):
 def run_job_with_runmode_flux(job):
     if not flux_available:
         raise ModuleNotFoundError(
-            "No module named 'flux'. No linux you can install flux via conda." +
-            "'conda install -c conda-forge flux'"
+            "No module named 'flux'. No linux you can install flux via conda."
+            + "'conda install -c conda-forge flux'"
         )
     if not state.database.database_is_disabled:
         executable_template = Template(

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -10,18 +10,14 @@ import subprocess
 from jinja2 import Template
 
 from pyiron_base.utils.deprecate import deprecate
-from pyiron_base.utils.error import ImportAlarm
 from pyiron_base.jobs.job.wrapper import JobWrapper
 from pyiron_base.state import state
 
 try:
     import flux.job
-
-    import_alarm = ImportAlarm()
+    flux_available = True
 except ImportError:
-    import_alarm = ImportAlarm(
-        message="job.server.run_mode.flux requires the flux-framework with python bindings."
-    )
+    flux_available = False
 
 
 """
@@ -460,8 +456,12 @@ def run_job_with_runmode_srun(job):
     )
 
 
-@import_alarm
 def run_job_with_runmode_flux(job):
+    if not flux_available:
+        raise ModuleNotFoundError(
+            "No module named 'flux'. No linux you can install flux via conda." +
+            "'conda install -c conda-forge flux'"
+        )
     if not state.database.database_is_disabled:
         executable_template = Template(
             """\


### PR DESCRIPTION
Example: 
```
>>> import flux.job
>>> from pyiron_atomistics import Project
>>> pr = Project('test')
>>> job = pr.create.job.Lammps("lmp")
>>> job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
>>> job.flux_executor = flux.job.FluxExecutor()
>>> job.server.cores = 2
>>> fs = job.run()
>>> print(fs.done())
>>> print(fs.result())
>>> print(fs.done())
False
0
True
```

The `fs` object here is a python `concurrent.futures` object, so you can use `fs.done()` to check if the calculation is finished or call `fs.result()` to wait until the calculation is finished. 