### PR TITLE
Replace copy_tree from distutils by copytree from shutil because dist…

### DIFF
--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -1,8 +1,7 @@
 import os
 import pandas
 import numpy as np
-from shutil import rmtree
-from distutils.dir_util import copy_tree
+from shutil import rmtree, copytree
 import tarfile
 from pyiron_base.project.archiving.shared import getdir
 from pyiron_base.utils.instance import static_isinstance
@@ -57,7 +56,7 @@ def import_jobs(project_instance, archive_directory, df, compressed=True):
     des = project_instance.path
     # source folder; archive folder
     src = os.path.abspath(archive_directory)
-    copy_tree(src, des)
+    copytree(src, des, dirs_exist_ok=True)
     if compressed:
         rmtree(src)
 

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -41,7 +41,6 @@ from pyiron_base.state.publications import publications
 from pathlib import Path
 from pyiron_base.interfaces.singleton import Singleton
 from typing import Union, Dict, List
-from distutils.util import strtobool
 from copy import deepcopy
 
 __author__ = "Jan Janssen, Liam Huber"
@@ -57,6 +56,25 @@ __date__ = "Sep 1, 2017"
 
 
 PYIRON_DICT_NAME = "PYIRON"
+
+
+def strtobool (val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Originally part of `distutils.util.strtobool`, but copied and pasted as
+    `distutils` was going to be removed from python 3.12.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 class Settings(metaclass=Singleton):

--- a/pyiron_base/state/settings.py
+++ b/pyiron_base/state/settings.py
@@ -38,6 +38,7 @@ import warnings
 from configparser import ConfigParser
 from pyiron_base.state.logger import logger
 from pyiron_base.state.publications import publications
+from pyiron_base.utils.strtobool import strtobool
 from pathlib import Path
 from pyiron_base.interfaces.singleton import Singleton
 from typing import Union, Dict, List
@@ -56,25 +57,6 @@ __date__ = "Sep 1, 2017"
 
 
 PYIRON_DICT_NAME = "PYIRON"
-
-
-def strtobool (val):
-    """Convert a string representation of truth to true (1) or false (0).
-
-    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
-    'val' is anything else.
-
-    Originally part of `distutils.util.strtobool`, but copied and pasted as
-    `distutils` was going to be removed from python 3.12.
-    """
-    val = val.lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
-        return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
-        return 0
-    else:
-        raise ValueError("invalid truth value %r" % (val,))
 
 
 class Settings(metaclass=Singleton):

--- a/pyiron_base/utils/strtobool.py
+++ b/pyiron_base/utils/strtobool.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+"""
+Utility functions used in pyiron.
+In order to be accessible from anywhere in pyiron, they *must* remain free of
+any imports from pyiron!
+"""
+
+
+__author__ = "Joerg Neugebauer, Jan Janssen"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "1.0"
+__maintainer__ = "Jan Janssen"
+__email__ = "janssen@mpie.de"
+__status__ = "production"
+__date__ = "Sep 1, 2017"
+
+
+def strtobool(val: str):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Originally part of `distutils.util.strtobool`, but copied and pasted as
+    `distutils` was going to be removed from python 3.12.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/pyiron_base/utils/strtobool.py
+++ b/pyiron_base/utils/strtobool.py
@@ -8,7 +8,6 @@ In order to be accessible from anywhere in pyiron, they *must* remain free of
 any imports from pyiron!
 """
 
-
 __author__ = "Joerg Neugebauer, Jan Janssen"
 __copyright__ = (
     "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "

--- a/tests/utils/test_strtobool.py
+++ b/tests/utils/test_strtobool.py
@@ -14,5 +14,6 @@ class TestStrtobool(unittest.TestCase):
         with self.assertRaises(ValueError):
             strtobool("Vegetarians do not eat Bratwurst")
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/test_strtobool.py
+++ b/tests/utils/test_strtobool.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pyiron_base.utils.strtobool import strtobool
+
+
+class TestStrtobool(unittest.TestCase):
+    def test_letters(self):
+        for val in ("y", "yes", "t", "true", "on", "1"):
+            self.assertTrue(strtobool(val))
+        for val in ("Y", "YEs", "T", "tRue", "oN", "1"):
+            self.assertTrue(strtobool(val))
+        for val in ("n", "no", "f", "false", "off", "0"):
+            self.assertFalse(strtobool(val))
+        with self.assertRaises(ValueError):
+            strtobool("Vegetarians do not eat Bratwurst")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…utils is going to be removed from python 3.12

I stumbled upon [this article](https://stackoverflow.com/questions/10047521/how-to-copy-directory-with-all-file-from-c-xxx-yyy-to-c-zzz-in-python while trying to fix the [archiving problem](https://github.com/pyiron/pyiron_base/issues/1444) so I did the change.