### PR TITLE
Clean traceback when trying to import a moved module

### DIFF
--- a/pyiron_base/storage/hdfio.py
+++ b/pyiron_base/storage/hdfio.py
@@ -92,7 +92,7 @@ def _import_class(module_path, class_name):
             raise RuntimeError(
                 f"Could not import {class_name} from {module_path}, but module path known to have changed. "
                 "Call project.maintenance.local.update_hdf_types() to upgrade storage!"
-            )
+            ) from None
         else:
             raise
 


### PR DESCRIPTION
If it's not from None we get two nested tracebacks, which hides the error