### PR TITLE
Drop pathlib2

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -8,7 +8,6 @@ dependencies:
 - h5py
 - numpy
 - pandas
-- pathlib2
 - pint
 - psutil
 - pyfileindex

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - h5py =3.9.0
 - numpy =1.24.3
 - pandas =2.0.2
-- pathlib2 =2.3.7.post1
 - pint =0.22
 - psutil =5.9.5
 - pyfileindex =0.0.11

--- a/pyiron_base/project/external.py
+++ b/pyiron_base/project/external.py
@@ -6,7 +6,7 @@ Load input parameters for jupyter notebooks from external HDF5 or JSON file
 """
 
 import json
-from pathlib2 import Path
+from pathlib import Path
 import warnings
 from pyiron_base.storage.hdfio import FileHDFio
 from pyiron_base.storage.datacontainer import DataContainer

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'h5py==3.9.0',
         'numpy==1.24.3',
         'pandas==2.0.2',
-        'pathlib2==2.3.7.post1',
         'pint==0.22',
         'psutil==5.9.5',
         'pyfileindex==0.0.11',


### PR DESCRIPTION
If I see this correctly `pathlib2` is purely a backport of `pathlib` to python2.  We were using it only in one place and all usage there seems to be supported by standard lib `pathlib` since python3.4.  Hence I kick it out here and see if anything breaks.