### PR TITLE
Workaround for SerialMaster

### DIFF
--- a/pyiron_base/jobs/master/generic.py
+++ b/pyiron_base/jobs/master/generic.py
@@ -167,7 +167,7 @@ class GenericMaster(GenericJob):
                 "GenericMaster requires reference jobs to have status initialized, rather than ",
                 job.status.string,
             )
-        if job.server.cores >= self.server.cores:
+        if job.server.cores > self.server.cores:
             self.server.cores = job.server.cores
         if job.job_name not in self._job_name_lst:
             self._job_name_lst.append(job.job_name)

--- a/pyiron_base/jobs/master/serial.py
+++ b/pyiron_base/jobs/master/serial.py
@@ -381,6 +381,10 @@ class SerialMasterBase(GenericMaster):
         ):
             self.server.run_mode.interactive = True
 
+    def append(self, job):
+        with self.server.unlocked():
+            super().append(job)
+
 
 class GenericOutput(OrderedDict):
     """


### PR DESCRIPTION
https://github.com/pyiron/pyiron_atomistics/pull/1265 flagged a failing test for SerialMasterBase, that tries to re-run a master job and fails because the server object is locked.  This is a hack to make it work again.