### PR TITLE
Mac Os - pympipool: Use localhost for connection rather than the network address

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1538,7 +1538,7 @@ class GenericJob(JobCore, HasDict):
         elif self._executor_type == "pympipool.mpi.executor.PyMPIExecutor" and platform.system() == "Darwin":
             # The Mac firewall might prevent connections based on the network address - especially Github CI
             return import_class(self._executor_type)(max_workers=max_workers, hostname_localhost=True)
-        elif isinstance(self._executor_type, str) and platform.system() == "Linux":
+        elif isinstance(self._executor_type, str):
             return import_class(self._executor_type)(max_workers=max_workers)
         else:
             raise TypeError("The self.executor_type has to be a string.")

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1535,9 +1535,14 @@ class GenericJob(JobCore, HasDict):
             raise ValueError(
                 "No executor type defined - Please set self.executor_type."
             )
-        elif self._executor_type == "pympipool.mpi.executor.PyMPIExecutor" and platform.system() == "Darwin":
+        elif (
+            self._executor_type == "pympipool.mpi.executor.PyMPIExecutor"
+            and platform.system() == "Darwin"
+        ):
             # The Mac firewall might prevent connections based on the network address - especially Github CI
-            return import_class(self._executor_type)(max_workers=max_workers, hostname_localhost=True)
+            return import_class(self._executor_type)(
+                max_workers=max_workers, hostname_localhost=True
+            )
         elif isinstance(self._executor_type, str) and platform.system() == "Linux":
             return import_class(self._executor_type)(max_workers=max_workers)
         else:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -9,6 +9,7 @@ from concurrent.futures import Future, Executor
 from datetime import datetime
 from inspect import isclass
 import os
+import platform
 import posixpath
 import warnings
 
@@ -1534,7 +1535,10 @@ class GenericJob(JobCore, HasDict):
             raise ValueError(
                 "No executor type defined - Please set self.executor_type."
             )
-        elif isinstance(self._executor_type, str):
+        elif self._executor_type == "pympipool.mpi.executor.PyMPIExecutor" and platform.system() == "Darwin":
+            # The Mac firewall might prevent connections based on the network address - especially Github CI
+            return import_class(self._executor_type)(max_workers=max_workers, hostname_localhost=True)
+        elif isinstance(self._executor_type, str) and platform.system() == "Linux":
             return import_class(self._executor_type)(max_workers=max_workers)
         else:
             raise TypeError("The self.executor_type has to be a string.")


### PR DESCRIPTION
While this is primarily a Github related issues as discussed in https://github.com/actions/runner-images/issues/8649 and local versions run fine. I now disabled the support for multiple nodes on macOS, as most computer clusters use Linux anyway. This is the same issue we discussed in `pympipool` in https://github.com/pyiron/pympipool/pull/258 