### PR TITLE
Fix wait_for_job() when for jobs with executors

### DIFF
--- a/pyiron_base/jobs/job/extension/server/queuestatus.py
+++ b/pyiron_base/jobs/job/extension/server/queuestatus.py
@@ -228,9 +228,13 @@ def wait_for_job(job, interval_in_s=5, max_iterations=100):
                     finished = True
                     break
                 elif isinstance(job.server.future, Future):
-                    job.server.future.result(timeout=interval_in_s)
-                    finished = job.server.future.done()
-                    break
+                    try:
+                        job.server.future.result(timeout=interval_in_s)
+                    except TimeoutError:
+                        pass
+                    else:
+                        finished = job.server.future.done()
+                        break
                 else:
                     time.sleep(interval_in_s)
             if not finished:

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -1,4 +1,6 @@
+import unittest
 from concurrent.futures import ProcessPoolExecutor
+import sys
 from time import sleep
 from pyiron_base._tests import TestWithProject
 
@@ -47,6 +49,7 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertIsNone(job.server.future.result())
             self.assertTrue(job.server.future.done())
 
+    @unittest.skipIf(sys.version_info < (3, 11), reason="requires python3.11 or higher")
     def test_with_executor_wait(self):
         with ProcessPoolExecutor() as exe:
             job = self.project.wrap_python_function(my_sleep_funct)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -56,5 +56,5 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertTrue(job.server.run_mode.executor)
             job.run()
             self.assertFalse(job.server.future.done())
-            self.project.wait_for_job(job=job, interval_in_s=0.01, max_iterations=100)
+            self.project.wait_for_job(job=job, interval_in_s=0.01, max_iterations=1000)
             self.assertTrue(job.server.future.done())


### PR DESCRIPTION
There was a bug in the `wait_for_job()` function on the project level as a result the function failed with a `TimeoutError` after the first iteration rather than iterating up to `max_iterations`. This issue is fixed now and two additional tests are added to validate this functionality is consistent.  