### PR TITLE
Try to access files after HDF

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -907,13 +907,6 @@ class JobCore(HasGroups):
             dict, list, float, int, :class:`.DataContainer`, None: data or data object; if nothing is found None is returned
         """
 
-        if item in self.files.list():
-            warnings.warn(
-                "Using __getitem__ on a job to access files in deprecated: use job.files instead!",
-                category=DeprecationWarning,
-            )
-            return _job_read_file(self, item)
-
         # first try to access HDF5 directly to make the common case fast
         try:
             group = self._hdf5[item]
@@ -959,6 +952,13 @@ class JobCore(HasGroups):
                 # either group does not contain a data container or it is does, but it does not have the path we're
                 # looking for
                 pass
+
+        if item in self.files.list():
+            warnings.warn(
+                "Using __getitem__ on a job to access files in deprecated: use job.files instead!",
+                category=DeprecationWarning,
+            )
+            return _job_read_file(self, item)
 
         item_obj = name_lst[0]
         if item_obj in self._list_ext_childs():


### PR DESCRIPTION
Currently job[x] first checks whether x is a file in the directory of job.  Crucially it also does this when the files are compressed and when job was obtained in inspect mode.  Together this conspires to make pyiron tables much slower, because every single table entry will search the compress tar archive for (non-existing) files first.

This commit reorders the access so that first the HDF files is searched for x, before looking for local files, based on two assumptions:
1. accessing HDF is the common case and should be faster
2. users that want to read files and avoid searching HDF can simply use job.files