### PR TITLE
Update h5io_browser to 0.0.3

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - codacy-coverage
 - cloudpickle =3.0.0
 - gitpython =3.1.40
-- h5io_browser =0.0.2
+- h5io_browser =0.0.3
 - h5py =3.10.0
 - jinja2 =3.1.2
 - numpy =1.26.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "cloudpickle==3.0.0",
     "gitpython==3.1.40",
-    "h5io_browser==0.0.2",
+    "h5io_browser==0.0.3",
     "h5py==3.10.0",
     "jinja2==3.1.2",
     "numpy==1.26.2",


### PR DESCRIPTION
`h5io_browser` version `0.0.3` supports `h5io` version `0.2.0`, which adds the new functionality to serialise all objects using `__getstate__()` and `__setstate__()`: https://github.com/h5io/h5io/pull/65 