### PR TITLE
Fixes for parallel master without database

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -137,12 +137,12 @@ class GenericJob(JobCore):
             self.refresh_job_status()
         elif os.path.exists(self.project_hdf5.file_name):
             initial_status = read_hdf5(
-                self.project_hdf5.file_name, self.job_name + "/status"
+                self.project_hdf5.file_name, self.project_hdf5.h5_path + "/status"
             )
             self._status = JobStatus(initial_status=initial_status)
             if "job_id" in self.list_nodes():
                 self._job_id = read_hdf5(
-                    self.project_hdf5.file_name, self.job_name + "/job_id"
+                    self.project_hdf5.file_name, self.project_hdf5.h5_path + "/job_id"
                 )
         else:
             self._status = JobStatus()

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -138,13 +138,15 @@ class GenericJob(JobCore):
         elif os.path.exists(self.project_hdf5.file_name):
             initial_status = read_hdf5(
                 # in most cases self.project_hdf5.h5_path == / + self.job_name but not for child jobs of GenericMasters
-                self.project_hdf5.file_name, self.project_hdf5.h5_path + "/status"
+                self.project_hdf5.file_name,
+                self.project_hdf5.h5_path + "/status",
             )
             self._status = JobStatus(initial_status=initial_status)
             if "job_id" in self.list_nodes():
                 self._job_id = read_hdf5(
                     # in most cases self.project_hdf5.h5_path == / + self.job_name but not for child jobs of GenericMasters
-                    self.project_hdf5.file_name, self.project_hdf5.h5_path + "/job_id"
+                    self.project_hdf5.file_name,
+                    self.project_hdf5.h5_path + "/job_id",
                 )
         else:
             self._status = JobStatus()

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -137,11 +137,13 @@ class GenericJob(JobCore):
             self.refresh_job_status()
         elif os.path.exists(self.project_hdf5.file_name):
             initial_status = read_hdf5(
+                # in most cases self.project_hdf5.h5_path == / + self.job_name but not for child jobs of GenericMasters
                 self.project_hdf5.file_name, self.project_hdf5.h5_path + "/status"
             )
             self._status = JobStatus(initial_status=initial_status)
             if "job_id" in self.list_nodes():
                 self._job_id = read_hdf5(
+                    # in most cases self.project_hdf5.h5_path == / + self.job_name but not for child jobs of GenericMasters
                     self.project_hdf5.file_name, self.project_hdf5.h5_path + "/job_id"
                 )
         else:

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -528,7 +528,7 @@ class ParallelMaster(GenericMaster):
         self.status.running = True
         self.submission_status.total_jobs = len(self._job_generator)
         self.submission_status.submitted_jobs = 0
-        if self.job_id and not self.is_finished():
+        if (self.job_id or state.database.database_is_disabled) and not self.is_finished():
             self._logger.debug(
                 "{} child project {}".format(self.job_name, self.project.__str__())
             )

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -273,6 +273,7 @@ class ParallelMaster(GenericMaster):
             yield: Yield of GenericJob or JobCore
         """
         project_working_directory = self.project.open(self.job_name + "_hdf5")
+        project_working_directory.db.update()
         for job_id in self._get_jobs_sorted():
             yield project_working_directory.load(
                 job_id, convert_to_object=convert_to_object

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -528,7 +528,9 @@ class ParallelMaster(GenericMaster):
         self.status.running = True
         self.submission_status.total_jobs = len(self._job_generator)
         self.submission_status.submitted_jobs = 0
-        if (self.job_id or state.database.database_is_disabled) and not self.is_finished():
+        if (
+            self.job_id or state.database.database_is_disabled
+        ) and not self.is_finished():
             self._logger.debug(
                 "{} child project {}".format(self.job_name, self.project.__str__())
             )

--- a/pyiron_base/jobs/master/parallel.py
+++ b/pyiron_base/jobs/master/parallel.py
@@ -273,7 +273,8 @@ class ParallelMaster(GenericMaster):
             yield: Yield of GenericJob or JobCore
         """
         project_working_directory = self.project.open(self.job_name + "_hdf5")
-        project_working_directory.db.update()
+        if state.database.database_is_disabled:
+            project_working_directory.db.update()
         for job_id in self._get_jobs_sorted():
             yield project_working_directory.load(
                 job_id, convert_to_object=convert_to_object

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1635,6 +1635,8 @@ class Project(ProjectPath, HasGroups):
                         state.logger.debug(
                             "Could not remove job with ID {0} ".format(job_id)
                         )
+            if state.database.database_is_disabled:
+                self.db.update()
         else:
             raise EnvironmentError("copy_to: is not available in Viewermode !")
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1635,8 +1635,6 @@ class Project(ProjectPath, HasGroups):
                         state.logger.debug(
                             "Could not remove job with ID {0} ".format(job_id)
                         )
-            if state.database.database_is_disabled:
-                self.db.update()
         else:
             raise EnvironmentError("copy_to: is not available in Viewermode !")
 


### PR DESCRIPTION
Example Code: 
```
import pyiron_gpl
from pyiron_atomistics import Project

pr = Project("elastic")
pr.remove_jobs(silently=True, recursive=True)

potential = '2008--Hepburn-D-J--Fe-C--LAMMPS--ipr1'
structure = pr.create.structure.ase.bulk("Fe", cubic=True)

lmp_mini = pr.create_job(pr.job_type.Lammps, "lmp_mini")
lmp_mini.structure = structure
lmp_mini.potential = potential
lmp_mini.calc_minimize(pressure=0.0)
lmp_mini.run()

lmp_elastic = pr.create_job(pr.job_type.Lammps, "lmp_fe_elastic")
lmp_elastic.structure = lmp_mini.get_structure()
lmp_elastic.potential = potential
elastic_fe = lmp_elastic.create_job(pr.job_type.ElasticMatrixJob, "elastic_fe")
elastic_fe.run()

elastic_fe["output/elasticmatrix"]["C"]
```

My `.pyiron` config: 
```
[DEFAULT]
RESOURCE_PATHS = /Users/janssen/pyiron/resources
PROJECT_CHECK_ENABLED = False
DISABLE_DATABASE = True
```