### PR TITLE
Revert "Turn np.array_equal into proper asserts"

### DIFF
--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -149,7 +149,10 @@ class FileHDFio(HasGroups, MutableMapping):
                 # underlying file once, this reduces the number of file opens in the most-likely case from 2 to 1 (1 to
                 # check whether the data is there and 1 to read it) and increases in the worst case from 1 to 2 (1 to
                 # try to read it here and one more time to verify it's not a group below).
-                return read_hdf5(self.file_name, title=self._get_h5_path(item))
+                obj = read_hdf5(self.file_name, title=self._get_h5_path(item))
+                if self._is_convertable_dtype_object_array(obj):
+                    obj = self._convert_dtype_obj_array(obj.copy())
+                return obj
             except (ValueError, OSError, RuntimeError, NotImplementedError):
                 # h5io couldn't find a dataset with name item, but there still might be a group with that name, which we
                 # check in the rest of the method

--- a/tests/generic/test_fileHDFio.py
+++ b/tests/generic/test_fileHDFio.py
@@ -182,14 +182,7 @@ class TestFileHDFio(PyironTestCase):
 
         with self.subTest("object_array_with_lists"):
             array = hdf["object_array_with_lists"]
-            self.assertEqual(len(array), len(object_array_with_lists),
-                             msg="object array read with incorrect length!")
-            for a_read, a_written in zip(array, object_array_with_lists):
-                # ProjectHDFio coerces lists inside numpy object arrays to
-                # arrays, because h5io cannot write them otherwise, so we have
-                # to do the same here
-                self.assertEqual(a_read, np.asarray(a_written),
-                                 msg="object array contents not the same!")
+            np.array_equal(array, object_array_with_lists)
             self.assertIsInstance(array, np.ndarray)
             self.assertEqual(
                 array.dtype,
@@ -208,14 +201,32 @@ class TestFileHDFio(PyironTestCase):
         #     self.assertTrue(array.dtype == np.dtype(object))
 
         with self.subTest("int_array_as_objects_array"):
-            array = hdf["int_array_as_objects_array"]
-            self.assertEqual(array, int_array_as_objects_array)
+            with self.assertLogs(state.logger) as w:
+                array = hdf["int_array_as_objects_array"]
+                self.assertEqual(len(w.output), 1)
+                self.assertTrue(w.output[0].startswith(warn_msg_start))
+            np.array_equal(array, int_array_as_objects_array)
             self.assertIsInstance(array, np.ndarray)
+            self.assertEqual(
+                array.dtype,
+                np.dtype(int),
+                msg="dtype=object array containing only int not converted "
+                "to dtype int array.",
+            )
 
         with self.subTest("float_array_as_objects_array"):
-            array = hdf["float_array_as_objects_array"]
-            self.assertEqual(array, float_array_as_objects_array)
+            with self.assertLogs(state.logger) as w:
+                array = hdf["float_array_as_objects_array"]
+                self.assertEqual(len(w.output), 1)
+                self.assertTrue(w.output[0].startswith(warn_msg_start))
+            np.array_equal(array, float_array_as_objects_array)
             self.assertIsInstance(array, np.ndarray)
+            self.assertEqual(
+                array.dtype,
+                np.dtype(float),
+                msg="dtype=object array containing only float not converted"
+                " to dtype float array.",
+            )
 
         hdf.remove_group()
 


### PR DESCRIPTION
Reverts pyiron/pyiron_base#1147

since this broke the pyiron_atomistics compatibility tests:
```
======================================================================
ERROR: test_get_structure (atomic.job.test_atomistic.TestAtomisticGenericJob)
get_structure() should return structures with the exact values from the HDF files even if the size of
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/pyiron_base/pyiron_atomistics/tests/atomic/job/test_atomistic.py", line 109, in test_get_structure
    self.assertTrue(np.allclose(job.output.cells[i], struct.cell.array))
  File "<__array_function__ internals>", line 200, in allclose
  File "/usr/share/miniconda3/envs/my-env/lib/python3.10/site-packages/numpy/core/numeric.py", line 2270, in allclose
    res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
  File "<__array_function__ internals>", line 200, in isclose
  File "/usr/share/miniconda3/envs/my-env/lib/python3.10/site-packages/numpy/core/numeric.py", line 2377, in isclose
    xfin = isfinite(x)
TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

----------------------------------------------------------------------
```

However, I am not sure on which side the actual problem is. With the (to be reverted) PR our hdfio should now put out what was put in, but for the `Atoms.cell` this seems to change the return type?! 