### PR TITLE
Job class creator can be static

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -332,8 +332,8 @@ class Project(ProjectPath, HasGroups):
         new = self.copy()
         return new.open(group, history=False)
 
+    @staticmethod
     def create_job_class(
-        self,
         class_name,
         write_input_funct,
         collect_output_funct,


### PR DESCRIPTION
~I want it so for `pyiron_workflow`, but~ PyCharm even nits me about it.

EDIT: Actually it doesn't look like I need it imminently, but I still agree with PyCharm.