### PR TITLE
Force user to use `bool` for `delete_existing_job`

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -759,7 +759,8 @@ class GenericJob(JobCore, HasDict):
         """
         if not isinstance(delete_existing_job, bool):
             raise ValueError(
-                "We got delete_existing_job = " + str(delete_existing_job)
+                "We got delete_existing_job = "
+                + str(delete_existing_job)
                 + ". If you meant to delete the job, set delete_existing_job"
                 + " = True"
             )

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -759,10 +759,9 @@ class GenericJob(JobCore, HasDict):
         """
         if not isinstance(delete_existing_job, bool):
             raise ValueError(
-                "We got delete_existing_job = "
-                + str(delete_existing_job)
-                + ". If you meant to delete the job, set delete_existing_job"
-                + " = True"
+                f"We got delete_existing_job = {delete_existing_job}. If you"
+                " meant to delete the job, set delete_existing_job"
+                " = True"
             )
         with catch_signals(self.signal_intercept):
             if run_again:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -759,8 +759,9 @@ class GenericJob(JobCore, HasDict):
         """
         if not isinstance(delete_existing_job, bool):
             raise ValueError(
-                "We got delete_existing_job = " + delete_existing_job + ". If"
-                " you meant to delete the job, set delete_existing_job = True"
+                "We got delete_existing_job = " + str(delete_existing_job)
+                + ". If you meant to delete the job, set delete_existing_job"
+                + " = True"
             )
         with catch_signals(self.signal_intercept):
             if run_again:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -757,6 +757,11 @@ class GenericJob(JobCore, HasDict):
             run_mode (str): ['modal', 'non_modal', 'queue', 'manual'] overwrites self.server.run_mode
             run_again (bool): Same as delete_existing_job (deprecated)
         """
+        if not isinstance(delete_existing_job, bool):
+            raise ValueError(
+                "We got delete_existing_job = " + delete_existing_job + ". If"
+                " you meant to delete the job, set delete_existing_job = True"
+            )
         with catch_signals(self.signal_intercept):
             if run_again:
                 delete_existing_job = True

--- a/pyiron_base/jobs/job/jobtype.py
+++ b/pyiron_base/jobs/job/jobtype.py
@@ -67,6 +67,11 @@ class JobType:
         Returns:
             GenericJob: object of type class_name
         """
+        if not isinstance(delete_existing_job, bool):
+            raise ValueError(
+                "We got delete_existing_job = " + delete_existing_job + ". If"
+                " you meant to delete the job, set delete_existing_job = True"
+            )
         job_name = _get_safe_job_name(job_name)
         cls.job_class_dict = job_class_dict or cls._job_class_dict
         if isinstance(class_name, str):

--- a/pyiron_base/jobs/job/jobtype.py
+++ b/pyiron_base/jobs/job/jobtype.py
@@ -69,8 +69,8 @@ class JobType:
         """
         if not isinstance(delete_existing_job, bool):
             raise ValueError(
-                "We got delete_existing_job = " + delete_existing_job + ". If"
-                " you meant to delete the job, set delete_existing_job = True"
+                f"We got delete_existing_job = {delete_existing_job}. If you"
+                " meant to delete the job, set delete_existing_job = True"
             )
         job_name = _get_safe_job_name(job_name)
         cls.job_class_dict = job_class_dict or cls._job_class_dict

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -422,6 +422,18 @@ class TestGenericJob(TestWithFilledProject):
     def test_run_if_finished(self):
         pass
 
+    def test_delete_existing_job_to_be_bool(self):
+        with self.assertRaises(
+            ValueError, msg="`delete_existing_job = like_this` must not pass"
+        ):
+            job = self.project.create_job(ToyJob, "set_non_bool", "like_this")
+        with self.assertRaises(
+            ValueError, msg="`delete_existing_job = 10` must not pass"
+        ):
+            job = self.project.create_job(ToyJob, "set_non_bool_10")
+            job.input.data_in = 10
+            job.run(job.input.data_in)
+
     def test_run_with_delete_existing_job_for_aborted_jobs(self):
         job = self.project.create_job(ToyJob, "rerun_aborted")
         with self.subTest("Drop to aborted if validate_ready_to_run fails"):


### PR DESCRIPTION
I constantly fall into the trap to set a job name like:

```python
job = pr.create.job.Lammps("lmp", strain)
```

without realising I had to write more parentheses. As the first argument after the job name is `delete_existing_job`, this often erases the job, which just shouldn't happen for a small typo.