### PR TITLE
Catch signal of aborted job in job wrapper

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -9,7 +9,6 @@ from concurrent.futures import Future
 from datetime import datetime
 import os
 import posixpath
-import signal
 import warnings
 
 from h5io_browser.base import _read_hdf, _write_hdf

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1232,6 +1232,7 @@ class GenericJob(JobCore, HasDict):
         self.refresh_job_status()
         if not (self.status.finished or self.status.suspended):
             self.status.aborted = True
+            self.project_hdf5["status"] = self.status.string
 
     def _run_if_new(self, debug=False):
         """

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -13,6 +13,7 @@ from jinja2 import Template
 from pyiron_base.utils.deprecate import deprecate
 from pyiron_base.jobs.job.wrapper import JobWrapper
 from pyiron_base.state import state
+from pyiron_base.state.signal import catch_signals
 from pyiron_base.utils.instance import static_isinstance
 
 
@@ -768,7 +769,8 @@ def multiprocess_wrapper(
         )
     else:
         raise ValueError("Either job_id or file_path have to be not None.")
-    job_wrap.job.run_static()
+    with catch_signals(job_wrap.job.signal_intercept):
+        job_wrap.job.run_static()
 
 
 def _generate_flux_execute_string(job, database_is_disabled):

--- a/pyiron_base/jobs/job/wrapper.py
+++ b/pyiron_base/jobs/job/wrapper.py
@@ -9,6 +9,7 @@ import os
 import logging
 from pyiron_base.project.generic import Project
 from pyiron_base.state import state
+from pyiron_base.state.signal import catch_signals
 from pyiron_base.database.filetable import (
     get_hamilton_from_file,
     get_hamilton_version_from_file,
@@ -126,7 +127,8 @@ class JobWrapper(object):
             self.job.status.collect = True
             self.job.run()
         else:
-            self.job.run_static()
+            with catch_signals(self.job.signal_intercept):
+                self.job.run_static()
 
 
 def job_wrapper_function(

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from time import sleep
 from pyiron_base._tests import TestWithProject
 from pyiron_base.jobs.job.jobtype import JOB_CLASS_DICT
 from pyiron_base import create_job_factory

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unittest
 from time import sleep
 from pyiron_base._tests import TestWithProject
 from pyiron_base.jobs.job.jobtype import JOB_CLASS_DICT
@@ -130,12 +131,18 @@ class TestExecutableContainer(TestWithProject):
             content = f.readlines()
         self.assertEqual(content[0].split()[0], "Python")
 
+    @unittest.skipIf(os.name == "nt", "Starting subprocesses on windows take a long time.")
     def test_job_run_mode_manual(self):
         create_sleep_job = create_job_factory(
             executable_str="sleep 10",
         )
         job = create_sleep_job(
-            project=ProjectHDFio(project=self.project, file_name="any.h5", h5_path=None, mode=None),
+            project=ProjectHDFio(
+                project=self.project,
+                file_name="job_sleep.h5",
+                h5_path=None,
+                mode=None,
+            ),
             job_name="job_sleep"
         )
         job.server.run_mode.manual = True
@@ -151,9 +158,9 @@ class TestExecutableContainer(TestWithProject):
         sleep(5)
         if process.poll() is not None:
             res = process.communicate()
-            print(process.returncode, res)
+            print("Debug test_job_run_mode_manual():", process.returncode, res)
         else:
             self.assertIsNone(process.poll())
         process.terminate()
-        sleep(2)
+        sleep(1)
         self.assertTrue(job.status.aborted)

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from pyiron_base._tests import TestWithProject
 from pyiron_base.jobs.job.jobtype import JOB_CLASS_DICT
 from pyiron_base import create_job_factory

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -59,9 +59,9 @@ class TestPythonFunctionContainer(TestWithProject):
         job.server.run_mode.thread = True
         job.run()
         self.assertIsNotNone(job._process)
-        sleep(10)
+        sleep(5)
         job._process.terminate()
-        sleep(1)
+        sleep(2)
         self.assertTrue(job.status.aborted)
         self.assertEqual(job["status"], "aborted")
 
@@ -77,9 +77,9 @@ class TestPythonFunctionContainer(TestWithProject):
         process = subprocess.Popen(
             ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.working_directory, "-j", str(job.job_id)],
         )
-        sleep(10)
+        sleep(5)
         process.terminate()
-        sleep(1)
+        sleep(2)
         self.assertTrue(job.status.aborted)
 
     @unittest.skipIf(sys.version_info < (3, 11), reason="requires python3.11 or higher")

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -78,6 +78,7 @@ class TestPythonFunctionContainer(TestWithProject):
             ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.working_directory, "-j", str(job.job_id)],
         )
         sleep(5)
+        self.assertIsNone(process.poll())
         process.terminate()
         sleep(2)
         self.assertTrue(job.status.aborted)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -75,7 +75,8 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertTrue(job.status.submitted)
         self.assertTrue(os.path.exists(job.project_hdf5.file_name))
         process = subprocess.Popen(
-            ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.working_directory, "-j", str(job.job_id)],
+            ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.project.path, "-j", str(job.job_id)],
+            cwd=job.project.path,
         )
         sleep(5)
         self.assertIsNone(process.poll())

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -61,7 +61,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertIsNotNone(job._process)
         sleep(10)
         job._process.terminate()
-        sleep(0.1)
+        sleep(1)
         self.assertTrue(job.status.aborted)
         self.assertEqual(job["status"], "aborted")
 

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -57,7 +57,7 @@ class TestPythonFunctionContainer(TestWithProject):
         job.server.run_mode.thread = True
         job.run()
         self.assertIsNotNone(job._process)
-        sleep(5)
+        sleep(10)
         job._process.terminate()
         sleep(2)
         self.assertTrue(job.status.aborted)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -9,8 +9,8 @@ def my_function(a, b=8):
     return a+b
 
 
-def my_sleep_funct(a, b=8):
-    sleep(0.01)
+def my_sleep_funct(a, b=8, sleep_time=0.01):
+    sleep(sleep_time)
     return a+b
 
 
@@ -48,6 +48,20 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertFalse(job.server.future.done())
             self.assertIsNone(job.server.future.result())
             self.assertTrue(job.server.future.done())
+
+    def test_terminate_job(self):
+        job = self.project.wrap_python_function(my_sleep_funct)
+        job.input["a"] = 5
+        job.input["b"] = 6
+        job.input["sleep_time"] = 10
+        job.server.run_mode.thread = True
+        job.run()
+        self.assertIsNotNone(job._process)
+        sleep(5)
+        job._process.terminate()
+        sleep(0.1)
+        self.assertTrue(job.status.aborted)
+        self.assertEqual(job["status"], "aborted")
 
     @unittest.skipIf(sys.version_info < (3, 11), reason="requires python3.11 or higher")
     def test_with_executor_wait(self):

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -1,10 +1,8 @@
-import os.path
 import unittest
 from concurrent.futures import ProcessPoolExecutor
 import sys
 from time import sleep
 from pyiron_base._tests import TestWithProject
-import subprocess
 
 
 def my_function(a, b=8):

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -76,10 +76,16 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertTrue(os.path.exists(job.project_hdf5.file_name))
         process = subprocess.Popen(
             ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.project.path, "-j", str(job.job_id)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             cwd=job.project.path,
         )
         sleep(5)
-        self.assertIsNone(process.poll())
+        if process.poll() is not None:
+            res = process.communicate()
+            print(process.returncode, res)
+        else:
+            self.assertIsNone(process.poll())
         process.terminate()
         sleep(2)
         self.assertTrue(job.status.aborted)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from concurrent.futures import ProcessPoolExecutor
 import sys
@@ -49,6 +50,7 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertIsNone(job.server.future.result())
             self.assertTrue(job.server.future.done())
 
+    @unittest.skipIf(os.name == "nt", "Starting subprocesses on windows take a long time.")
     def test_terminate_job(self):
         job = self.project.wrap_python_function(my_sleep_funct)
         job.input["a"] = 5
@@ -57,9 +59,9 @@ class TestPythonFunctionContainer(TestWithProject):
         job.server.run_mode.thread = True
         job.run()
         self.assertIsNotNone(job._process)
-        sleep(10)
+        sleep(5)
         job._process.terminate()
-        sleep(2)
+        sleep(1)
         self.assertTrue(job.status.aborted)
         self.assertEqual(job["status"], "aborted")
 

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -55,11 +55,11 @@ class TestPythonFunctionContainer(TestWithProject):
         job = self.project.wrap_python_function(my_sleep_funct)
         job.input["a"] = 5
         job.input["b"] = 6
-        job.input["sleep_time"] = 10
+        job.input["sleep_time"] = 20
         job.server.run_mode.thread = True
         job.run()
         self.assertIsNotNone(job._process)
-        sleep(5)
+        sleep(10)
         job._process.terminate()
         sleep(0.1)
         self.assertTrue(job.status.aborted)
@@ -69,7 +69,7 @@ class TestPythonFunctionContainer(TestWithProject):
         job = self.project.wrap_python_function(my_sleep_funct)
         job.input["a"] = 6
         job.input["b"] = 7
-        job.input["sleep_time"] = 10
+        job.input["sleep_time"] = 20
         job.server.run_mode.manual = True
         job.run()
         self.assertTrue(job.status.submitted)
@@ -77,7 +77,7 @@ class TestPythonFunctionContainer(TestWithProject):
         process = subprocess.Popen(
             ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.working_directory, "-j", str(job.job_id)],
         )
-        sleep(5)
+        sleep(10)
         process.terminate()
         sleep(1)
         self.assertTrue(job.status.aborted)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -65,31 +65,6 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertTrue(job.status.aborted)
         self.assertEqual(job["status"], "aborted")
 
-    def test_job_run_mode_manual(self):
-        job = self.project.wrap_python_function(my_sleep_funct)
-        job.input["a"] = 6
-        job.input["b"] = 7
-        job.input["sleep_time"] = 20
-        job.server.run_mode.manual = True
-        job.run()
-        self.assertTrue(job.status.submitted)
-        self.assertTrue(os.path.exists(job.project_hdf5.file_name))
-        process = subprocess.Popen(
-            ["python", "-m", "pyiron_base.cli", "wrapper", "-p", job.project.path, "-j", str(job.job_id)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=job.project.path,
-        )
-        sleep(5)
-        if process.poll() is not None:
-            res = process.communicate()
-            print(process.returncode, res)
-        else:
-            self.assertIsNone(process.poll())
-        process.terminate()
-        sleep(2)
-        self.assertTrue(job.status.aborted)
-
     @unittest.skipIf(sys.version_info < (3, 11), reason="requires python3.11 or higher")
     def test_with_executor_wait(self):
         with ProcessPoolExecutor() as exe:


### PR DESCRIPTION
We discussed this issue in the Friday FAQ meeting and @ahmedabdelkawy agreed to test it once in production, by reducing the `run_time` of a given calculation so the `SLURM` queuing system kills the job and to check if `pyiron_base` correctly identifies the job as killed and the status is set to aborted. 