### PR TITLE
GenericParameters: add to_dict() and from_dict()

### DIFF
--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -19,6 +19,7 @@ __date__ = "Dec 20, 2023"
 
 class HasDict(ABC):
     __dict_version__ = "0.1.0"
+
     @abstractmethod
     def from_dict(self, obj_dict: dict, version: str = None):
         pass

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""Interface for classes to serialize to dictionary."""
+
+from abc import ABC, abstractmethod
+
+__author__ = "Jan Janssen"
+__copyright__ = (
+    "Copyright 2023, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Jan Janssen"
+__email__ = "janssen@mpie.de"
+__status__ = "production"
+__date__ = "Dec 20, 2023"
+
+
+class HasDict(ABC):
+    __dict_version__ = "0.1.0"
+
+    @abstractmethod
+    def _from_dict(self, data_dict: dict, version: str = None):
+        pass
+
+    @abstractmethod
+    def _to_dict(self):
+        pass
+
+    def _store_type_to_dict(self):
+        type_dict = {
+            "NAME": self.__class__.__name__,
+            "TYPE": str(type(self)),
+            "OBJECT": self.__class__.__name__,  # unused alias
+            "DICT_VERSION": self.__dict_version__,
+        }
+        if hasattr(self, "__version__"):
+            type_dict["VERSION"] = self.__version__
+        return type_dict

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -19,9 +19,9 @@ __date__ = "Dec 20, 2023"
 
 class HasDict(ABC):
     __dict_version__ = "0.1.0"
-
+    @abstractmethod
     def from_dict(self, obj_dict: dict, version: str = None):
-        raise NotImplementedError
+        pass
 
     def to_dict(self):
         raise NotImplementedError

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -20,13 +20,11 @@ __date__ = "Dec 20, 2023"
 class HasDict(ABC):
     __dict_version__ = "0.1.0"
 
-    @abstractmethod
     def from_dict(self, obj_dict: dict, version: str = None):
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def to_dict(self):
-        pass
+        raise NotImplementedError
 
     def _type_to_dict(self):
         type_dict = {

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -23,8 +23,9 @@ class HasDict(ABC):
     def from_dict(self, obj_dict: dict, version: str = None):
         pass
 
+    @abstractmethod
     def to_dict(self):
-        raise NotImplementedError
+        pass
 
     def _type_to_dict(self):
         type_dict = {

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -21,14 +21,14 @@ class HasDict(ABC):
     __dict_version__ = "0.1.0"
 
     @abstractmethod
-    def _from_dict(self, data_dict: dict, version: str = None):
+    def from_dict(self, obj_dict: dict, version: str = None):
         pass
 
     @abstractmethod
-    def _to_dict(self):
+    def to_dict(self):
         pass
 
-    def _store_type_to_dict(self):
+    def _type_to_dict(self):
         type_dict = {
             "NAME": self.__class__.__name__,
             "TYPE": str(type(self)),

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -92,7 +92,7 @@ class HasHDF(HasDict, ABC):
     >>> hdf
     {'groups': ['list'], 'nodes': []}
     >>> hdf['list']
-    {'groups': [], 'nodes': ['HDF_VERSION', 'NAME', 'OBJECT', 'TYPE', '__index_0', '__index_1', '__index_2', '__index_3']}
+    {'groups': [], 'nodes': ['DICT_VERSION', 'HDF_VERSION', 'NAME', 'OBJECT', 'TYPE', '__index_0', '__index_1', '__index_2', '__index_3']}
 
     (Since this is a docstring, actually calling :meth:`ProjectHDFio.to_object()` wont' work, so we'll simulate it.)
 

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -4,7 +4,6 @@
 """Interface for classes to serialize to HDF5."""
 
 from pyiron_base.storage.hdfio import ProjectHDFio
-from pyiron_base.interfaces.has_dict import HasDict
 
 from abc import ABC, abstractmethod
 
@@ -92,7 +91,7 @@ class HasHDF(ABC):
     >>> hdf
     {'groups': ['list'], 'nodes': []}
     >>> hdf['list']
-    {'groups': [], 'nodes': ['DICT_VERSION', 'HDF_VERSION', 'NAME', 'OBJECT', 'TYPE', '__index_0', '__index_1', '__index_2', '__index_3']}
+    {'groups': [], 'nodes': ['HDF_VERSION', 'NAME', 'OBJECT', 'TYPE', '__index_0', '__index_1', '__index_2', '__index_3']}
 
     (Since this is a docstring, actually calling :meth:`ProjectHDFio.to_object()` wont' work, so we'll simulate it.)
 
@@ -174,8 +173,14 @@ class HasHDF(ABC):
         return {}
 
     def _type_to_dict(self):
-        type_dict = super()._type_to_dict()
-        type_dict["HDF_VERSION"] = self.__hdf_version__
+        type_dict = {
+            "NAME": self.__class__.__name__,
+            "TYPE": str(type(self)),
+            "OBJECT": self.__class__.__name__,  # unused alias
+            "HDF_VERSION": self.__hdf_version__,
+        }
+        if hasattr(self, "__version__"):
+            type_dict["VERSION"] = self.__version__
         return type_dict
 
     def from_hdf(self, hdf: ProjectHDFio, group_name: str = None):

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -40,7 +40,7 @@ class _WithHDF:
             self._hdf.close()
 
 
-class HasHDF(HasDict, ABC):
+class HasHDF(ABC):
     """
     Mixin class for objects that can write themselves to HDF.
 

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -4,6 +4,7 @@
 """Interface for classes to serialize to HDF5."""
 
 from pyiron_base.storage.hdfio import ProjectHDFio
+from pyiron_base.interfaces.has_dict import HasDict
 
 from abc import ABC, abstractmethod
 
@@ -39,7 +40,7 @@ class _WithHDF:
             self._hdf.close()
 
 
-class HasHDF(ABC):
+class HasHDF(HasDict, ABC):
     """
     Mixin class for objects that can write themselves to HDF.
 
@@ -172,15 +173,9 @@ class HasHDF(ABC):
         """
         return {}
 
-    def _store_type_to_dict(self):
-        type_dict = {
-            "NAME": self.__class__.__name__,
-            "TYPE": str(type(self)),
-            "OBJECT": self.__class__.__name__,  # unused alias
-            "HDF_VERSION": self.__hdf_version__,
-        }
-        if hasattr(self, "__version__"):
-            type_dict["VERSION"] = self.__version__
+    def _type_to_dict(self):
+        type_dict = super()._type_to_dict()
+        type_dict["HDF_VERSION"] = self.__hdf_version__
         return type_dict
 
     def from_hdf(self, hdf: ProjectHDFio, group_name: str = None):
@@ -220,7 +215,7 @@ class HasHDF(ABC):
             ):
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
-            for k, v in self._store_type_to_dict().items():
+            for k, v in self._type_to_dict().items():
                 hdf[k] = v
 
     def rewrite_hdf(self, hdf: ProjectHDFio, group_name: str = None):

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -47,6 +47,7 @@ from pyiron_base.utils.deprecate import deprecate
 from pyiron_base.jobs.job.extension.server.generic import Server
 from pyiron_base.database.filetable import FileTable
 from pyiron_base.storage.helper_functions import write_hdf5, read_hdf5
+from pyiron_base.interfaces.has_dict import HasDict
 
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
@@ -109,7 +110,7 @@ _doc_str_generic_job_attr = (
 )
 
 
-class GenericJob(JobCore):
+class GenericJob(JobCore, HasDict):
     __doc__ = (
         """
     Generic Job class extends the JobCore class with all the functionality to run the job object. From this class

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1342,14 +1342,9 @@ class GenericJob(JobCore, HasDict):
         """
         Internal helper function to save type and version in HDF5 file root
         """
-        data_dict = {
-            "NAME": self.__name__,
-            "TYPE": str(type(self)),
-        }
-        if self._executable:
+        data_dict = super()._type_to_dict()
+        if self._executable:  # overwrite version - default self.__version__
             data_dict["VERSION"] = self.executable.version
-        else:
-            data_dict["VERSION"] = self.__version__
         if hasattr(self, "__hdf_version__"):
             data_dict["HDF_VERSION"] = self.__hdf_version__
         return data_dict

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -31,7 +31,15 @@ __status__ = "production"
 __date__ = "Jun 17, 2020"
 
 
-_internal_hdf_nodes = ["NAME", "TYPE", "OBJECT", "VERSION", "HDF_VERSION", "DICT_VERSION", "READ_ONLY"]
+_internal_hdf_nodes = [
+    "NAME",
+    "TYPE",
+    "OBJECT",
+    "VERSION",
+    "HDF_VERSION",
+    "DICT_VERSION",
+    "READ_ONLY",
+]
 
 
 def _normalize(key):

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -31,15 +31,7 @@ __status__ = "production"
 __date__ = "Jun 17, 2020"
 
 
-_internal_hdf_nodes = [
-    "NAME",
-    "TYPE",
-    "OBJECT",
-    "VERSION",
-    "HDF_VERSION",
-    "DICT_VERSION",
-    "READ_ONLY",
-]
+_internal_hdf_nodes = ["NAME", "TYPE", "OBJECT", "VERSION", "HDF_VERSION", "READ_ONLY"]
 
 
 def _normalize(key):

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -31,7 +31,7 @@ __status__ = "production"
 __date__ = "Jun 17, 2020"
 
 
-_internal_hdf_nodes = ["NAME", "TYPE", "OBJECT", "VERSION", "HDF_VERSION", "READ_ONLY"]
+_internal_hdf_nodes = ["NAME", "TYPE", "OBJECT", "VERSION", "HDF_VERSION", "DICT_VERSION", "READ_ONLY"]
 
 
 def _normalize(key):

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -500,12 +500,24 @@ class GenericParameters:
         self._block_dict = block_dict
 
     def to_dict(self):
+        """
+        Convert the GenericParameters object to a dictionary for storage
+
+        Returns:
+            dict: GenericParameters object as a dictionary
+        """
         data_dict = self._type_to_dict()
         data_dict["data_dict"] = self._dataset
         return data_dict
 
     def from_dict(self, generic_parameters_dict):
-        self._dataset = generic_parameters_dict
+        """
+        Reload GenericParameters from dictionary
+
+        Args:
+            generic_parameters_dict (dict): dictionary for reloading GenericParameters object
+        """
+        self._dataset = generic_parameters_dict["data_dict"]
 
     def to_hdf(self, hdf, group_name=None):
         """
@@ -537,9 +549,11 @@ class GenericParameters:
         else:
             data = hdf[self.table_name]
         if isinstance(data, dict):
-            self.from_dict(generic_parameters_dict=data)
+            self.from_dict(generic_parameters_dict={"data_dict": data})
         else:
-            self.from_dict(generic_parameters_dict=data._read("data_dict"))
+            self.from_dict(
+                generic_parameters_dict={"data_dict": data._read("data_dict")}
+            )
 
     def get_string_lst(self):
         """

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -13,6 +13,7 @@ import posixpath
 import warnings
 from ast import literal_eval
 from pyiron_base.state import state
+from pyiron_base.interfaces.has_dict import HasDict
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
@@ -26,7 +27,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-class GenericParameters:
+class GenericParameters(HasDict):
     """
     GenericParameters class defines the typical input file with a key value structure plus an additional column for comments.
     Convenience class to easily create, read, and modify input files
@@ -510,14 +511,15 @@ class GenericParameters:
         data_dict["data_dict"] = self._dataset
         return data_dict
 
-    def from_dict(self, generic_parameters_dict):
+    def from_dict(self, obj_dict, version: str = None):
         """
         Reload GenericParameters from dictionary
 
         Args:
-            generic_parameters_dict (dict): dictionary for reloading GenericParameters object
+            obj_dict (dict): dictionary for reloading GenericParameters object
+            version (str, optional): version of the HasDict format that is used
         """
-        self._dataset = generic_parameters_dict["data_dict"]
+        self._dataset = obj_dict["data_dict"]
 
     def to_hdf(self, hdf, group_name=None):
         """
@@ -549,10 +551,10 @@ class GenericParameters:
         else:
             data = hdf[self.table_name]
         if isinstance(data, dict):
-            self.from_dict(generic_parameters_dict={"data_dict": data})
+            self.from_dict(obj_dict={"data_dict": data})
         else:
             self.from_dict(
-                generic_parameters_dict={"data_dict": data._read("data_dict")}
+                obj_dict={"data_dict": data._read("data_dict")}
             )
 
     def get_string_lst(self):
@@ -956,20 +958,6 @@ class GenericParameters:
                 lst["Value"].append("")
                 lst["Comment"].append("")
         return lst
-
-    def _type_to_dict(self):
-        """
-        Internal helper function to save type and version in hdf root
-
-        Args:
-            hdf (ProjectHDFio): HDF5 group object
-        """
-        return {
-            "NAME": self.__name__,
-            "TYPE": str(type(self)),
-            "VERSION": self.__version__,
-            "OBJECT": "GenericParameters",
-        }
 
     def _find_line(self, key_name):
         """

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -553,9 +553,7 @@ class GenericParameters(HasDict):
         if isinstance(data, dict):
             self.from_dict(obj_dict={"data_dict": data})
         else:
-            self.from_dict(
-                obj_dict={"data_dict": data._read("data_dict")}
-            )
+            self.from_dict(obj_dict={"data_dict": data._read("data_dict")})
 
     def get_string_lst(self):
         """

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -510,7 +510,7 @@ class GenericParameters:
         data_dict = self._type_to_dict()
         data_dict["data_dict"] = self._dataset
         if group_name:
-            h5_path = group_name/self.table_name
+            h5_path = group_name / self.table_name
         else:
             h5_path = self.table_name
         with hdf.open(h5_path) as hdf_group:

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -499,6 +499,14 @@ class GenericParameters:
             raise AssertionError()
         self._block_dict = block_dict
 
+    def to_dict(self):
+        data_dict = self._type_to_dict()
+        data_dict["data_dict"] = self._dataset
+        return data_dict
+
+    def from_dict(self, generic_parameters_dict):
+        self._dataset = generic_parameters_dict
+
     def to_hdf(self, hdf, group_name=None):
         """
         Store the GenericParameters in an HDF5 file
@@ -507,14 +515,12 @@ class GenericParameters:
             hdf (ProjectHDFio): HDF5 group object
             group_name (str): HDF5 subgroup name - optional
         """
-        data_dict = self._type_to_dict()
-        data_dict["data_dict"] = self._dataset
         if group_name:
             h5_path = group_name + "/" + self.table_name
         else:
             h5_path = self.table_name
         with hdf.open(h5_path) as hdf_group:
-            for k, v in data_dict.items():
+            for k, v in self.to_dict().items():
                 hdf_group[k] = v
 
     def from_hdf(self, hdf, group_name=None):
@@ -531,9 +537,9 @@ class GenericParameters:
         else:
             data = hdf[self.table_name]
         if isinstance(data, dict):
-            self._dataset = data
+            self.from_dict(generic_parameters_dict=data)
         else:
-            self._dataset = data._read("data_dict")
+            self.from_dict(generic_parameters_dict=data._read("data_dict"))
 
     def get_string_lst(self):
         """

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -507,14 +507,15 @@ class GenericParameters:
             hdf (ProjectHDFio): HDF5 group object
             group_name (str): HDF5 subgroup name - optional
         """
+        data_dict = self._type_to_dict()
+        data_dict["data_dict"] = self._dataset
         if group_name:
-            with hdf.open(group_name) as hdf_group:
-                hdf_child = hdf_group.create_group(self.table_name)
+            h5_path = group_name/self.table_name
         else:
-            hdf_child = hdf.create_group(self.table_name)
-
-        self._type_to_hdf(hdf_child)
-        hdf_child["data_dict"] = self._dataset
+            h5_path = self.table_name
+        with hdf.open(h5_path) as hdf_group:
+            for k, v in data_dict.items():
+                hdf_group[k] = v
 
     def from_hdf(self, hdf, group_name=None):
         """
@@ -936,17 +937,19 @@ class GenericParameters:
                 lst["Comment"].append("")
         return lst
 
-    def _type_to_hdf(self, hdf):
+    def _type_to_dict(self):
         """
         Internal helper function to save type and version in hdf root
 
         Args:
             hdf (ProjectHDFio): HDF5 group object
         """
-        hdf["NAME"] = self.__name__
-        hdf["TYPE"] = str(type(self))
-        hdf["VERSION"] = self.__version__
-        hdf["OBJECT"] = "GenericParameters"
+        return {
+            "NAME": self.__name__,
+            "TYPE": str(type(self)),
+            "VERSION": self.__version__,
+            "OBJECT": "GenericParameters",
+        }
 
     def _find_line(self, key_name):
         """

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -510,7 +510,7 @@ class GenericParameters:
         data_dict = self._type_to_dict()
         data_dict["data_dict"] = self._dataset
         if group_name:
-            h5_path = group_name / self.table_name
+            h5_path = group_name + "/" + self.table_name
         else:
             h5_path = self.table_name
         with hdf.open(h5_path) as hdf_group:


### PR DESCRIPTION
In analogy to https://github.com/pyiron/pyiron_base/pull/1248 this pull request adds the `to_dict()` and `from_dict()` function to the `GenericParameters` class. This is required to enable more flexible storage backends.  