### PR TITLE
Switch to use conda as default

### DIFF
--- a/pyiron_base/project/condaenv.py
+++ b/pyiron_base/project/condaenv.py
@@ -21,7 +21,7 @@ class CondaEnvironment:
             )
 
     @staticmethod
-    def create(env_name, env_file, use_mamba=True):
+    def create(env_name, env_file, use_mamba=False):
         exe = "mamba" if use_mamba else "conda"
         subprocess.check_output(
             [exe, "env", "create", "-n", env_name, "-f", env_file, "-y"],


### PR DESCRIPTION
We require the `conda` package to be available, so we can expect that the `conda` executable is available but that does not mean that the `mamba` executable is available.