### PR TITLE
Move recursive loading of DataContainer to HDF5Content

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -964,6 +964,7 @@ class JobCore(HasGroups):
             )
             return _job_read_file(self, item)
 
+        name_lst = item.split("/")
         item_obj = name_lst[0]
         if item_obj in self._list_ext_childs():
             # ToDo: Murn['strain_0.9'] - sucht im HDF5 file, dort gibt es aber die entsprechenden Gruppen noch nicht.

--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -953,7 +953,7 @@ class JobCore(HasGroups):
             dict, list, float, int, :class:`.DataContainer`, None: data or data object; if nothing is found None is returned
         """
         # first try to access HDF5 directly to make the common case fast
-        value = recursive_load_from_hdf(self._project_hdf5, item)
+        value = recursive_load_from_hdf(self._hdf5, item)
         if value is not None:
             return value
 

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -8,7 +8,7 @@ from pyiron_base.project.generic import Project
 from pyiron_base._tests import PyironTestCase
 
 
-class DatabasePropertyIntegration(PyironTestCase):
+class InspectTest(PyironTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -32,7 +32,7 @@ class InspectTest(PyironTestCase):
             job_inspect.content.input.__repr__(), job_inspect["input"].__repr__()
         )
         self.assertEqual(
-            sorted(dir(job_inspect.content.input)),
+            sorted((job_inspect.content.input).keys()),
             sorted(job_inspect["input"].list_nodes()
                     + job_inspect["input"].list_groups())
         )


### PR DESCRIPTION
This will allow users and internal code to use job.content[...] if they what they are looking for is saved in HDF5 storage and obviate the need to rely on job[...] which may be slow because it is also searching the compressed job files.

I will need some logic like this to fix the slow loading of pyiron_atomistics jobs.