### PR TITLE
Executable: Switch from HasHDF to HasDict

### DIFF
--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -3,7 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
-from pyiron_base.interfaces.object import HasStorage
+from pyiron_base.interfaces.has_dict import HasDict
+from pyiron_base.storage.datacontainer import DataContainer
 from pyiron_base.state import state
 
 """
@@ -22,7 +23,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-class Executable(HasStorage):
+class Executable(HasDict):
     __hdf_version__ = "0.3.0"
 
     def __init__(
@@ -42,6 +43,7 @@ class Executable(HasStorage):
             overwrite_nt_flag (bool):
         """
         super().__init__()
+        self.storage = DataContainer()
         self.storage.table_name = "executable"
 
         if path_binary_codes is None:

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -238,13 +238,9 @@ class Executable(HasDict):
             "mpi",
             "accepted_return_codes",
         ]
-        self.storage.update(
-            {
-                key: executable_dict["executable"][key]
-                for key in data_container_keys
-                if key in executable_dict["executable"].keys()
-            }
-        )
+        for key in data_container_keys:
+            if key in executable_dict["executable"]:
+                self.storage[key] = executable_dict["executable"][key]
         if executable_dict["executable"]["READ_ONLY"]:
             self.storage.read_only = True
 

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -237,7 +237,7 @@ class Executable(HasStorage):
             'accepted_return_codes'
         ]
         self.storage.update({
-            executable_dict["executable"][key]
+            key: executable_dict["executable"][key]
             for key in data_container_keys
             if key in executable_dict["executable"].keys()
         })

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -23,6 +23,8 @@ __date__ = "Sep 1, 2017"
 
 
 class Executable(HasStorage):
+    __hdf_version__ = "0.3.0"
+
     def __init__(
         self,
         path_binary_codes=None,
@@ -216,6 +218,31 @@ class Executable(HasStorage):
             self.storage.mpi = True
         else:
             self.storage.mpi = False
+
+    def to_dict(self):
+        executable_dict = self._type_to_dict()
+        executable_storage_dict = self.storage._type_to_dict()
+        executable_storage_dict["READ_ONLY"] = self.storage._read_only
+        executable_storage_dict.update(self.storage.to_builtin())
+        executable_dict["executable"] = executable_storage_dict
+        return executable_dict
+
+    def from_dict(self, executable_dict):
+        data_container_keys = [
+            'version',
+            'name',
+            'operation_system_nt',
+            'executable',
+            'mpi',
+            'accepted_return_codes'
+        ]
+        self.storage.update({
+            executable_dict["executable"][key]
+            for key in data_container_keys
+            if key in executable_dict["executable"].keys()
+        })
+        if executable_dict["executable"]['READ_ONLY']:
+            self.storage.read_only = True
 
     def get_input_for_subprocess_call(self, cores, threads, gpus=None):
         """

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -229,19 +229,21 @@ class Executable(HasStorage):
 
     def from_dict(self, executable_dict):
         data_container_keys = [
-            'version',
-            'name',
-            'operation_system_nt',
-            'executable',
-            'mpi',
-            'accepted_return_codes'
+            "version",
+            "name",
+            "operation_system_nt",
+            "executable",
+            "mpi",
+            "accepted_return_codes",
         ]
-        self.storage.update({
-            executable_dict["executable"][key]
-            for key in data_container_keys
-            if key in executable_dict["executable"].keys()
-        })
-        if executable_dict["executable"]['READ_ONLY']:
+        self.storage.update(
+            {
+                executable_dict["executable"][key]
+                for key in data_container_keys
+                if key in executable_dict["executable"].keys()
+            }
+        )
+        if executable_dict["executable"]["READ_ONLY"]:
             self.storage.read_only = True
 
     def get_input_for_subprocess_call(self, cores, threads, gpus=None):

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1048,8 +1048,8 @@ class GenericJob(JobCore, HasDict):
             "exclude_groups_hdf": self._exclude_groups_hdf,
         }
         data_dict["server"] = self._server.to_dict()
+        self._executable_activate_mpi()
         if self._executable is not None:
-            self._executable_activate_mpi()
             data_dict["executable"] = self._executable.to_dict()
         if self._import_directory is not None:
             data_dict["import_directory"] = self._import_directory
@@ -1063,7 +1063,7 @@ class GenericJob(JobCore, HasDict):
             self._import_directory = job_dict["import_directory"]
         self._server.from_dict(server_dict=job_dict["server"])
         if "executable" in job_dict.keys() and job_dict["executable"] is not None:
-            self._executable.from_dict(job_dict["executable"])
+            self.executable.from_dict(job_dict["executable"])
         input_dict = job_dict["input"]
         if "generic_dict" in input_dict.keys():
             generic_dict = input_dict["generic_dict"]

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1062,7 +1062,7 @@ class GenericJob(JobCore, HasDict):
         if "import_directory" in job_dict.keys():
             self._import_directory = job_dict["import_directory"]
         self._server.from_dict(server_dict=job_dict["server"])
-        if "executable" in job_dict.keys():
+        if "executable" in job_dict.keys() and job_dict["executable"] is not None:
             self._executable.from_dict(job_dict["executable"])
         input_dict = job_dict["input"]
         if "generic_dict" in input_dict.keys():

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1125,9 +1125,7 @@ class GenericJob(JobCore, HasDict):
         if "executable" in self._hdf5.list_groups():
             exe_dict = self._hdf5["executable/executable"].to_object().to_builtin()
             exe_dict["READ_ONLY"] = self._hdf5["executable/executable/READ_ONLY"]
-            job_dict["executable"] = {
-                "executable": exe_dict
-            }
+            job_dict["executable"] = {"executable": exe_dict}
         self.from_dict(job_dict=job_dict)
 
     def save(self):

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1048,6 +1048,9 @@ class GenericJob(JobCore, HasDict):
             "exclude_groups_hdf": self._exclude_groups_hdf,
         }
         data_dict["server"] = self._server.to_dict()
+        if self._executable is not None:
+            self._executable_activate_mpi()
+            data_dict["executable"] = self._executable.to_dict()
         if self._import_directory is not None:
             data_dict["import_directory"] = self._import_directory
         if self._executor_type is not None:
@@ -1059,6 +1062,8 @@ class GenericJob(JobCore, HasDict):
         if "import_directory" in job_dict.keys():
             self._import_directory = job_dict["import_directory"]
         self._server.from_dict(server_dict=job_dict["server"])
+        if "executable" in job_dict.keys():
+            self._executable.from_dict(job_dict["executable"])
         input_dict = job_dict["input"]
         if "generic_dict" in input_dict.keys():
             generic_dict = input_dict["generic_dict"]
@@ -1086,16 +1091,8 @@ class GenericJob(JobCore, HasDict):
             hdf (ProjectHDFio): HDF5 group object - optional
             group_name (str): HDF5 subgroup name - optional
         """
-
         self._set_hdf(hdf=hdf, group_name=group_name)
-        self._executable_activate_mpi()
-
-        # Write combined dictionary to HDF5
         self._hdf5.write_dict(data_dict=self.to_dict())
-
-        # Write remaining objects to HDF5
-        if self._executable is not None:
-            self.executable.to_hdf(self._hdf5)
 
     @classmethod
     def from_hdf_args(cls, hdf):

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -45,8 +45,8 @@ class TestExecutableContainer(TestWithProject):
             'mpi': False,
             'accepted_return_codes': [0]
         }
-        self.assertEqual(job.executable._storage.to_builtin(), executable_dict)
-        self.assertEqual(job_reload.executable._storage.to_builtin(), executable_dict)
+        self.assertEqual(job.executable.storage.to_builtin(), executable_dict)
+        self.assertEqual(job_reload.executable.storage.to_builtin(), executable_dict)
         del JOB_CLASS_DICT["CatJob"]
 
     def test_create_job_factory_with_project(self):


### PR DESCRIPTION
This pull request reverts parts of https://github.com/pyiron/pyiron_base/pull/728 to simplify the `to_dict()` and `from_dict()` interface of the `GenericJob` class. In the future the interface should use `__getstate__()` and `__setstate__()`. 