### PR TITLE
Accelerate import of pyiron_base by 18%

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -12,7 +12,6 @@ from pyiron_base.storage.datacontainer import DataContainer
 from pyiron_base.storage.has_stored_traits import HasStoredTraits
 from pyiron_base.storage.inputlist import InputList
 from pyiron_base.storage.parameters import GenericParameters
-from pyiron_base.storage.filedata import load_file, FileDataTemplate, FileData
 from pyiron_base.utils.deprecate import Deprecator, deprecate, deprecate_soon
 from pyiron_base.utils.error import ImportAlarm
 from pyiron_base.jobs.job.extension.executable import Executable
@@ -50,12 +49,6 @@ from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.jobs.job.toolkit import Toolkit, BaseTools
 
 Project.register_tools("base", BaseTools)
-
-# optional API of the pyiron_base module
-try:
-    from pyiron_base.project.gui import ProjectGUI
-except (ImportError, TypeError, AttributeError):
-    pass
 
 # Internal init
 from ._version import get_versions

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -32,7 +32,6 @@ from pyiron_base.database.jobtable import (
     get_job_status,
 )
 from pyiron_base.storage.hdfio import ProjectHDFio
-from pyiron_base.storage.filedata import load_file
 from pyiron_base.utils.deprecate import deprecate
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.jobs.flex.factory import create_job_factory
@@ -1694,6 +1693,7 @@ class Project(ProjectPath, HasGroups):
             return ProjectHDFio(project=self, file_name=file_name)
         if item in self.list_files():
             file_name = posixpath.join(self.path, "{}".format(item))
+            from pyiron_base.storage.filedata import load_file
             return load_file(file_name, project=self)
         if item in self.list_dirs():
             with self.open(item) as new_item:

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1694,6 +1694,7 @@ class Project(ProjectPath, HasGroups):
         if item in self.list_files():
             file_name = posixpath.join(self.path, "{}".format(item))
             from pyiron_base.storage.filedata import load_file
+
             return load_file(file_name, project=self)
         if item in self.list_dirs():
             with self.open(item) as new_item:


### PR DESCRIPTION
The PIL module loads jupyter and everything, which slows down the import.
```
import time: self [us] | cumulative | imported package
import time:    145346 |    3295085 | pyiron_base
import time:    129456 |    3318212 | pyiron_base
import time:    113622 |    3214552 | pyiron_base
import time:    118646 |    2450846 | pyiron_base
```