### PR TITLE
FileTable on windows

### DIFF
--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -571,7 +571,11 @@ class FileTable(IsDatabase, metaclass=FileTableSingleton):
                 "status": get_job_status_from_file(hdf5_file=path, job_name=job),
                 "job": job,
                 "subjob": "/" + job,
-                "project": os.path.dirname(path) + "/",
+                "project": os.path.dirname(path).replace("\\", "/") + "/",
+                # pyiron Project paths are forced to be posix-like with / instead of \
+                # in order for the contains and endswith tests down in _get_job_table
+                # to work on windows, we need to make sure that the file table obeys
+                # this conversion
                 "timestart": time,
                 "timestop": time,
                 "totalcputime": 0.0,

--- a/pyiron_base/database/filetable.py
+++ b/pyiron_base/database/filetable.py
@@ -534,9 +534,15 @@ class FileTable(IsDatabase, metaclass=FileTableSingleton):
                     )
                 ]
             )
+            sanitized_paths = self._fileindex.dataframe.path.str.replace("\\", "/")
+            # The files_list is generated using project path values
+            # In pyiron, these are all forced to be posix-like with /
+            # But _fileindex is of type PyFileIndex, which does _not_ modify paths
+            # so to get the two compatible for an isin check, we need to sanitize the
+            # _fileindex.dataframe.path results
             df_new = self._fileindex.dataframe[
                 ~self._fileindex.dataframe.is_directory
-                & ~self._fileindex.dataframe.path.isin(files_lst)
+                & ~sanitized_paths.isin(files_lst)
             ]
         else:
             files_lst, working_dir_lst = [], []

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -6,9 +6,10 @@ from os import mkdir, rmdir
 from os.path import abspath, dirname, join
 from time import time
 
-from pyiron_base._tests import PyironTestCase
+from pyiron_base._tests import PyironTestCase, ToyJob
 
 from pyiron_base.database.filetable import FileTable
+from pyiron_base.project.generic import Project
 
 
 class TestFileTable(PyironTestCase):
@@ -60,3 +61,30 @@ class TestFileTable(PyironTestCase):
             ft is another_ft,
             msg="New paths should create new FileTable instances"
         )
+
+    def test_job_table(self):
+        pr = Project(dirname(__file__))
+        job = pr.create_job(job_type=ToyJob, job_name="toy_1")
+        job.run()
+        self.assertEqual(len(pr.job_table()), 1)
+
+        with self.subTest("Check if the file table can see the job and see it once"):
+            ft = FileTable(index_from=pr.path)
+            self.assertEqual(
+                len(pr.job_table()),
+                len(ft._job_table),
+                msg="We expect to see exactly the same job(s) that is in the project's "
+                    "database job table"
+            )
+
+            ft.update()
+            self.assertEqual(
+                len(pr.job_table()),
+                len(ft._job_table),
+                msg="update is called in each _get_job_table call, and if path "
+                    "comparisons fail -- e.g. because you're on windows but pyiron "
+                    "Projects force all the paths to use \\ instead of /, then the "
+                    "update can (and was before the PR where this test got added) "
+                    "duplicate jobs in the job table."
+            )
+        pr.remove_jobs(recursive=True, progress=False, silently=True)

--- a/tests/database/test_filetable.py
+++ b/tests/database/test_filetable.py
@@ -63,7 +63,7 @@ class TestFileTable(PyironTestCase):
         )
 
     def test_job_table(self):
-        pr = Project(dirname(__file__))
+        pr = Project(dirname(__file__) + "test_filetable_test_job_table")
         job = pr.create_job(job_type=ToyJob, job_name="toy_1")
         job.run()
         self.assertEqual(len(pr.job_table()), 1)


### PR DESCRIPTION
Running without the database didn't work on windows because neither `FileTable` nor `PyFileIndex` conformed to `Project`'s standard of using `\` instead of `/` in file paths.

This conversion is now made in `FileTable` in a permanent way, so that the `\` paths show up in `pr.job_table().project` when running without the database, and internally and idempotently in when using `PyFileIndex.dataframe.path` data.

Tests were added to catch the failures on Windows machines.