### PR TITLE
Fix reloading of executables for flexible jobs

### DIFF
--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -299,7 +299,10 @@ class Executable(HasStorage):
         try:
             return self.executable_lst[self.version]
         except KeyError:
-            return ""
+            if isinstance(self.version, str):
+                return self.version
+            else:
+                return ""
 
     def _get_hdf_group_name(self):
         return "executable"

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -37,7 +37,7 @@ class TestExecutableContainer(TestWithProject):
         executable_dict = {
             'version': 'cat input_file > output_file',
             'name': 'executablecontainerjob',
-            'operation_system_nt': False,
+            'operation_system_nt': os.name == "nt",
             'executable': None,
             'mpi': False,
             'accepted_return_codes': [0]

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -34,6 +34,16 @@ class TestExecutableContainer(TestWithProject):
         self.assertEqual(job_reload.output["energy"], energy_value)
         self.assertEqual(str(job.executable), "cat input_file > output_file")
         self.assertEqual(str(job_reload.executable), "cat input_file > output_file")
+        executable_dict = {
+            'version': 'cat input_file > output_file',
+            'name': 'executablecontainerjob',
+            'operation_system_nt': False,
+            'executable': None,
+            'mpi': False,
+            'accepted_return_codes': [0]
+        }
+        self.assertEqual(job.executable._storage.to_builtin(), executable_dict)
+        self.assertEqual(job_reload.executable._storage.to_builtin(), executable_dict)
         del JOB_CLASS_DICT["CatJob"]
 
     def test_create_job_factory_with_project(self):

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -32,6 +32,8 @@ class TestExecutableContainer(TestWithProject):
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
         self.assertEqual(job_reload.output["energy"], energy_value)
+        self.assertEqual(str(job.executable), "cat input_file > output_file")
+        self.assertEqual(str(job_reload.executable), "cat input_file > output_file")
         del JOB_CLASS_DICT["CatJob"]
 
     def test_create_job_factory_with_project(self):


### PR DESCRIPTION
The executable of a flexible job created using the `create_job_class()` function was empty when reloading the job from the HDF5 file. This issue is fixed in this pull request and the corresponding test is added. 