### PR TITLE
Implement concurrent.futures.ProcessPoolExecutor interface

### DIFF
--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -456,7 +456,11 @@ class Server:  # add the option to return the job id and the hold id to the serv
 
     @property
     def executor(self) -> Union[Executor, None]:
-        return self._executor
+        if self.run_mode.executor:
+            return self._executor
+        else:
+            self._executor = None
+            return self._executor
 
     @executor.setter
     def executor(self, exe: Union[Executor, None]):

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -8,9 +8,11 @@ Server object class which is connected to each job containing the technical deta
 from concurrent.futures import Executor
 from collections import OrderedDict
 import numbers
+import socket
+from typing import Union
+
 from pyiron_base.state import state
 from pyiron_base.jobs.job.extension.server.runmode import Runmode
-import socket
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -76,6 +78,10 @@ class Server:  # add the option to return the job id and the hold id to the serv
         .. attribute:: executor
 
             the executor can be used to execute the job object
+
+        .. attribute:: future
+
+            the concurrent.futures.Future object for monitoring the execution of the job object
     """
 
     def __init__(
@@ -108,6 +114,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._new_hdf = new_hdf
         self._send_to_db = False
         self._structure_id = None
+        self._future = None
         self._accept_crash = False
         self.additional_arguments = {}
 
@@ -448,18 +455,29 @@ class Server:  # add the option to return the job id and the hold id to the serv
             return None
 
     @property
-    def executor(self):
+    def executor(self) -> Union[Executor, None]:
         return self._executor
 
     @executor.setter
-    def executor(self, exe):
+    def executor(self, exe: Union[Executor, None]):
         if isinstance(exe, Executor):
             self._executor = exe
             self.run_mode.executor = True
+        elif exe is None:
+            self._executor = None
+            self.run_mode.executor = False
         else:
             raise TypeError(
                 "The executor has to be derived from the concurrent.futures.Executor class."
             )
+
+    @property
+    def future(self):
+        return self._future
+
+    @future.setter
+    def future(self, future_obj):
+        self._future = future_obj
 
     def to_hdf(self, hdf, group_name=None):
         """

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -254,10 +254,22 @@ class Server:  # add the option to return the job id and the hold id to the serv
 
     @property
     def gpus(self):
+        """
+        Total number of GPUs to use for this calculation.
+
+        Returns:
+            int: Total number of GPUs to use for this calculation.
+        """
         return self._gpus
 
     @gpus.setter
     def gpus(self, number_of_gpus):
+        """
+        Total number of GPUs to use for this calculation.
+
+        Args:
+            number_of_gpus (int): Total number of GPUs to use for this calculation.
+        """
         self._gpus = number_of_gpus
 
     @property

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -463,15 +463,14 @@ class Server:  # add the option to return the job id and the hold id to the serv
     @executor.setter
     def executor(self, exe: Union[Executor, None]):
         if isinstance(exe, Executor):
-            self._executor = exe
             self.run_mode.executor = True
         elif exe is None:
-            self._executor = None
             self.run_mode.modal = True
         else:
             raise TypeError(
                 "The executor has to be derived from the concurrent.futures.Executor class."
             )
+        self._executor = exe
 
     @property
     def future(self):

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -114,7 +114,6 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._new_hdf = new_hdf
         self._send_to_db = False
         self._structure_id = None
-        self._future = None
         self._accept_crash = False
         self.additional_arguments = {}
 

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -5,6 +5,7 @@
 Server object class which is connected to each job containing the technical details how the job is executed.
 """
 
+from concurrent.futures import Executor
 from collections import OrderedDict
 import numbers
 from pyiron_base.state import state
@@ -71,6 +72,10 @@ class Server:  # add the option to return the job id and the hold id to the serv
         .. attribute:: new_hdf
 
             defines whether a subjob should be stored in the same HDF5 file or in a new one.
+
+        .. attribute:: executor
+
+            the executor can be used to execute the job object
     """
 
     def __init__(
@@ -91,6 +96,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._memory_limit = None
         self._host = self._init_host(host=host)
         self._run_mode = Runmode()
+        self._executor = None
 
         self.queue = queue
 
@@ -440,6 +446,20 @@ class Server:  # add the option to return the job id and the hold id to the serv
             return state.queue_adapter.queue_view
         else:
             return None
+
+    @property
+    def executor(self):
+        return self._executor
+
+    @executor.setter
+    def executor(self, exe):
+        if isinstance(exe, Executor):
+            self._executor = exe
+            self.run_mode.executor = True
+        else:
+            raise TypeError(
+                "The executor has to be derived from the concurrent.futures.Executor class."
+            )
 
     def to_hdf(self, hdf, group_name=None):
         """

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -102,7 +102,8 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._memory_limit = None
         self._host = self._init_host(host=host)
         self._run_mode = Runmode()
-        self._executor = None
+        self._executor: Union[Executor, None] = None
+        self._future: Union[Future, None] = None
 
         self.queue = queue
 

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -465,7 +465,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
             self.run_mode.executor = True
         elif exe is None:
             self._executor = None
-            self.run_mode.executor = False
+            self.run_mode.modal = True
         else:
             raise TypeError(
                 "The executor has to be derived from the concurrent.futures.Executor class."

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -485,7 +485,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         self._executor = exe
 
     @property
-    def future(self):
+    def future(self) -> Union[Future, None]:
         """
         Python concurrent.futures.Future object to track the status of the execution of the job this server object is
         attached to. This is an internal pyiron feature and most users never have to interact with the future object

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -246,10 +246,22 @@ class Server:  # add the option to return the job id and the hold id to the serv
 
     @property
     def threads(self):
+        """
+        The number of threads selected for the current simulation
+
+        Returns:
+            (int): number of threads
+        """
         return self._threads
 
     @threads.setter
     def threads(self, number_of_threads):
+        """
+        The number of threads selected for the current simulation
+
+        Args:
+            number_of_threads (int): number of threads
+        """
         self._threads = number_of_threads
 
     @property
@@ -375,7 +387,8 @@ class Server:  # add the option to return the job id and the hold id to the serv
         Get the run mode of the job
 
         Returns:
-            (str/pyiron_base.server.runmode.Runmode): ['modal', 'non_modal', 'queue', 'manual']
+            (str/pyiron_base.server.runmode.Runmode): ['modal', 'non_modal', 'queue', 'manual', 'thread', 'worker',
+                        'interactive', 'interactive_non_modal', 'srun', 'executor']
         """
         return self._run_mode
 
@@ -385,7 +398,8 @@ class Server:  # add the option to return the job id and the hold id to the serv
         Set the run mode of the job
 
         Args:
-            new_mode (str): ['modal', 'non_modal', 'queue', 'manual']
+            new_mode (str): ['modal', 'non_modal', 'queue', 'manual', 'thread', 'worker', 'interactive',
+                        'interactive_non_modal', 'srun', 'executor']
         """
         self._run_mode.mode = new_mode
         if new_mode == "queue":
@@ -442,12 +456,24 @@ class Server:  # add the option to return the job id and the hold id to the serv
 
     @property
     def executor(self) -> Union[Executor, None]:
+        """
+        Executor to execute the job object this server object is attached to in the background.
+
+        Returns:
+            concurrent.futures.Executor:
+        """
         if not self.run_mode.executor and self._executor is not None:
             self._executor = None
         return self._executor
 
     @executor.setter
     def executor(self, exe: Union[Executor, None]):
+        """
+        Executor to execute the job object this server object is attached to in the background.
+
+        Args:
+            exe (concurrent.futures.Executor):
+        """
         if isinstance(exe, Executor):
             self.run_mode.executor = True
         elif exe is None:

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -476,7 +476,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
         """
         if isinstance(exe, Executor):
             self.run_mode.executor = True
-        elif exe is None:
+        elif exe is None and self.run_mode.executor:
             self.run_mode.modal = True
         else:
             raise TypeError(

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -478,7 +478,7 @@ class Server:  # add the option to return the job id and the hold id to the serv
             self.run_mode.executor = True
         elif exe is None and self.run_mode.executor:
             self.run_mode.modal = True
-        else:
+        elif exe is not None:
             raise TypeError(
                 "The executor has to be derived from the concurrent.futures.Executor class."
             )

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -456,11 +456,9 @@ class Server:  # add the option to return the job id and the hold id to the serv
 
     @property
     def executor(self) -> Union[Executor, None]:
-        if self.run_mode.executor:
-            return self._executor
-        else:
+        if not self.run_mode.executor and self._executor is not None:
             self._executor = None
-            return self._executor
+        return self._executor
 
     @executor.setter
     def executor(self, exe: Union[Executor, None]):

--- a/pyiron_base/jobs/job/extension/server/queuestatus.py
+++ b/pyiron_base/jobs/job/extension/server/queuestatus.py
@@ -228,8 +228,8 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                     finished = True
                     break
                 elif isinstance(job.server.future, Future):
-                    finished = True
                     job.server.future.result(timeout=interval_in_s)
+                    finished = job.server.future.done()
                     break
                 else:
                     time.sleep(interval_in_s)

--- a/pyiron_base/jobs/job/extension/server/queuestatus.py
+++ b/pyiron_base/jobs/job/extension/server/queuestatus.py
@@ -228,6 +228,7 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                     finished = True
                     break
                 elif isinstance(job.server.future, Future):
+                    finished = True
                     job.server.future.result()
                     break
                 else:

--- a/pyiron_base/jobs/job/extension/server/queuestatus.py
+++ b/pyiron_base/jobs/job/extension/server/queuestatus.py
@@ -5,6 +5,7 @@
 Set of functions to interact with the queuing system directly from within pyiron - optimized for the Sun grid engine.
 """
 
+from concurrent.futures import Future
 import pandas
 import time
 import numpy as np
@@ -226,7 +227,11 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                 if job.status.string in job_status_finished_lst:
                     finished = True
                     break
-                time.sleep(interval_in_s)
+                elif isinstance(job.server.future, Future):
+                    job.server.future.result()
+                    break
+                else:
+                    time.sleep(interval_in_s)
             if not finished:
                 raise ValueError(
                     "Maximum iterations reached, but the job was not finished."

--- a/pyiron_base/jobs/job/extension/server/queuestatus.py
+++ b/pyiron_base/jobs/job/extension/server/queuestatus.py
@@ -229,7 +229,7 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                     break
                 elif isinstance(job.server.future, Future):
                     finished = True
-                    job.server.future.result()
+                    job.server.future.result(timeout=interval_in_s)
                     break
                 else:
                     time.sleep(interval_in_s)

--- a/pyiron_base/jobs/job/extension/server/runmode.py
+++ b/pyiron_base/jobs/job/extension/server/runmode.py
@@ -28,6 +28,7 @@ run_mode_lst = [
     "srun",
     "interactive",
     "interactive_non_modal",
+    "executor",
 ]
 
 
@@ -39,9 +40,15 @@ class Runmode(object):
     - queue: submit the job to the queuing system
     - manual: let the user manually execute the job
     - thread: internal job mode, which is selected when the master job is send to the queue.
+    - worker: submit the job to the worker job for execution
     - interactive: the interactive run mode
+    - interactive_non_modal: the combination of the interactive and the non_modal mode
+    - srun: call SLURM to start the subprocess rather than starting it directly
+    - executor: python interface to execute jobs based on the concurrent.futures.Executor
+
     Args:
-        mode (str): ['modal', 'non_modal', 'queue', 'manual', 'thread', 'interactive']
+        mode (str): ['modal', 'non_modal', 'queue', 'manual', 'thread', 'worker', 'interactive',
+                     'interactive_non_modal', 'srun', 'executor']
     """
 
     def __init__(self, mode="modal"):

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -480,7 +480,7 @@ class GenericJob(JobCore):
         # Copy executor - it cannot be copied and is just linked instead
         if self.server.executor is not None:
             copied_self.server.executor = self.server.executor
-        if self.server.future is not None and not self.sever.future.done():
+        if self.server.future is not None and not self.server.future.done():
             raise RuntimeError(
                 "Jobs whose server has executor and future attributes cannot be copied unless the future is `done()`"
             )

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -694,9 +694,9 @@ class GenericJob(JobCore):
                 if repair and self.job_id and not self.status.finished:
                     self._run_if_repair()
                 elif status == "initialized":
-                    return self._run_if_new(debug=debug)
+                    self._run_if_new(debug=debug)
                 elif status == "created":
-                    return self._run_if_created()
+                    self._run_if_created()
                 elif status == "submitted":
                     run_job_with_status_submitted(job=self)
                 elif status == "running":
@@ -1195,7 +1195,7 @@ class GenericJob(JobCore):
         Args:
             debug (bool): Debug Mode
         """
-        return run_job_with_status_initialized(job=self, debug=debug)
+        run_job_with_status_initialized(job=self, debug=debug)
 
     def _run_if_created(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -481,7 +481,9 @@ class GenericJob(JobCore):
         if self.server.executor is not None:
             copied_self.server.executor = self.server.executor
         if self.server.future is not None and not self.sever.future.done():
-            raise RuntimeError("Jobs whose server has executor and future attributes cannot be copied unless the future is `done()`")
+            raise RuntimeError(
+                "Jobs whose server has executor and future attributes cannot be copied unless the future is `done()`"
+            )
         return copied_self
 
     def _internal_copy_to(

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -439,7 +439,7 @@ class GenericJob(JobCore):
             if self.server.future.cancelled():
                 self.status.aborted = True
             else:
-                self._status.finished = True
+                self.status.finished = True
 
     def clear_job(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -433,7 +433,7 @@ class GenericJob(JobCore):
             )
         if (
             isinstance(self.server.future, Future)
-            and not self._status.finished
+            and not self.status.finished
             and self.server.future.done()
         ):
             if self.server.future.cancelled():

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -466,6 +466,10 @@ class GenericJob(JobCore):
         _job_reload_after_copy(
             job=copied_self, delete_file_after_copy=delete_file_after_copy
         )
+
+        # Copy executor - it cannot be copied and is just linked instead
+        if self.server.executor is not None:
+            copied_self.server.executor = self.server.executor
         return copied_self
 
     def _internal_copy_to(
@@ -690,9 +694,9 @@ class GenericJob(JobCore):
                 if repair and self.job_id and not self.status.finished:
                     self._run_if_repair()
                 elif status == "initialized":
-                    self._run_if_new(debug=debug)
+                    return self._run_if_new(debug=debug)
                 elif status == "created":
-                    self._run_if_created()
+                    return self._run_if_created()
                 elif status == "submitted":
                     run_job_with_status_submitted(job=self)
                 elif status == "running":
@@ -1191,7 +1195,7 @@ class GenericJob(JobCore):
         Args:
             debug (bool): Debug Mode
         """
-        run_job_with_status_initialized(job=self, debug=debug)
+        return run_job_with_status_initialized(job=self, debug=debug)
 
     def _run_if_created(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -437,7 +437,7 @@ class GenericJob(JobCore):
             and self.server.future.done()
         ):
             if self.server.future.cancelled():
-                self._status.aborted = True
+                self.status.aborted = True
             else:
                 self._status.finished = True
 

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -480,6 +480,8 @@ class GenericJob(JobCore):
         # Copy executor - it cannot be copied and is just linked instead
         if self.server.executor is not None:
             copied_self.server.executor = self.server.executor
+        if self.server.future is not None and not self.sever.future.done():
+            raise RuntimeError("Jobs whose server has executor and future attributes cannot be copied unless the future is `done()`")
         return copied_self
 
     def _internal_copy_to(

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -16,7 +16,6 @@ from pyiron_base.state import state
 from pyiron_base.utils.instance import static_isinstance
 
 
-
 """
 The function job.run() inside pyiron is executed differently depending on the status of the job object. This module 
 introduces the most general run functions and how they are selected. 

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -110,6 +110,8 @@ def run_job_with_status_created(job):
             gpus_per_slot = int(job.server.gpus / job.server.cores)
         else:
             gpus_per_slot = None
+        if gpus_per_slot < 0:
+            raise ValueError("Both job.server.gpus and job.server.cores have to be greater than zero.")
         run_job_with_runmode_executor(
             job=job,
             executor=job.server.executor,

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -109,7 +109,9 @@ def run_job_with_status_created(job):
         if job.server.gpus is not None:
             gpus_per_slot = int(job.server.gpus / job.server.cores)
             if gpus_per_slot < 0:
-                raise ValueError("Both job.server.gpus and job.server.cores have to be greater than zero.")
+                raise ValueError(
+                    "Both job.server.gpus and job.server.cores have to be greater than zero."
+                )
         else:
             gpus_per_slot = None
         run_job_with_runmode_executor(

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -108,10 +108,10 @@ def run_job_with_status_created(job):
     elif job.server.run_mode.executor:
         if job.server.gpus is not None:
             gpus_per_slot = int(job.server.gpus / job.server.cores)
+            if gpus_per_slot < 0:
+                raise ValueError("Both job.server.gpus and job.server.cores have to be greater than zero.")
         else:
             gpus_per_slot = None
-        if gpus_per_slot < 0:
-            raise ValueError("Both job.server.gpus and job.server.cores have to be greater than zero.")
         run_job_with_runmode_executor(
             job=job,
             executor=job.server.executor,

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -552,6 +552,10 @@ class ParallelMaster(GenericMaster):
                     self._run_if_master_modal_child_modal(job)
                 elif self.server.run_mode.modal and job.server.run_mode.non_modal:
                     self._run_if_master_modal_child_non_modal(job)
+                elif job.server.run_mode.executor:
+                    raise NotImplementedError(
+                        "Currently ParallelMaster jobs do not support child jobs with job.server.run_mode.executor."
+                    )
                 else:
                     raise TypeError()
         else:

--- a/pyiron_base/jobs/master/serial.py
+++ b/pyiron_base/jobs/master/serial.py
@@ -273,6 +273,10 @@ class SerialMasterBase(GenericMaster):
                 self._run_if_master_modal_child_modal(job)
             elif self.server.run_mode.modal and job.server.run_mode.non_modal:
                 self._run_if_master_modal_child_non_modal(job)
+            elif job.server.run_mode.executor:
+                raise NotImplementedError(
+                    "Currently SerialMasterBase jobs do not support child jobs with job.server.run_mode.executor."
+                )
             else:
                 raise TypeError()
         else:

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -4,6 +4,7 @@
 
 import unittest
 import os
+from concurrent.futures import ProcessPoolExecutor
 from pyiron_base.storage.parameters import GenericParameters
 from pyiron_base.jobs.job.generic import GenericJob
 from pyiron_base._tests import TestWithFilledProject, ToyJob
@@ -501,6 +502,26 @@ class TestGenericJob(TestWithFilledProject):
         except RuntimeError:
             pass
         self.assertTrue(j.status.aborted, "Job did not abort even though return code is 2!")
+
+    def test_job_executor(self):
+        j = self.project.create_job(ReturnCodeJob, "job_with_executor")
+        j.input["accepted_codes"] = [1]
+        j.server.executor = ProcessPoolExecutor()
+        self.assertTrue(j.server.run_mode.executor)
+        fs = j.run()
+        fs.result()
+        self.assertTrue(fs.done())
+
+    def test_job_executor_copy(self):
+        j1 = self.project.create_job(ReturnCodeJob, "job_with_executor_copy")
+        j1.input["accepted_codes"] = [1]
+        j1.server.executor = ProcessPoolExecutor()
+        j2 = j1.copy()
+        self.assertTrue(j2.server.run_mode.executor)
+        fs = j2.run()
+        fs.result()
+        self.assertTrue(fs.done())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -504,14 +504,6 @@ class TestGenericJob(TestWithFilledProject):
             pass
         self.assertTrue(j.status.aborted, "Job did not abort even though return code is 2!")
 
-    def test_job_executor_set(self):
-        j = self.project.create_job(ReturnCodeJob, "job_with_executor_set")
-        j.server.executor = ProcessPoolExecutor()
-        self.assertTrue(j.server.run_mode.executor)
-        j.server.run_mode.modal = True
-        self.assertFalse(j.server.run_mode.executor)
-        self.assertIsNone(j.server.executor)
-
     def test_job_executor_run(self):
         j = self.project.create_job(ReturnCodeJob, "job_with_executor_run")
         j.input["accepted_codes"] = [1]
@@ -559,6 +551,7 @@ class TestGenericJob(TestWithFilledProject):
         # No copying jobs with futures that aren't done
         with self.assertRaises(RuntimeError):
             j2.copy()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -510,6 +510,7 @@ class TestGenericJob(TestWithFilledProject):
         self.assertTrue(j.server.run_mode.executor)
         j.server.run_mode.modal = True
         self.assertFalse(j.server.run_mode.executor)
+        self.assertIsNone(j.server.executor)
 
     def test_job_executor_run(self):
         j = self.project.create_job(ReturnCodeJob, "job_with_executor_run")

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -504,8 +504,15 @@ class TestGenericJob(TestWithFilledProject):
             pass
         self.assertTrue(j.status.aborted, "Job did not abort even though return code is 2!")
 
-    def test_job_executor(self):
-        j = self.project.create_job(ReturnCodeJob, "job_with_executor")
+    def test_job_executor_set(self):
+        j = self.project.create_job(ReturnCodeJob, "job_with_executor_set")
+        j.server.executor = ProcessPoolExecutor()
+        self.assertTrue(j.server.run_mode.executor)
+        j.server.run_mode.modal = True
+        self.assertFalse(j.server.run_mode.executor)
+
+    def test_job_executor_run(self):
+        j = self.project.create_job(ReturnCodeJob, "job_with_executor_run")
         j.input["accepted_codes"] = [1]
         j.server.executor = ProcessPoolExecutor()
         self.assertTrue(j.server.run_mode.executor)

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -5,7 +5,7 @@
 import unittest
 import os
 from time import sleep
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor
 from pyiron_base.storage.parameters import GenericParameters
 from pyiron_base.jobs.job.generic import GenericJob
 from pyiron_base._tests import TestWithFilledProject, ToyJob

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -517,7 +517,7 @@ class TestGenericJob(TestWithFilledProject):
         j1.input["accepted_codes"] = [1]
         j1.server.executor = ProcessPoolExecutor()
         j2 = j1.copy()
-        self.assertIs(j2.server.executor, j.server.executor)
+        self.assertIs(j2.server.executor, j1.server.executor)
         self.assertTrue(j2.server.run_mode.executor)
         j2.run()
         j2.server.future.result()

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -508,19 +508,20 @@ class TestGenericJob(TestWithFilledProject):
         j.input["accepted_codes"] = [1]
         j.server.executor = ProcessPoolExecutor()
         self.assertTrue(j.server.run_mode.executor)
-        fs = j.run()
-        fs.result()
-        self.assertTrue(fs.done())
+        j.run()
+        j.server.future.result()
+        self.assertTrue(j.server.future.done())
 
     def test_job_executor_copy(self):
         j1 = self.project.create_job(ReturnCodeJob, "job_with_executor_copy")
         j1.input["accepted_codes"] = [1]
         j1.server.executor = ProcessPoolExecutor()
         j2 = j1.copy()
+        self.assertIs(j2.server.executor, j.server.executor)
         self.assertTrue(j2.server.run_mode.executor)
-        fs = j2.run()
-        fs.result()
-        self.assertTrue(fs.done())
+        j2.run()
+        j2.server.future.result()
+        self.assertTrue(j2.server.future.done())
 
 
 if __name__ == "__main__":

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -554,7 +554,11 @@ class TestGenericJob(TestWithFilledProject):
         j2.run()
         j2.server.future.result()
         self.assertTrue(j2.server.future.done())
-
+        j2.server.future = Future()
+        # Manually override the future with one that isn't done() to test copy spec:
+        # No copying jobs with futures that aren't done
+        with self.assertRaises(RuntimeError):
+            j2.copy()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
+from concurrent.futures import ProcessPoolExecutor
 from pyiron_base.jobs.job.extension.server.generic import Server
 from pyiron_base._tests import PyironTestCase
 from pyiron_base.state.queue_adapter import queue_adapters
@@ -258,6 +259,13 @@ class TestRunmode(PyironTestCase):
                 None,
                 "setting run_time should not set a memory_limit",
             )
+
+    def test_server_executor_set(self):
+        self.server.executor = ProcessPoolExecutor()
+        self.assertTrue(self.server.run_mode.executor)
+        self.server.run_mode.modal = True
+        self.assertFalse(self.server.run_mode.executor)
+        self.assertIsNone(self.server.executor)
 
     def test_set_memory_limit(self):
         with self.subTest("None queue"):


### PR DESCRIPTION
Example code:
```
from concurrent.futures import ProcessPoolExecutor
from pyiron_atomistics import Project

pr = Project('test')

job = pr.create.job.Lammps("lmp")
job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
job.server.executor = ProcessPoolExecutor()
job.server.cores = 2
fs = job.run()

print(fs.done())
print(fs.result())
print(fs.done())
```