### PR TITLE
Unlock when calling from_hdf for DataContainer

### DIFF
--- a/pyiron_base/interfaces/lockable.py
+++ b/pyiron_base/interfaces/lockable.py
@@ -15,6 +15,7 @@ and `object.__getattribute__` to avoid any overloading attribute access that
 sibling classes may bring in.
 """
 
+from contextlib import nullcontext
 from typing import Optional, Literal
 from functools import wraps
 import warnings
@@ -348,4 +349,7 @@ class Lockable:
 
             There is a small asymmetry between these two methods.  :meth:`.lock` can only be done once (meaningfully), while :meth:`.unlocked` is a context manager and can be called multiple times.
         """
-        return _UnlockContext(self)
+        if self.read_only:
+            return _UnlockContext(self)
+        else:
+            return nullcontext(self)

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -7,7 +7,6 @@ Data structure for versatile data handling.
 
 import copy
 import json
-import warnings
 from collections.abc import Sequence, Set, Mapping, MutableMapping
 
 import numpy as np
@@ -817,6 +816,7 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
         warnings.warn("Unlock previously locked object!")
         super()._on_unlock()
 
+
 class DataContainer(DataContainerBase, HasHDF):
     __doc__ = f"""{DataContainerBase.__doc__}
 
@@ -930,7 +930,10 @@ class DataContainer(DataContainerBase, HasHDF):
                     if n in _internal_hdf_nodes:
                         continue
                     items.append(
-                        (*normalize_key(n), hdf[n] if not self._lazy else HDFStub(hdf, n))
+                        (
+                            *normalize_key(n),
+                            hdf[n] if not self._lazy else HDFStub(hdf, n),
+                        )
                     )
                 for g in hdf.list_groups():
                     items.append(

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -815,12 +815,16 @@ class DataContainerBase(MutableMapping, Lockable, HasGroups):
     # Lockable overload
     def _on_unlock(self):
         from sys import version_info as python_version
+
         # a little dance to ensure that warning appear at the correct call
         # site, i.e. where someone either calls unlocked() or sets read_only
         if python_version[0] == 3 and python_version[1] >= 12:
             from pyiron_base.interfaces.lockable import __file__ as lock_file
-            warnings.warn("Unlock previously locked object!",
-                          skip_file_prefixes=(__file__, lock_file))
+
+            warnings.warn(
+                "Unlock previously locked object!",
+                skip_file_prefixes=(__file__, lock_file),
+            )
         else:
             # stacklevel is so high, because _on_unlock is called after several
             # layers of Lockable and DataContainer.__setattr__ when used to set

--- a/tests/generic/test_datacontainer.py
+++ b/tests/generic/test_datacontainer.py
@@ -688,8 +688,10 @@ class TestDataContainer(TestWithCleanProject):
 
         with warnings.catch_warnings(record=True) as w:
             pl.read_only = False
-            self.assertEqual(
-                len(w), 1, "Trying to change read-only flag back didn't raise warning."
+            # since read_only is propageted recursively through sub data
+            # containers, this can raise more than one warning
+            self.assertGreater(
+                len(w), 0, "Trying to change read-only flag back didn't raise warning."
             )
 
     def test_recursive_append(self):


### PR DESCRIPTION
Reloading a `DataContainer` object threw a warning that the object was locked when `self.clear()` was called in `from_hdf`.

Change 1: Run `from_hdf` while unlocked.

Change 2: Remove additional warning that the object is being unlocked.