### PR TITLE
If JOB_CLASS_DICT contains class return early

### DIFF
--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -1313,6 +1313,8 @@ class ProjectHDFio(FileHDFio):
         class_module_path = ".".join(class_path)
         if internal_class_name in self._project.job_type.job_class_dict:
             module_path = self._project.job_type.job_class_dict[internal_class_name]
+            if isinstance(module_path, type):
+                return module_path
             if class_module_path != module_path:
                 state.logger.info(
                     f'Using registered module "{module_path}" instead of custom/old module "{class_module_path}" to'


### PR DESCRIPTION
Usually JOB_CLASS_DICT contains the module path from where to import the class. However Project.create.job/register also supports live classes in there, but this was not handled when loading jobs from HDF again.  That code path always expected the module path (as a string) and consequently crashed when it found an object there.