### PR TITLE
[feedback wanted] Use regex for job table sorting

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -85,7 +85,7 @@ class IsDatabase(ABC):
 
     @staticmethod
     def _get_filtered_job_table(
-        df: pandas.DataFrame, **kwargs: dict, regex=False,
+        df: pandas.DataFrame, regex=False, **kwargs: dict,
     ) -> pandas.DataFrame:
         """
         Get a job table in a project based on matching values from any column in the project database
@@ -113,7 +113,9 @@ class IsDatabase(ABC):
                     f"Column name {key} does not exist in the project database!"
                 )
         if len(kwargs) > 0 and not regex:
-            logger.warn("regex=False when using keyword sorting is deprecated")
+            logger.warning(
+                "regex=False when using keyword sorting is deprecated",
+            )
         for key, val in kwargs.items():
             if regex:
                 update = df[key].apply(lambda x: re.search(val, x)).astype(bool)
@@ -219,7 +221,7 @@ class IsDatabase(ABC):
                 "`job_name_contains` is deprecated - use `job='*term*'` instead"
             )
             kwargs["job"] = "*{}*".format(job_name_contains)
-        df = self._get_filtered_job_table(df, **kwargs, regex=regex)
+        df = self._get_filtered_job_table(df, regex=regex, **kwargs)
         if sort_by is not None:
             return df.sort_values(by=sort_by)
         return df

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from pyiron_base.utils.deprecate import deprecate
 import pandas
 import typing
+import fnmatch
 from sqlalchemy import (
     create_engine,
     MetaData,

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -137,7 +137,7 @@ class IsDatabase(ABC):
         full_table=False,
         element_lst=None,
         job_name_contains="",
-        regex=False,
+        mode: typing.Literal["regex", "glob"]="glob"
         **kwargs,
     ):
         """
@@ -206,7 +206,7 @@ class IsDatabase(ABC):
                 "`job_name_contains` is deprecated - use `job='*term*'` instead"
             )
             kwargs["job"] = "*{}*".format(job_name_contains)
-        df = self._get_filtered_job_table(df, regex=regex, **kwargs)
+        df = self._get_filtered_job_table(df, mode=mode, **kwargs)
         if sort_by is not None:
             return df.sort_values(by=sort_by)
         return df

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -148,6 +148,7 @@ class IsDatabase(ABC):
         full_table=False,
         element_lst=None,
         job_name_contains="",
+        regex=False,
         **kwargs,
     ):
         """
@@ -216,7 +217,7 @@ class IsDatabase(ABC):
                 "`job_name_contains` is deprecated - use `job='*term*'` instead"
             )
             kwargs["job"] = "*{}*".format(job_name_contains)
-        df = self._get_filtered_job_table(df, **kwargs)
+        df = self._get_filtered_job_table(df, **kwargs, regex=regex)
         if sort_by is not None:
             return df.sort_values(by=sort_by)
         return df

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -88,7 +88,7 @@ class IsDatabase(ABC):
     @staticmethod
     def _get_filtered_job_table(
         df: pandas.DataFrame,
-        mode: typing.Literal["regex", "glob"]="glob",
+        mode: typing.Literal["regex", "glob"] = "glob",
         **kwargs: dict,
     ) -> pandas.DataFrame:
         """
@@ -136,7 +136,7 @@ class IsDatabase(ABC):
         full_table=False,
         element_lst=None,
         job_name_contains="",
-        mode: typing.Literal["regex", "glob"]="glob",
+        mode: typing.Literal["regex", "glob"] = "glob",
         **kwargs,
     ):
         """

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -116,7 +116,7 @@ class IsDatabase(ABC):
         for key, val in kwargs.items():
             if mode == "regex":
                 pattern = re.compile(str(val))
-                update = df[key].apply(lambda x: pattern.search(x)).astype(bool)
+                update = df[key].apply(pattern.search).astype(bool)
             elif mode == "glob":
                 if str(val).startswith("!"):
                     logger.warn(

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -112,6 +112,8 @@ class IsDatabase(ABC):
                 raise ValueError(
                     f"Column name {key} does not exist in the project database!"
                 )
+        if len(kwargs) > 0 and not regex:
+            logger.warn("regex=False when using keyword sorting is deprecated")
         for key, val in kwargs.items():
             if regex:
                 update = df[key].apply(lambda x: re.search(val, x)).astype(bool)

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -115,11 +115,12 @@ class IsDatabase(ABC):
                 )
         for key, val in kwargs.items():
             if mode == "regex":
-                pattern = re.compile(val)
-                update = df[key].apply(lambda x: pattern(x)).astype(bool)
+                pattern = re.compile(str(val))
+                update = df[key].apply(lambda x: pattern.search(x)).astype(bool)
             elif mode == "glob":
-                matches = fnmatch.filter(df[key], val)
-                update = np.array([k in matches for k in df[key]])
+                arr = np.asarray(df[key]).astype(str)
+                matches = fnmatch.filter(arr, str(val))
+                update = np.array([k in matches for k in arr])
             mask &= update
         return df[mask]
 

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -135,7 +135,7 @@ class IsDatabase(ABC):
         full_table=False,
         element_lst=None,
         job_name_contains="",
-        mode: typing.Literal["regex", "glob"]="glob"
+        mode: typing.Literal["regex", "glob"]="glob",
         **kwargs,
     ):
         """

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -118,6 +118,13 @@ class IsDatabase(ABC):
                 pattern = re.compile(str(val))
                 update = df[key].apply(lambda x: pattern.search(x)).astype(bool)
             elif mode == "glob":
+                if str(val).startswith("!"):
+                    logger.warn(
+                        "It looks like you are using an old pyiron convention."
+                        " If you meant to exclude the term following '!', use"
+                        " `mode='regex' and use a regex convention (such as"
+                        " `^(?!term$)`)"
+                    )
                 arr = np.asarray(df[key]).astype(str)
                 matches = fnmatch.filter(arr, str(val))
                 update = np.array([k in matches for k in arr])

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -87,7 +87,7 @@ class IsDatabase(ABC):
     @staticmethod
     def _get_filtered_job_table(
         df: pandas.DataFrame,
-        mode: typing.Literal["regex", "glob"]="glob"
+        mode: typing.Literal["regex", "glob"]="glob",
         **kwargs: dict,
     ) -> pandas.DataFrame:
         """

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -85,7 +85,9 @@ class IsDatabase(ABC):
 
     @staticmethod
     def _get_filtered_job_table(
-        df: pandas.DataFrame, regex=False, **kwargs: dict,
+        df: pandas.DataFrame,
+        regex=False,
+        **kwargs: dict,
     ) -> pandas.DataFrame:
         """
         Get a job table in a project based on matching values from any column in the project database

--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -93,11 +93,8 @@ class IsDatabase(ABC):
         """
         Get a job table in a project based on matching values from any column in the project database
 
-        The values in `kwargs` can be wildcards, with the following special charaters:
-            - !value matches in the inverse of value
-            - *value matches anything that ends in value
-            - value* matches anything that starts with value
-            - *value* matches anything that contains value
+        The values in `kwargs` can be wildcards. The matches can be given
+        either via "glob" or "regex".
 
         Args:
             df (pandas.DataFrame): DataFrame to be filtered
@@ -117,7 +114,8 @@ class IsDatabase(ABC):
                 )
         for key, val in kwargs.items():
             if mode == "regex":
-                update = df[key].apply(lambda x: re.search(val, x)).astype(bool)
+                pattern = re.compile(val)
+                update = df[key].apply(lambda x: pattern(x)).astype(bool)
             elif mode == "glob":
                 matches = fnmatch.filter(df[key], val)
                 update = np.array([k in matches for k in df[key]])
@@ -158,6 +156,7 @@ class IsDatabase(ABC):
             full_table (bool): Whether to show the entire pandas table
             element_lst (list): list of elements required in the chemical formular - by default None
             job_name_contains (str): (deprecated) A string which should be contained in every job_name
+            mode (str): search mode when kwargs are given.
             **kwargs (dict): Optional arguments for filtering with keys matching the project database column name
                             (eg. status="finished"). Asterisk can be used to denote a wildcard, for zero or more
                             instances of any character

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -690,6 +690,7 @@ class Project(ProjectPath, HasGroups):
         element_lst=None,
         job_name_contains="",
         auto_refresh_job_status=False,
+        regex=False,
         **kwargs: dict,
     ):
         """
@@ -707,6 +708,7 @@ class Project(ProjectPath, HasGroups):
             sort_by=sort_by,
             full_table=full_table,
             element_lst=element_lst,
+            regex=regex,
             **kwargs,
         )
         if not isinstance(self.db, FileTable) or not auto_refresh_job_status:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -781,7 +781,7 @@ class Project(ProjectPath, HasGroups):
         element_lst=None,
         job_name_contains="",
         auto_refresh_job_status=False,
-        regex=False,
+        mode: typing.Literal["regex", "glob"]="glob"
         **kwargs: dict,
     ):
         """
@@ -799,7 +799,7 @@ class Project(ProjectPath, HasGroups):
             sort_by=sort_by,
             full_table=full_table,
             element_lst=element_lst,
-            regex=regex,
+            mode=mode,
             **kwargs,
         )
         if not isinstance(self.db, FileTable) or not auto_refresh_job_status:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -781,7 +781,7 @@ class Project(ProjectPath, HasGroups):
         element_lst=None,
         job_name_contains="",
         auto_refresh_job_status=False,
-        mode: typing.Literal["regex", "glob"]="glob",
+        mode: typing.Literal["regex", "glob"] = "glob",
         **kwargs: dict,
     ):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -56,7 +56,7 @@ from pyiron_base.jobs.job.extension.server.queuestatus import (
 from pyiron_base.project.external import Notebook
 from pyiron_base.project.data import ProjectData
 from pyiron_base.project.archiving import export_archive, import_archive
-from typing import Generator, Union, Dict, TYPE_CHECKING
+from typing import Generator, Union, Dict, TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from pyiron_base.jobs.job.generic import GenericJob
@@ -781,7 +781,7 @@ class Project(ProjectPath, HasGroups):
         element_lst=None,
         job_name_contains="",
         auto_refresh_job_status=False,
-        mode: typing.Literal["regex", "glob"] = "glob",
+        mode: Literal["regex", "glob"] = "glob",
         **kwargs: dict,
     ):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -781,7 +781,7 @@ class Project(ProjectPath, HasGroups):
         element_lst=None,
         job_name_contains="",
         auto_refresh_job_status=False,
-        mode: typing.Literal["regex", "glob"]="glob"
+        mode: typing.Literal["regex", "glob"]="glob",
         **kwargs: dict,
     ):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -709,7 +709,7 @@ class Project(ProjectPath, HasGroups):
             element_lst=element_lst,
             **kwargs,
         )
-        if not isinstance(self.db, FileTable):
+        if not isinstance(self.db, FileTable) or not auto_refresh_job_status:
             return job_table
         else:
             return self._refresh_job_status_file_table(df=job_table)

--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -178,19 +178,19 @@ class TestProjectOperations(TestWithFilledProject):
             n_top_jobs_named_toy_1
         )
         self.assertEqual(
-            len(self.project.job_table(recursive=True, status="!finished")),
+            len(self.project.job_table(recursive=True, status="^(?!finished)", mode="regex")),
             n_suspended_jobs + n_aborted_jobs,
         )
         self.assertEqual(
-            len(self.project.job_table(recursive=True, status="!aborted")),
+            len(self.project.job_table(recursive=True, status="^(?!aborted)", mode="regex")),
             n_jobs - n_aborted_jobs
         )
         self.assertEqual(
-            len(self.project.job_table(recursive=True, job="!toy_1")),
+            len(self.project.job_table(recursive=True, job="^(?!toy_1)", mode="regex")),
             n_jobs - n_jobs_named_toy_1
         )
         self.assertEqual(
-            len(self.project.job_table(recursive=True, job="!toy_*")),
+            len(self.project.job_table(recursive=True, job="^(?!toy_)", mode="regex")),
             0
         )
         self.assertRaises(ValueError, self.project.job_table, gibberish=True)


### PR DESCRIPTION
@sudarsan-surendralal and I introduced some time ago the sorting of job tables such as:

```python
pr.job_table(status="finished")
```

which returns the job table containing only entries where the status is `finished`. While doing this, we allowed also *some* flexibility with `*` (and `!` added some time later). This feature isn't so bad, but I would like to replace it with regex, because we've got the following problems:

- This functionality is super limited compared to regex
- Our current code: 16 lines vs. with regex: 1 line
- Ours is not a standardised method?
  - At least we have to write in the doc string what would be understood for each case, while with regex we can simply say "It's regex"

If I remember correctly, using regex was originally @niklassiemer's idea, and we sort of gave him the cold shoulder and now I would like to come back to it because I'm super frustrated by how limited our current functionality is.

I am not going to merge this one until the next pyiron meeting, and even if it's merged the current functionality will be maintained, because if `regex=True` not set, you will only get a warning saying it's deprecated. Anyway ahead of it I would like to get some feedback from you.