### PR TITLE
ExecutableContainerJob: store command line output in job.output

### DIFF
--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -79,6 +79,9 @@ class ExecutableContainerJob(TemplateJob):
                 working_directory=self.working_directory,
             )
 
+    def run_static(self):
+        self.storage.output.command_line = super().run_static()
+
     def collect_output(self):
         if self._collect_output_funct is not None:
             self.output.update(

--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -80,7 +80,7 @@ class ExecutableContainerJob(TemplateJob):
             )
 
     def run_static(self):
-        self.storage.output.command_line = super().run_static()
+        self.storage.output.stdout = super().run_static()
 
     def collect_output(self):
         if self._collect_output_funct is not None:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -796,7 +796,7 @@ class GenericJob(JobCore, HasDict):
         """
         The run static function is called by run to execute the simulation.
         """
-        execute_job_with_external_executable(job=self)
+        return execute_job_with_external_executable(job=self)
 
     def run_if_scheduler(self):
         """

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -607,10 +607,11 @@ def run_time_decorator(func):
     def wrapper(job):
         if not state.database.database_is_disabled and job.job_id is not None:
             job.project.db.item_update({"timestart": datetime.now()}, job.job_id)
-            func(job)
+            output = func(job)
             job.project.db.item_update(job._runtime(), job.job_id)
         else:
-            func(job)
+            output = func(job)
+        return output
 
     return wrapper
 
@@ -683,6 +684,7 @@ def execute_job_with_external_executable(job):
     ) as f_err:
         f_err.write(out)
     handle_finished_job(job=job, job_crashed=job_crashed, collect_output=True)
+    return out
 
 
 def handle_finished_job(job, job_crashed=False, collect_output=True):

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -31,7 +31,7 @@ class TestExecutableContainer(TestWithProject):
         job = self.project.create.job.CatJob(job_name="job_test")
         job.input["energy"] = energy_value
         job.run()
-        self.assertIsNone(job.output['command_line'])
+        self.assertEqual(job.output['command_line'], "")
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -81,7 +81,7 @@ class TestExecutableContainer(TestWithProject):
         )
         job.input["energy"] = energy_value
         job.run()
-        self.assertIsNone(job.output['command_line'])
+        self.assertEqual(job.output['command_line'], "")
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -99,7 +99,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_output_files"
         )
         job.run()
-        self.assertIsNone(job.output['command_line'])
+        self.assertEqual(job.output['command_line'], "")
         for file in ['error_out', 'input_file', 'output_file']:
             self.assertTrue(file in dir(job.files))
         output_file_path = os.path.abspath(os.path.join(__file__, "..", "test_executablecontainer", "job_output_files_hdf5", "job_output_files", "error.out"))

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -61,7 +61,6 @@ class TestExecutableContainer(TestWithProject):
         job = create_catjob(project=self.project, job_name="job_test")
         job.input["energy"] = energy_value
         job.run()
-        self.assertIsNone(job.output['command_line'])
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -81,7 +80,6 @@ class TestExecutableContainer(TestWithProject):
         )
         job.input["energy"] = energy_value
         job.run()
-        self.assertEqual(job.output['command_line'], "")
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -31,7 +31,7 @@ class TestExecutableContainer(TestWithProject):
         job = self.project.create.job.CatJob(job_name="job_test")
         job.input["energy"] = energy_value
         job.run()
-        self.assertEqual(job.output['command_line'], "")
+        self.assertEqual(job.output['stdout'], "")
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -97,7 +97,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_output_files"
         )
         job.run()
-        self.assertEqual(job.output['command_line'], "")
+        self.assertEqual(job.output['stdout'], "")
         for file in ['error_out', 'input_file', 'output_file']:
             self.assertTrue(file in dir(job.files))
         output_file_path = os.path.abspath(os.path.join(__file__, "..", "test_executablecontainer", "job_output_files_hdf5", "job_output_files", "error.out"))
@@ -127,7 +127,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_no"
         )
         job.run()
-        self.assertTrue("Python" in job.output['command_line'])
+        self.assertTrue("Python" in job.output['stdout'])
         self.assertTrue(job.status.finished)
         self.assertEqual(os.listdir(job.working_directory), ['error.out'])
         with open(os.path.join(job.working_directory, 'error.out'), "r") as f:

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -129,7 +129,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_no"
         )
         job.run()
-        self.assertEqual(job.output['command_line'], "Python 3.11.8\n")
+        self.assertTrue("Python" in job.output['command_line'])
         self.assertTrue(job.status.finished)
         self.assertEqual(os.listdir(job.working_directory), ['error.out'])
         with open(os.path.join(job.working_directory, 'error.out'), "r") as f:

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -31,6 +31,7 @@ class TestExecutableContainer(TestWithProject):
         job = self.project.create.job.CatJob(job_name="job_test")
         job.input["energy"] = energy_value
         job.run()
+        self.assertIsNone(job.output['command_line'])
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -60,6 +61,7 @@ class TestExecutableContainer(TestWithProject):
         job = create_catjob(project=self.project, job_name="job_test")
         job.input["energy"] = energy_value
         job.run()
+        self.assertIsNone(job.output['command_line'])
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -79,6 +81,7 @@ class TestExecutableContainer(TestWithProject):
         )
         job.input["energy"] = energy_value
         job.run()
+        self.assertIsNone(job.output['command_line'])
         self.assertEqual(job.output["energy"], energy_value)
         job_reload = self.project.load(job.job_name)
         self.assertEqual(job_reload.input["energy"], energy_value)
@@ -96,6 +99,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_output_files"
         )
         job.run()
+        self.assertIsNone(job.output['command_line'])
         for file in ['error_out', 'input_file', 'output_file']:
             self.assertTrue(file in dir(job.files))
         output_file_path = os.path.abspath(os.path.join(__file__, "..", "test_executablecontainer", "job_output_files_hdf5", "job_output_files", "error.out"))
@@ -125,6 +129,7 @@ class TestExecutableContainer(TestWithProject):
             job_name="job_no"
         )
         job.run()
+        self.assertEqual(job.output['command_line'], "Python 3.11.8\n")
         self.assertTrue(job.status.finished)
         self.assertEqual(os.listdir(job.working_directory), ['error.out'])
         with open(os.path.join(job.working_directory, 'error.out'), "r") as f:

--- a/tests/flex/test_executablecontainer_conda.py
+++ b/tests/flex/test_executablecontainer_conda.py
@@ -40,4 +40,5 @@ class TestExecutableContainerConda(TestWithProject):
         job = self.project.create.job.PythonVersionJob(job_name="job_conda_path")
         job.server.conda_environment_path = self.project.conda_environment.py312
         job.run()
-        self.assertEqual(job["error.out"][0], "Python 3.12.1\n")
+        self.assertEqual(job.output['command_line'], "")
+        self.assertTrue("Python" in job["error.out"][0])

--- a/tests/flex/test_executablecontainer_conda.py
+++ b/tests/flex/test_executablecontainer_conda.py
@@ -40,5 +40,5 @@ class TestExecutableContainerConda(TestWithProject):
         job = self.project.create.job.PythonVersionJob(job_name="job_conda_path")
         job.server.conda_environment_path = self.project.conda_environment.py312
         job.run()
-        self.assertEqual(job.output['command_line'], "")
-        self.assertTrue("Python" in job["error.out"][0])
+        self.assertEqual(job.output['command_line'][0], "Python 3.12.1\n")
+        self.assertEqual(job["error.out"][0], "Python 3.12.1\n")

--- a/tests/flex/test_executablecontainer_conda.py
+++ b/tests/flex/test_executablecontainer_conda.py
@@ -40,5 +40,5 @@ class TestExecutableContainerConda(TestWithProject):
         job = self.project.create.job.PythonVersionJob(job_name="job_conda_path")
         job.server.conda_environment_path = self.project.conda_environment.py312
         job.run()
-        self.assertEqual(job.output['command_line'][0], "Python 3.12.1\n")
+        self.assertEqual(job.output['command_line'], "Python 3.12.1\n")
         self.assertEqual(job["error.out"][0], "Python 3.12.1\n")

--- a/tests/flex/test_executablecontainer_conda.py
+++ b/tests/flex/test_executablecontainer_conda.py
@@ -40,5 +40,5 @@ class TestExecutableContainerConda(TestWithProject):
         job = self.project.create.job.PythonVersionJob(job_name="job_conda_path")
         job.server.conda_environment_path = self.project.conda_environment.py312
         job.run()
-        self.assertEqual(job.output['command_line'], "Python 3.12.1\n")
+        self.assertEqual(job.output['stdout'], "Python 3.12.1\n")
         self.assertEqual(job["error.out"][0], "Python 3.12.1\n")

--- a/tests/flex/test_wrap_executable.py
+++ b/tests/flex/test_wrap_executable.py
@@ -43,5 +43,5 @@ class TestWrapExecutable(TestWithProject):
         )
         job.input.energy = 2.0
         job.run()
-        self.assertEqual(job.output['command_line'], "")
+        self.assertEqual(job.output['stdout'], "")
         self.assertEqual(job.output.energy, 2.0)

--- a/tests/flex/test_wrap_executable.py
+++ b/tests/flex/test_wrap_executable.py
@@ -25,6 +25,7 @@ class TestWrapExecutable(TestWithProject):
             input_file_lst=None,
             execute_job=True,
         )
+        self.assertTrue("Python" in python_version_step["error.out"][0])
         self.assertTrue(python_version_step.status.finished)
         self.assertEqual(
             python_version_step.files.error_out,
@@ -42,4 +43,5 @@ class TestWrapExecutable(TestWithProject):
         )
         job.input.energy = 2.0
         job.run()
+        self.assertEqual(job.output['command_line'], "")
         self.assertEqual(job.output.energy, 2.0)


### PR DESCRIPTION
Previously, the output of the command line was only stored in the `error.out` file, now it is also directly stored in the datacontainer of the job output: `job.output.command_line`