### PR TITLE
Split DataContainer to a HDF and non HDF part

### DIFF
--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -447,7 +447,11 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
             )
         else:
             return list(
-                v.to_builtin(stringify=stringify) if isinstance(v, DataContainerBase) else v
+                (
+                    v.to_builtin(stringify=stringify)
+                    if isinstance(v, DataContainerBase)
+                    else v
+                )
                 for v in self.values()
             )
 

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -430,7 +430,7 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
                 # _normalize calls int() on all digit string keys this is
                 # transparent for the rest of the module
                 k = str(k)
-                if isinstance(v, type(self)):
+                if isinstance(v, DataContainerBase):
                     dd[k] = v.to_builtin(stringify=stringify)
                 else:
                     dd[k] = repr(v) if stringify else v
@@ -440,14 +440,14 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
             return list(
                 (
                     v.to_builtin(stringify=stringify)
-                    if isinstance(v, type(self))
+                    if isinstance(v, DataContainerBase)
                     else repr(v)
                 )
                 for v in self.values()
             )
         else:
             return list(
-                v.to_builtin(stringify=stringify) if isinstance(v, type(self)) else v
+                v.to_builtin(stringify=stringify) if isinstance(v, DataContainerBase) else v
                 for v in self.values()
             )
 
@@ -545,11 +545,11 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
         # descend into subgroups
         for it in self.groups():
             hit = self[it]._search_parent(key, stop_on_first_hit)
-            if isinstance(hit, type(self)):
+            if isinstance(hit, DataContainerBase):
                 if stop_on_first_hit:
                     return hit
                 else:
-                    if isinstance(first_hit, type(self)):
+                    if isinstance(first_hit, DataContainerBase):
                         raise ValueError("'" + key + "' exists more than once!")
                 first_hit = hit
         return first_hit
@@ -759,7 +759,7 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
             :class:`list`: list of keys to normal values.
         """
         for k, v in self.items():
-            if not isinstance(v, type(self)):
+            if not isinstance(v, DataContainerBase):
                 yield k
 
     def _list_nodes(self):
@@ -773,7 +773,7 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
             :class:`list`: list of all keys to elements of :class:`DataContainerBase`.
         """
         for k, v in self.items():
-            if isinstance(v, type(self)):
+            if isinstance(v, DataContainerBase):
                 yield k
 
     def _list_groups(self):
@@ -962,7 +962,7 @@ class DataContainer(DataContainerBase, HasHDF):
 
         # values are loaded from HDF once they are accessed via __getitem__, which is implicitly called by values()
         for v in self.values():
-            if recursive and isinstance(v, type(self)):
+            if recursive and isinstance(v, DataContainer):
                 v._force_load()
 
     def copy(self):

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -813,6 +813,7 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
         warnings.warn("Unlock previously locked object!")
         super()._on_unlock()
 
+
 class DataContainer(DataContainerBase, HasHDF):
     __doc__ = f"""{DataContainerBase.__doc__}
 
@@ -852,9 +853,12 @@ class DataContainer(DataContainerBase, HasHDF):
             wrap_blacklist (tuple of types): any values in `init` that are instances of the given types are *not*
                                              wrapped in :class:`.DataContainerBase`
         """
-        super().__init__(init=init, table_name=table_name,
-                         wrap_blacklist=wrap_blacklist,
-                         lock_method=lock_method)
+        super().__init__(
+            init=init,
+            table_name=table_name,
+            wrap_blacklist=wrap_blacklist,
+            lock_method=lock_method,
+        )
         self._lazy = lazy
 
     # HasHDF impl'
@@ -984,5 +988,6 @@ class DataContainer(DataContainerBase, HasHDF):
         # called whenever a subclass of DataContainer is defined, then register all subclasses with the same function
         # that the DataContainer is registered
         HDFStub.register(cls, lambda h, g: h[g].to_object(lazy=True))
+
 
 HDFStub.register(DataContainer, lambda h, g: h[g].to_object(lazy=True))

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -17,9 +17,7 @@ import pandas as pd
 
 
 class Sub(DataContainer):
-    def __init__(self, init=None, table_name=None, lazy=False, wrap_blacklist=()):
-        super().__init__(init=init, table_name=table_name, lazy=lazy, wrap_blacklist=())
-        self.foo = 42
+    pass
 
 class TestDataContainer(TestWithCleanProject):
 

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -2,7 +2,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 import pyiron_base
 from pyiron_base._tests import TestWithCleanProject, PyironTestCase
-from pyiron_base.storage.datacontainer import DataContainer
+from pyiron_base.storage.datacontainer import DataContainer, DataContainerBase
 from pyiron_base.storage.hdfstub import HDFStub
 from pyiron_base.storage.inputlist import InputList
 from collections.abc import Iterator
@@ -698,6 +698,29 @@ class TestDataContainer(TestWithCleanProject):
         self.assertEqual(pl_reload.project.project_path, self.project.project_path)
         self.assertEqual(pl_reload.project.root_path, self.project.root_path)
 
+class TestDataContainerBase(unittest.TestCase):
+    """Test interactions between base class and full data container."""
+
+    @classmethod
+    def setUpClass(cls):
+        inner = [0, {"depth": 23}]
+        cls.body = [
+            {"foo": "bar"},
+            2,
+            42,
+            {"next": inner}
+        ]
+        cls.base_inside = DataContainer(cls.body)
+        cls.base_inside[-1]["next"] = DataContainerBase(cls.base_inside[-1]["next"])
+        cls.base_outside = DataContainerBase(cls.body)
+        cls.base_outside[-1]["next"] = DataContainer(cls.base_outside[-1]["next"])
+
+    def test_to_builtin(self):
+        """to_builtin should recurse fully even if DataContainer and DataContainerBase are nested."""
+        self.assertEqual(self.body, self.base_inside.to_builtin(),
+                         "incorrect when DataContainerBase is inside")
+        self.assertEqual(self.body, self.base_outside.to_builtin(),
+                         "incorrect when DataContainer is inside")
 
 class TestInputList(PyironTestCase):
 

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -701,17 +701,20 @@ class TestDataContainerBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        first = {"foo": "bar"}
         inner = [0, {"depth": 23}]
         cls.body = [
-            {"foo": "bar"},
+            first,
             2,
             42,
             {"next": inner}
         ]
         cls.base_inside = DataContainer(cls.body)
-        cls.base_inside[-1]["next"] = DataContainerBase(cls.base_inside[-1]["next"])
+        cls.base_inside[0] = Sub(first)
+        cls.base_inside[-1]["next"] = DataContainerBase(inner)
         cls.base_outside = DataContainerBase(cls.body)
-        cls.base_outside[-1]["next"] = DataContainer(cls.base_outside[-1]["next"])
+        cls.base_outside[-1]["next"] = DataContainer(inner)
+        cls.base_outside[0] = Sub(first)
 
     def test_to_builtin(self):
         """to_builtin should recurse fully even if DataContainer and DataContainerBase are nested."""
@@ -719,6 +722,20 @@ class TestDataContainerBase(unittest.TestCase):
                          "incorrect when DataContainerBase is inside")
         self.assertEqual(self.body, self.base_outside.to_builtin(),
                          "incorrect when DataContainer is inside")
+
+    def test_nodes(self):
+        """list_nodes() should never return sub classes of DataContainerBase"""
+        self.assertEqual(self.base_inside.list_nodes(), [1, 2],
+                         "nodes should not contain first and last key.")
+        self.assertEqual(self.base_outside.list_nodes(), [1, 2],
+                         "nodes should not contain first and last key.")
+
+    def test_groups(self):
+        """list_groups() should never return sub classes of DataContainerBase"""
+        self.assertEqual(self.base_inside.list_groups(), [0, 3],
+                         "groups should not contain second and third key.")
+        self.assertEqual(self.base_outside.list_groups(), [0, 3],
+                         "groups should not contain second and third key.")
 
 class TestInputList(PyironTestCase):
 


### PR DESCRIPTION
Basically DataContainer is renamed to DataContainerBase and the methods used for HasHDF/HDFStub are moved to a new sub class DataContainer. Docstrings are replicated where necessary.  No API changes for users.

In preparation of https://github.com/orgs/pyiron/projects/7/views/1

@liamhuber Pulling `DataContainer` out should be just a matter of copy/paste now.