### PR TITLE
HDF5 interface: add write_dict_to_hdf() and read_dict_from_hdf()

### DIFF
--- a/.ci_support/environment-old.yml
+++ b/.ci_support/environment-old.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - dill =0.3.1.1
 - gitpython =3.1.23
-- h5io =0.1.2
+- h5io =0.1.8
 - h5py =3.6.0
 - jinja2 =2.11.3
 - numpy =1.23.5

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -18,6 +18,7 @@ from typing import Union, Optional, Any, Tuple
 
 from pyiron_base.utils.deprecate import deprecate
 from pyiron_base.storage.helper_functions import (
+    get_h5_path,
     open_hdf5,
     read_hdf5,
     list_groups_and_nodes,
@@ -837,7 +838,11 @@ class FileHDFio(HasGroups, MutableMapping):
                 (set(hdf_old.list_nodes()) ^ set(check_nodes))
                 & set(hdf_old.list_nodes())
             )
-        write_dict_to_hdf(hdf=hdf_new, data_dict={p: hdf_old[p] for p in node_list})
+        write_dict_to_hdf(
+            file_name=hdf_new.file_name,
+            h5_path=hdf_new.h5_path,
+            data_dict={p: hdf_old[p] for p in node_list}
+        )
         for p in group_list:
             h_new = hdf_new.create_group(p)
             ex_n = [e[-1] for e in exclude_nodes_split if p == e[0] or len(e) == 1]
@@ -988,7 +993,7 @@ class FileHDFio(HasGroups, MutableMapping):
         Returns:
             str: combined path
         """
-        return posixpath.join(self.h5_path, name)
+        return get_h5_path(h5_path=self.h5_path, name=name)
 
     def _get_h5io_type(self, name):
         """

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -20,6 +20,7 @@ from pyiron_base.utils.deprecate import deprecate
 from pyiron_base.storage.helper_functions import (
     open_hdf5,
     read_hdf5,
+    list_groups_and_nodes,
     write_hdf5_with_json_support,
     write_dict_to_hdf,
     _is_ragged_in_1st_dim_only,
@@ -722,22 +723,12 @@ class FileHDFio(HasGroups, MutableMapping):
             dict: {'groups': [list of groups], 'nodes': [list of nodes]}
         """
         if self.file_exists:
-            groups = set()
-            nodes = set()
-            with open_hdf5(self.file_name) as h:
-                try:
-                    h = h[self.h5_path]
-                    for k in h.keys():
-                        if isinstance(h[k], h5py.Group):
-                            groups.add(k)
-                        else:
-                            nodes.add(k)
-                except KeyError:
-                    pass
-            iopy_nodes = self._filter_io_objects(groups)
+            with open_hdf5(self.file_name) as hdf:
+                groups, nodes = list_groups_and_nodes(hdf=hdf, h5_path=self.h5_path)
+            iopy_nodes = self._filter_io_objects(set(groups))
             return {
-                "groups": sorted(list(groups - iopy_nodes)),
-                "nodes": sorted(list((nodes - groups).union(iopy_nodes))),
+                "groups": sorted(list(set(groups) - iopy_nodes)),
+                "nodes": sorted(list((set(nodes) - set(groups)).union(iopy_nodes))),
             }
         else:
             return {"groups": [], "nodes": []}

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -66,12 +66,12 @@ def _is_ragged_in_1st_dim_only(value: Union[np.ndarray, list]) -> bool:
 def _check_json_conversion(value):
     use_json = True
     if (
-            isinstance(value, (list, np.ndarray))
-            and len(value) > 0
-            and isinstance(value[0], (list, np.ndarray))
-            and len(value[0]) > 0
-            and not isinstance(value[0][0], str)
-            and _is_ragged_in_1st_dim_only(value)
+        isinstance(value, (list, np.ndarray))
+        and len(value) > 0
+        and isinstance(value[0], (list, np.ndarray))
+        and len(value[0]) > 0
+        and not isinstance(value[0][0], str)
+        and _is_ragged_in_1st_dim_only(value)
     ):
         # if the sub-arrays in value all share shape[1:], h5io comes up with a more efficient storage format than
         # just writing a dataset for each element, by concatenating along the first axis and storing the indices

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -21,6 +21,7 @@ from pyiron_base.storage.helper_functions import (
     open_hdf5,
     read_hdf5,
     write_hdf5_with_json_support,
+    write_dict_to_hdf,
     _is_ragged_in_1st_dim_only,
 )
 from pyiron_base.interfaces.has_groups import HasGroups
@@ -28,7 +29,6 @@ from pyiron_base.state import state
 from pyiron_base.jobs.dynamic import JOB_DYN_DICT, class_constructor
 from pyiron_base.jobs.job.util import _get_safe_job_name
 import pyiron_base.project.maintenance
-import warnings
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -846,8 +846,7 @@ class FileHDFio(HasGroups, MutableMapping):
                 (set(hdf_old.list_nodes()) ^ set(check_nodes))
                 & set(hdf_old.list_nodes())
             )
-        for p in node_list:
-            hdf_new[p] = hdf_old[p]
+        write_dict_to_hdf(hdf=hdf_new, data_dict={p: hdf_old[p] for p in node_list})
         for p in group_list:
             h_new = hdf_new.create_group(p)
             ex_n = [e[-1] for e in exclude_nodes_split if p == e[0] or len(e) == 1]

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -841,7 +841,7 @@ class FileHDFio(HasGroups, MutableMapping):
         write_dict_to_hdf(
             file_name=hdf_new.file_name,
             h5_path=hdf_new.h5_path,
-            data_dict={p: hdf_old[p] for p in node_list}
+            data_dict={p: hdf_old[p] for p in node_list},
         )
         for p in group_list:
             h_new = hdf_new.create_group(p)

--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -221,7 +221,7 @@ class FileHDFio(HasGroups, MutableMapping):
                 # underlying file once, this reduces the number of file opens in the most-likely case from 2 to 1 (1 to
                 # check whether the data is there and 1 to read it) and increases in the worst case from 1 to 2 (1 to
                 # try to read it here and one more time to verify it's not a group below).
-                return read_hdf5(self.file_name, title=self.get_h5_path(item))
+                return read_hdf5(self.file_name, title=self._get_h5_path(item))
             except (ValueError, OSError, RuntimeError, NotImplementedError):
                 # h5io couldn't find a dataset with name item, but there still might be a group with that name, which we
                 # check in the rest of the method
@@ -315,7 +315,7 @@ class FileHDFio(HasGroups, MutableMapping):
             value.to_hdf(self, key)
             return
         write_hdf5_with_json_support(
-            value=value, path=self.get_h5_path(key), file_handle=self.file_name
+            value=value, path=self._get_h5_path(key), file_handle=self.file_name
         )
 
     def __delitem__(self, key):
@@ -328,7 +328,7 @@ class FileHDFio(HasGroups, MutableMapping):
         if self.file_exists:
             try:
                 with open_hdf5(self.file_name, mode="a") as store:
-                    del store[self.get_h5_path(key)]
+                    del store[self._get_h5_path(key)]
             except (AttributeError, KeyError):
                 pass
 
@@ -584,7 +584,7 @@ class FileHDFio(HasGroups, MutableMapping):
         Returns:
             FileHDFio: FileHDFio object pointing to the new group
         """
-        full_name = self.get_h5_path(name)
+        full_name = self._get_h5_path(name)
         with open_hdf5(self.file_name, mode="a") as h:
             try:
                 h.create_group(full_name, track_order=track_order)
@@ -623,7 +623,7 @@ class FileHDFio(HasGroups, MutableMapping):
         if h5_rel_path.strip() == ".":
             h5_rel_path = ""
         if h5_rel_path.strip() != "":
-            new_h5_path.h5_path = self.get_h5_path(h5_rel_path)
+            new_h5_path.h5_path = self._get_h5_path(h5_rel_path)
         new_h5_path.history.append(h5_rel_path)
 
         return new_h5_path
@@ -947,7 +947,7 @@ class FileHDFio(HasGroups, MutableMapping):
         Returns:
             dict, list, float, int: data or data object
         """
-        return read_hdf5(self.file_name, title=self.get_h5_path(item))
+        return read_hdf5(self.file_name, title=self._get_h5_path(item))
 
     # def _open_store(self, mode="r"):
     #     """
@@ -983,7 +983,7 @@ class FileHDFio(HasGroups, MutableMapping):
 
         return Project(path=self.file_path)
 
-    def get_h5_path(self, name):
+    def _get_h5_path(self, name):
         """
         Internal function to combine the current h5_path with the relative path
 

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -205,7 +205,7 @@ def read_dict_from_hdf(file_name, h5_path, group_paths=[], slash="ignore"):
     Args:
        hdf (pyiron_base.storage.hdfio.FileHDFio): HDF5 file object
        file_name (str): Name of the file on disk
-       h5_path (str): Path to a group in the HDF5 file where the data is stored
+       h5_path (str): Path to a group in the HDF5 file from where the data is read
        group_paths (list): list of additional groups to be included in the dictionary, for example:
                            ["input", "output", "output/generic"]
                            These groups are defined relative to the h5_path.

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -72,19 +72,12 @@ def write_hdf5_with_json_support(value, path, file_handle):
         ) from None
 
 
-def write_dict_to_hdf(hdf, data_dict, groups=[]):
+def write_dict_to_hdf(hdf, data_dict):
     with open_hdf5(hdf.file_name, mode="a") as store:
         for k, v in data_dict.items():
-            if k not in groups:
-                write_hdf5_with_json_support(
-                    file_handle=store, value=v, path=hdf.get_h5_path(k)
-                )
-        for group in groups:
-            hdf_group = hdf.create_group(group)
-            for k, v in data_dict[group].items():
-                write_hdf5_with_json_support(
-                    file_handle=store, value=v, path=hdf_group.get_h5_path(k)
-                )
+            write_hdf5_with_json_support(
+                file_handle=store, value=v, path=hdf.get_h5_path(k)
+            )
 
 
 def _check_json_conversion(value):

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -39,8 +39,7 @@ def read_hdf5(fname, title, slash="ignore"):
     Args:
         fname (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core' driver,
                      HDF5 still requires this be non-empty.
-        title (str): The top-level directory name to use. Typically it is useful to make this your package name,
-                     e.g. ``'mnepython'``.
+        title (str): the HDF5 internal dataset path from which should be read, slashes indicate sub groups
         slash (str): 'ignore' | 'replace' Whether to replace the string {FWDSLASH} with the value /. This does
                      not apply to the top level name (title). If 'ignore', nothing will be replaced.
 

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -223,15 +223,11 @@ def read_dict_from_hdf(file_name, h5_path, group_paths=[], slash="ignore"):
         }
 
     def resolve_nested_dict(group_path, data_dict):
-        group_lst = group_path.split("/")
-        if len(group_lst) > 1:
-            return {
-                group_lst[0]: resolve_nested_dict(
-                    group_path="/".join(group_lst[1:]), data_dict=data_dict
-                )
-            }
-        else:
-            return {group_lst[0]: data_dict}
+        groups = group_path.split("/")
+        nested_dict = data_dict
+        for g in groups[::-1]:
+            nested_dict = {g: nested_dict}
+        return nested_dict
 
     with open_hdf5(file_name, mode="r") as store:
         output_dict = get_dict_from_nodes(store=store, h5_path=h5_path, slash=slash)

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -266,7 +266,7 @@ def get_h5_path(h5_path, name):
 
 def _check_json_conversion(value):
     """
-    Check if the object can be converted to JSON to optimize the HDF5 performance. This can change the data tupe of the
+    Check if the object can be converted to JSON to optimize the HDF5 performance. This can change the data type of the
     object which is going to be stored in the HDF5 file.
 
     Args:

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -198,7 +198,7 @@ def list_groups_and_nodes(hdf, h5_path):
     return list(groups), list(nodes)
 
 
-def read_dict_from_hdf5(file_name, h5_path, group_paths=[], slash="ignore"):
+def read_dict_from_hdf(file_name, h5_path, group_paths=[], slash="ignore"):
     """
     Read data from HDF5 file into a dictionary - by default only the nodes are converted to dictionaries, additional
     groups can be specified using the group_paths parameter.

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -193,7 +193,6 @@ def list_groups_and_nodes(hdf, h5_path):
                 nodes.add(k)
     except KeyError:
         pass
-    print("list_groups_and_nodes():", h5_path, groups, nodes)
     return list(groups), list(nodes)
 
 

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -218,7 +218,9 @@ def read_dict_from_hdf5(file_name, h5_path, group_paths=[], slash="ignore"):
 
     def get_dict_from_nodes(store, h5_path, slash="ignore"):
         return {
-            n: read_hdf5(fname=store, title=get_h5_path(h5_path=h5_path, name=n), slash=slash)
+            n: read_hdf5(
+                fname=store, title=get_h5_path(h5_path=h5_path, name=n), slash=slash
+            )
             for n in list_groups_and_nodes(hdf=store, h5_path=h5_path)[1]
         }
 
@@ -242,7 +244,7 @@ def read_dict_from_hdf5(file_name, h5_path, group_paths=[], slash="ignore"):
                     data_dict=get_dict_from_nodes(
                         store=store,
                         h5_path=get_h5_path(h5_path=h5_path, name=group_path),
-                        slash=slash
+                        slash=slash,
                     ),
                 )
             )

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -7,15 +7,45 @@ import warnings
 
 
 def open_hdf5(filename, mode="r", swmr=False):
+    """
+    Open HDF5 file
+
+    Args:
+        filename (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core' driver,
+                        HDF5 still requires this be non-empty.
+        mode (str): r        Readonly, file must exist (default)
+                    r+       Read/write, file must exist
+                    w        Create file, truncate if exists
+                    w- or x  Create file, fail if exists
+                    a        Read/write if exists, create otherwise
+        swmr (bool): Open the file in SWMR read mode. Only used when mode = 'r'.
+
+    Returns:
+        h5py.File: open HDF5 file object
+    """
     if swmr and mode != "r":
-        store = h5py.File(filename, mode=mode, libver="latest")
+        store = h5py.File(name=filename, mode=mode, libver="latest")
         store.swmr = True
         return store
     else:
-        return h5py.File(filename, mode=mode, libver="latest", swmr=swmr)
+        return h5py.File(name=filename, mode=mode, libver="latest", swmr=swmr)
 
 
 def read_hdf5(fname, title="h5io", slash="ignore"):
+    """
+    Read data from HDF5 file
+
+    Args:
+        fname (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core' driver,
+                     HDF5 still requires this be non-empty.
+        title (str): The top-level directory name to use. Typically it is useful to make this your package name,
+                     e.g. ``'mnepython'``.
+        slash (str): 'ignore' | 'replace' Whether to replace the string {FWDSLASH} with the value /. This does
+                     not apply to the top level name (title). If 'ignore', nothing will be replaced.
+
+    Returns:
+        object:     The loaded data. Can be of any type supported by ``write_hdf5``.
+    """
     return retry(
         lambda: h5io.read_hdf5(
             fname=fname,
@@ -38,6 +68,26 @@ def write_hdf5(
     slash="error",
     use_json=False,
 ):
+    """
+    Write data to HDF5 file
+
+    Args:
+        fname (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core' driver,
+                     HDF5 still requires this be non-empty.
+        data (object): Object to write. Can be of any of these types: {ndarray, dict, list, tuple, int, float, str,
+                       datetime, timezone} Note that dict objects must only have ``str`` keys. It is recommended
+                       to use ndarrays where possible, as it is handled most efficiently.
+        overwrite (str/bool): True | False | 'update' If True, overwrite file (if it exists). If 'update', appends the
+                              title to the file (or replace value if title exists).
+        compression (int): Compression level to use (0-9) to compress data using gzip.
+        title (str): The top-level directory name to use. Typically it is useful to make this your package name,
+                     e.g. ``'mnepython'``.
+        slash (str): 'error' | 'replace' Whether to replace forward-slashes ('/') in any key found nested within
+                      keys in data. This does not apply to the top level name (title). If 'error', '/' is not allowed
+                      in any lower-level keys.
+        use_json (bool): To accelerate the read and write performance of small dictionaries and lists they can be
+                         combined to JSON objects and stored as strings.
+    """
     retry(
         lambda: h5io.write_hdf5(
             fname=fname,
@@ -55,15 +105,35 @@ def write_hdf5(
     )
 
 
-def write_hdf5_with_json_support(value, path, file_handle):
+def write_hdf5_with_json_support(
+    value, path, file_handle, compression=4, slash="error"
+):
+    """
+    Write data to HDF5 file and store dictionaries as JSON to optimize performance
+
+    Args:
+        value (object): Object to write. Can be of any of these types: {ndarray, dict, list, tuple, int, float, str,
+                        datetime, timezone} Note that dict objects must only have ``str`` keys. It is recommended
+                        to use ndarrays where possible, as it is handled most efficiently.
+        path (str): The top-level directory name to use. Typically it is useful to make this your package name,
+                     e.g. ``'mnepython'``.
+        file_handle (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core'
+                           driver, HDF5 still requires this be non-empty.:
+        compression (int): Compression level to use (0-9) to compress data using gzip.
+        slash (str): 'error' | 'replace' Whether to replace forward-slashes ('/') in any key found nested within
+                      keys in data. This does not apply to the top level name (title). If 'error', '/' is not allowed
+                      in any lower-level keys.
+    """
     value, use_json = _check_json_conversion(value=value)
     try:
         write_hdf5(
-            file_handle,
-            value,
+            fname=file_handle,
+            data=value,
+            compression=compression,
+            slash=slash,
+            use_json=use_json,
             title=path,
             overwrite="update",
-            use_json=use_json,
         )
     except TypeError:
         raise TypeError(
@@ -72,15 +142,46 @@ def write_hdf5_with_json_support(value, path, file_handle):
         ) from None
 
 
-def write_dict_to_hdf(hdf, data_dict):
+def write_dict_to_hdf(hdf, data_dict, compression=4, slash="error"):
+    """
+    Write dictionary to HDF5 file
+
+    Args:
+        hdf (pyiron_base.storage.hdfio.FileHDFio): HDF5 file object
+        data_dict (dict): dictionary of data objects to be stored in the HDF5 file, the keys provide the path inside
+                          the HDF5 file and the values the data to be stored in those nodes. The corresponding HDF5
+                          groups are created automatically:
+                              {
+                                  'hdf5root/group/node_name': {},
+                                  'hdf5root/group/subgroup/node_name': [...],
+                              }
+        compression (int): Compression level to use (0-9) to compress data using gzip.
+        slash (str): 'error' | 'replace' Whether to replace forward-slashes ('/') in any key found nested within
+                      keys in data. This does not apply to the top level name (title). If 'error', '/' is not allowed
+                      in any lower-level keys.
+    """
     with open_hdf5(hdf.file_name, mode="a") as store:
         for k, v in data_dict.items():
             write_hdf5_with_json_support(
-                file_handle=store, value=v, path=hdf.get_h5_path(k)
+                file_handle=store,
+                value=v,
+                path=hdf.get_h5_path(k),
+                compression=compression,
+                slash=slash,
             )
 
 
 def _check_json_conversion(value):
+    """
+    Check if the object can be converted to JSON to optimize the HDF5 performance. This can change the data tupe of the
+    object which is going to be stored in the HDF5 file.
+
+    Args:
+        value (object): Object to be converted.
+
+    Returns:
+        object bool: value object and boolean flag to store the dictionary as JSON
+    """
     use_json = True
     if (
         isinstance(value, (list, np.ndarray))

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -200,7 +200,7 @@ def list_groups_and_nodes(hdf, h5_path):
 def read_dict_from_hdf(file_name, h5_path, group_paths=[], slash="ignore"):
     """
     Read data from HDF5 file into a dictionary - by default only the nodes are converted to dictionaries, additional
-    groups can be specified using the group_paths parameter.
+    sub groups can be specified using the group_paths parameter.
 
     Args:
        hdf (pyiron_base.storage.hdfio.FileHDFio): HDF5 file object

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -220,10 +220,11 @@ def read_dict_from_hdf5(hdf, group_paths=[], slash="ignore"):
     def resolve_nested_dict(group_path, data_dict):
         group_lst = group_path.split("/")
         if len(group_lst) > 1:
-            return {group_lst[0]: resolve_nested_dict(
-                group_path='/'.join(group_lst[1:]),
-                data_dict=data_dict
-            )}
+            return {
+                group_lst[0]: resolve_nested_dict(
+                    group_path="/".join(group_lst[1:]), data_dict=data_dict
+                )
+            }
         else:
             return {group_lst[0]: data_dict}
 
@@ -231,12 +232,14 @@ def read_dict_from_hdf5(hdf, group_paths=[], slash="ignore"):
         output_dict = get_dict_from_nodes(store=store, hdf=hdf, slash=slash)
         for group_path in group_paths:
             with hdf.open(group_path) as hdf_group:
-                output_dict.update(resolve_nested_dict(
-                    group_path=group_path,
-                    data_dict=get_dict_from_nodes(
-                        store=store, hdf=hdf_group, slash=slash
+                output_dict.update(
+                    resolve_nested_dict(
+                        group_path=group_path,
+                        data_dict=get_dict_from_nodes(
+                            store=store, hdf=hdf_group, slash=slash
+                        ),
                     )
-                ))
+                )
     return output_dict
 
 

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -26,7 +26,7 @@ def open_hdf5(filename, mode="r", swmr=False):
     """
     if swmr and mode != "r":
         store = h5py.File(name=filename, mode=mode, libver="latest")
-        store.swmr = True
+        store.swmr_mode = True
         return store
     else:
         return h5py.File(name=filename, mode=mode, libver="latest", swmr=swmr)

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -1,5 +1,17 @@
+import numpy as np
 import h5io
+import h5py
 from pyiron_base.utils.error import retry
+from typing import Union
+
+
+def open_hdf5(filename, mode="r", swmr=False):
+    if swmr and mode != "r":
+        store = h5py.File(filename, mode=mode, libver="latest")
+        store.swmr = True
+        return store
+    else:
+        return h5py.File(filename, mode=mode, libver="latest", swmr=swmr)
 
 
 def read_hdf5(fname, title="h5io", slash="ignore"):
@@ -40,3 +52,60 @@ def write_hdf5(
         at_most=10,
         delay=1,
     )
+
+
+def write_hdf5_with_json_support(value, path, file_handle):
+    value, use_json = _check_json_conversion(value=value)
+    write_hdf5(
+        file_handle,
+        value,
+        title=path,
+        overwrite="update",
+        use_json=use_json,
+    )
+
+
+def _check_json_conversion(value):
+    use_json = True
+    if (
+        isinstance(value, (list, np.ndarray))
+        and len(value) > 0
+        and isinstance(value[0], (list, np.ndarray))
+        and len(value[0]) > 0
+        and not isinstance(value[0][0], str)
+        and _is_ragged_in_1st_dim_only(value)
+    ):
+        # if the sub-arrays in value all share shape[1:], h5io comes up with a more efficient storage format than
+        # just writing a dataset for each element, by concatenating along the first axis and storing the indices
+        # where to break the concatenated array again
+        value = np.array([np.asarray(v) for v in value], dtype=object)
+        use_json = False
+    elif isinstance(value, tuple):
+        value = list(value)
+    return value, use_json
+
+
+def _is_ragged_in_1st_dim_only(value: Union[np.ndarray, list]) -> bool:
+    """
+    Checks whether array or list of lists is ragged in the first dimension.
+
+    That means all other dimensions (except the first one) still have to match.
+
+    Args:
+        value (ndarray/list): array to check
+
+    Returns:
+        bool: True if elements of value are not all of the same shape
+    """
+    if isinstance(value, np.ndarray) and value.dtype != np.dtype("O"):
+        return False
+    else:
+
+        def extract_dims(v):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                s = np.shape(v)
+            return s[0], s[1:]
+
+        dim1, dim_other = zip(*map(extract_dims, value))
+        return len(set(dim1)) > 1 and len(set(dim_other)) == 1

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -148,7 +148,7 @@ def write_dict_to_hdf(file_name, h5_path, data_dict, compression=4, slash="error
 
     Args:
         file_name (str): Name of the file on disk
-        h5_path (str): Path to a group in the HDF5 file where the data_dict is going to be stored
+        h5_path (str): Path to a group in the HDF5 file where the data_dict is going to be stored; all entries of `data_dict` will be stored beneath it.
         data_dict (dict): Dictionary of data objects to be stored in the HDF5 file, the keys provide the path inside
                           the HDF5 file and the values the data to be stored in those nodes. The corresponding HDF5
                           groups are created automatically:

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -80,8 +80,7 @@ def write_hdf5(
         overwrite (str/bool): True | False | 'update' If True, overwrite file (if it exists). If 'update', appends the
                               title to the file (or replace value if title exists).
         compression (int): Compression level to use (0-9) to compress data using gzip.
-        title (str): The top-level directory name to use. Typically it is useful to make this your package name,
-                     e.g. ``'mnepython'``.
+        title (str): the HDF5 internal dataset path from which should be read, slashes indicate sub groups
         slash (str): 'error' | 'replace' Whether to replace forward-slashes ('/') in any key found nested within
                       keys in data. This does not apply to the top level name (title). If 'error', '/' is not allowed
                       in any lower-level keys.
@@ -115,8 +114,7 @@ def write_hdf5_with_json_support(
         value (object): Object to write. Can be of any of these types: {ndarray, dict, list, tuple, int, float, str,
                         datetime, timezone} Note that dict objects must only have ``str`` keys. It is recommended
                         to use ndarrays where possible, as it is handled most efficiently.
-        path (str): The top-level directory name to use. Typically it is useful to make this your package name,
-                     e.g. ``'mnepython'``.
+        path (str): the HDF5 internal dataset path from which should be read, slashes indicate sub groups
         file_handle (str): Name of the file on disk, or file-like object.  Note: for files created with the 'core'
                            driver, HDF5 still requires this be non-empty.:
         compression (int): Compression level to use (0-9) to compress data using gzip.
@@ -148,7 +146,8 @@ def write_dict_to_hdf(file_name, h5_path, data_dict, compression=4, slash="error
 
     Args:
         file_name (str): Name of the file on disk
-        h5_path (str): Path to a group in the HDF5 file where the data_dict is going to be stored; all entries of `data_dict` will be stored beneath it.
+        h5_path (str): Path to a group in the HDF5 file where the data_dict is going to be stored; all entries of
+                       `data_dict` will be stored beneath it.
         data_dict (dict): Dictionary of data objects to be stored in the HDF5 file, the keys provide the path inside
                           the HDF5 file and the values the data to be stored in those nodes. The corresponding HDF5
                           groups are created automatically:

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -32,7 +32,7 @@ def open_hdf5(filename, mode="r", swmr=False):
         return h5py.File(name=filename, mode=mode, libver="latest", swmr=swmr)
 
 
-def read_hdf5(fname, title="h5io", slash="ignore"):
+def read_hdf5(fname, title, slash="ignore"):
     """
     Read data from HDF5 file
 

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -3,6 +3,7 @@ import h5io
 import h5py
 from pyiron_base.utils.error import retry
 from typing import Union
+import warnings
 
 
 def open_hdf5(filename, mode="r", swmr=False):

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -223,6 +223,7 @@ def read_dict_from_hdf(file_name, h5_path, group_paths=[], slash="ignore"):
         }
 
     def resolve_nested_dict(group_path, data_dict):
+        """Turns a dict with a key containing slashes into a nested dict.  {'/a/b/c': 1} -> {'a': {'b': {'c': 1}"""
         group_lst = group_path.split("/")
         if len(group_lst) > 1:
             return {

--- a/pyiron_base/storage/helper_functions.py
+++ b/pyiron_base/storage/helper_functions.py
@@ -87,6 +87,76 @@ def write_dict_to_hdf(hdf, data_dict, groups=[]):
                 )
 
 
+def list_groups_and_nodes(hdf, h5_path):
+    """
+    Get the list of groups and list of nodes from an open HDF5 file
+
+    Args:
+        hdf (h5py.File): file handle of an open HDF5 file
+        h5_path (str): path inside the HDF5 file
+
+    Returns:
+        list, list: list of groups and list of nodes
+    """
+    groups = set()
+    nodes = set()
+    try:
+        h = hdf[h5_path]
+        for k in h.keys():
+            if isinstance(h[k], h5py.Group):
+                groups.add(k)
+            else:
+                nodes.add(k)
+    except KeyError:
+        pass
+    print("list_groups_and_nodes():", h5_path, groups, nodes)
+    return list(groups), list(nodes)
+
+
+def read_dict_from_hdf5(hdf, group_paths=[], slash="ignore"):
+    """
+    Read data from HDF5 file into a dictionary - by default only the nodes are converted to dictionaries, additional
+    groups can be specified using the group_paths parameter.
+
+    Args:
+       hdf (pyiron_base.storage.hdfio.FileHDFio): HDF5 file object
+       group_paths (list): list of additional groups to be included in the dictionary, for example:
+                           ["input", "output", "output/generic"]
+       slash (str): 'ignore' | 'replace' Whether to replace the string {FWDSLASH} with the value /. This does
+                    not apply to the top level name (title). If 'ignore', nothing will be replaced.
+    Returns:
+       dict:     The loaded data. Can be of any type supported by ``write_hdf5``.
+    """
+
+    def get_dict_from_nodes(store, hdf, slash="ignore"):
+        return {
+            n: read_hdf5(fname=store, title=hdf.get_h5_path(n), slash=slash)
+            for n in list_groups_and_nodes(hdf=store, h5_path=hdf.h5_path)[1]
+        }
+
+    def resolve_nested_dict(group_path, data_dict):
+        group_lst = group_path.split("/")
+        if len(group_lst) > 1:
+            return {group_lst[0]: resolve_nested_dict(
+                group_path='/'.join(group_lst[1:]),
+                data_dict=data_dict
+            )}
+        else:
+            return {group_lst[0]: data_dict}
+
+    with open_hdf5(hdf.file_name, mode="r") as store:
+        output_dict = get_dict_from_nodes(store=store, hdf=hdf, slash=slash)
+        for group_path in group_paths:
+            with hdf.open(group_path) as hdf_group:
+                output_dict.update(resolve_nested_dict(
+                    group_path=group_path,
+                    data_dict=get_dict_from_nodes(
+                        store=store, hdf=hdf_group, slash=slash
+                    )
+                ))
+    return output_dict
+
+
 def _check_json_conversion(value):
     use_json = True
     if (


### PR DESCRIPTION
This pull request refactors the helper functions in the `pyiron_base.storage` module and adds the `write_dict_to_hdf()` and `read_dict_from_hdf()` functions. The `write_dict_to_hdf()` function takes a dictionary where the keys represent the path in the HDF5 file and the values represent the objects which should be stored in these nodes. The corresponding HDF5 groups are created automatically. The `read_dict_from_hdf()` function reads the nodes from a given HDF5 group and subgroups can be included using the optional `group_paths` parameter. The function returns a hierarchical dictionary which can be directly converted to a `DataContainer`. 