### PR TITLE
Files: first check working directory then archive

### DIFF
--- a/pyiron_base/jobs/job/extension/files.py
+++ b/pyiron_base/jobs/job/extension/files.py
@@ -92,12 +92,18 @@ class FileBrowser:
         )
 
     def __getitem__(self, item):
-        if item not in _working_directory_list_files(
-            working_directory=self._working_directory
+        if item in _working_directory_list_files(
+            working_directory=self._working_directory,
+            include_archive=False,
         ):
+            return File(os.path.join(self._working_directory, item))
+        elif item in _working_directory_list_files(
+            working_directory=self._working_directory,
+            include_archive=True,
+        ):
+            return File(os.path.join(self._working_directory, item))
+        else:
             raise FileNotFoundError(item)
-
-        return File(os.path.join(self._working_directory, item))
 
     def __getattr__(self, item):
         if item.startswith("__") and item.endswith("__"):

--- a/pyiron_base/jobs/job/util.py
+++ b/pyiron_base/jobs/job/util.py
@@ -351,7 +351,7 @@ def _job_is_compressed(job):
     return _working_directory_is_compressed(working_directory=job.working_directory)
 
 
-def _working_directory_list_files(working_directory):
+def _working_directory_list_files(working_directory, include_archive=True):
     """
     Returns list of files in the jobs working directory.
 
@@ -359,22 +359,24 @@ def _working_directory_list_files(working_directory):
 
     Args:
         working_directory (str): working directory of the job object to inspect files in
+        include_archive (bool): include files in the .tag.gz archive
 
     Returns:
         list of str: file names
     """
     if os.path.isdir(working_directory):
         uncompressed_files_lst = os.listdir(working_directory)
-        if _working_directory_is_compressed(working_directory=working_directory):
+        if include_archive and _working_directory_is_compressed(
+            working_directory=working_directory
+        ):
             compressed_job_name = _get_compressed_job_name(
                 working_directory=working_directory
             )
             with tarfile.open(compressed_job_name, "r") as tar:
-                job_archive_name = os.path.basename(compressed_job_name)
                 compressed_files_lst = [
                     member.name for member in tar.getmembers() if member.isfile()
                 ]
-                uncompressed_files_lst.remove(job_archive_name)
+                uncompressed_files_lst.remove(os.path.basename(compressed_job_name))
                 return uncompressed_files_lst + compressed_files_lst
         else:
             return uncompressed_files_lst


### PR DESCRIPTION
I see the restarting of jobs getting very slow as we always check the archive if the file is located in there, still commonly restart files are stored outside of the archive. This pull request introduced an additions `os.listdir()` for the case when the file is inside the archive, but only calls this `os.listdir()` for the case the file is outside the archive. 