### PR TITLE
meaningful error messages

### DIFF
--- a/pyiron_base/utils/error.py
+++ b/pyiron_base/utils/error.py
@@ -145,7 +145,10 @@ def retry(
             return func()
         except error as e:
             logger.warn(
-                f"{msg} Trying again in {delay}s. Tried {i + 1} times so far..."
+                f"{e}"
+            )
+            logger.warn(
+                f"Trying again in {delay}s. Tried {i + 1} times so far..."
             )
             time.sleep(delay)
             delay *= delay_factor


### PR DESCRIPTION
Why do you replace the real error message with a custom message that does not know what happened?  
https://github.com/pyiron/pyiron_base/blob/0a6c4bb166908380761daa494d9250322c631cb1/pyiron_base/utils/error.py#L148

Example:
`FATAL:  password authentication failed for user "seibll"` is reported as `WARNING - Database busy with too many connections. Trying again in 0.1s. Tried 1 times so far...`

The real error message is only shown after all retries have failed.

Suggesting to print it immediately.