### PR TITLE
HasHDF: Add _store_type_to_dict()

### DIFF
--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -183,10 +183,6 @@ class HasHDF(ABC):
             type_dict["VERSION"] = self.__version__
         return type_dict
 
-    def _store_type_to_hdf(self, hdf: ProjectHDFio):
-        for k, v in self._store_type_to_dict().items():
-            hdf[k] = v
-
     def from_hdf(self, hdf: ProjectHDFio, group_name: str = None):
         """
         Read object to HDF.
@@ -224,7 +220,8 @@ class HasHDF(ABC):
             ):
                 raise ValueError("HDF group must be empty when group_name is not set.")
             self._to_hdf(hdf)
-            self._store_type_to_hdf(hdf)
+            for k, v in self._store_type_to_dict().items():
+                hdf[k] = v
 
     def rewrite_hdf(self, hdf: ProjectHDFio, group_name: str = None):
         """

--- a/pyiron_base/interfaces/has_hdf.py
+++ b/pyiron_base/interfaces/has_hdf.py
@@ -172,13 +172,20 @@ class HasHDF(ABC):
         """
         return {}
 
-    def _store_type_to_hdf(self, hdf: ProjectHDFio):
-        hdf["NAME"] = self.__class__.__name__
-        hdf["TYPE"] = str(type(self))
-        hdf["OBJECT"] = hdf["NAME"]  # unused alias
+    def _store_type_to_dict(self):
+        type_dict = {
+            "NAME": self.__class__.__name__,
+            "TYPE": str(type(self)),
+            "OBJECT": self.__class__.__name__,  # unused alias
+            "HDF_VERSION": self.__hdf_version__,
+        }
         if hasattr(self, "__version__"):
-            hdf["VERSION"] = self.__version__
-        hdf["HDF_VERSION"] = self.__hdf_version__
+            type_dict["VERSION"] = self.__version__
+        return type_dict
+
+    def _store_type_to_hdf(self, hdf: ProjectHDFio):
+        for k, v in self._store_type_to_dict().items():
+            hdf[k] = v
 
     def from_hdf(self, hdf: ProjectHDFio, group_name: str = None):
         """


### PR DESCRIPTION
Rename `_store_type_to_hdf()` to `_store_type_to_dict()`. While at the current stage this is only an internal change, it is designed to be combined with the `write_dict_to_hdf()` function from https://github.com/pyiron/pyiron_base/pull/1247 to open the HDF5 file only once for writing all the type information. 