### PR TITLE
GenericJob: extend the compress() function

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -209,6 +209,8 @@ class JobCore(HasGroups):
         self._import_directory = None
         self._database_property = DatabaseProperties()
         self._hdf5_content = HDF5Content(project_hdf5=self._hdf5)
+        self._files_to_remove = list()
+        self._files_to_compress = list()
 
     @property
     def content(self):
@@ -384,6 +386,14 @@ class JobCore(HasGroups):
             project (ProjectHDFio): HDF5 project
         """
         self._hdf5 = project.copy()
+
+    @property
+    def files_to_compress(self):
+        return self._files_to_compress
+
+    @property
+    def files_to_remove(self):
+        return self._files_to_remove
 
     def relocate_hdf5(self, h5_path=None):
         """
@@ -1061,14 +1071,22 @@ class JobCore(HasGroups):
         childs = self.list_childs()
         return list(set(childs) - set(nodes))
 
-    def compress(self, files_to_compress=None):
+    def compress(self, files_to_compress=None, files_to_remove=None):
         """
         Compress the output files of a job object.
 
         Args:
             files_to_compress (list):
         """
-        _job_compress(job=self, files_to_compress=files_to_compress)
+        if files_to_compress is None and len(self._files_to_compress) != 0:
+            files_to_compress = self._files_to_compress
+        elif files_to_compress is None:
+            files_to_compress = self.files.list()
+        if files_to_remove is None:
+            files_to_remove = self._files_to_remove
+        else:
+            files_to_remove = []
+        _job_compress(job=self, files_to_compress=files_to_compress, files_to_remove=files_to_remove)
 
     def decompress(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1069,6 +1069,10 @@ class GenericJob(JobCore, HasDict):
             data_dict["import_directory"] = self._import_directory
         if self._executor_type is not None:
             data_dict["executor_type"] = self._executor_type
+        if len(self._files_to_compress) > 0:
+            data_dict["files_to_compress"] = self._files_to_compress
+        if len(self._files_to_remove) > 0:
+            data_dict["files_to_compress"] = self._files_to_remove
         return data_dict
 
     def from_dict(self, job_dict):

--- a/pyiron_base/jobs/job/util.py
+++ b/pyiron_base/jobs/job/util.py
@@ -302,7 +302,7 @@ def _job_compress(job, files_to_compress=[], files_to_remove=[]):
                     if "tar" not in name and not stat.S_ISFIFO(os.stat(name).st_mode):
                         tar.add(name)
             for name in files_to_compress:
-                if "tar" not in name:
+                if name != _job_compressed_name(job):
                     delete_file_or_folder(
                         fullname=os.path.join(job.working_directory, name)
                     )


### PR DESCRIPTION
For codes like VASP we typically remove certain files before we compress the working directory and other files we leave out of the archive. This is now possible using `job.files_to_compress` and `job.files_to_remove`. Both properties return a list, so the user can append additional files.