### PR TITLE
warn if job could not be deleted

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1782,7 +1782,7 @@ class Project(ProjectPath, HasGroups):
                 self.remove_job(job_specifier=job_id)
                 state.logger.debug("Remove job with ID {0} ".format(job_id))
             except (IndexError, Exception):
-                state.logger.debug("Could not remove job with ID {0} ".format(job_id))
+                state.logger.warning("Could not remove job with ID {0} ".format(job_id))
 
     def _remove_files(self, pattern="*"):
         """


### PR DESCRIPTION
Since debug messages are not printed by default I think this should be a warning. In particular since it resolves exceptions.