### PR TITLE
[patch] restore forbidding duplicate imports

### DIFF
--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -27,8 +27,6 @@ def extract_archive(archive_directory):
 
 
 def import_jobs(project_instance, archive_directory, df, compressed=True):
-    if len(set(df["job"]) & set(project_instance.job_table().job)) > 0:
-        raise ValueError("Overlapping", df["job"], project_instance.job_table().job)
     # Copy HDF5 files
     # if the archive_directory is a path(string)/name of the compressed file
     if static_isinstance(

--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -27,6 +27,8 @@ def extract_archive(archive_directory):
 
 
 def import_jobs(project_instance, archive_directory, df, compressed=True):
+    if len(set(df["job"]) & set(project_instance.job_table().job)) > 0:
+        raise ValueError("Overlapping", df["job"], project_instance.job_table().job)
     # Copy HDF5 files
     # if the archive_directory is a path(string)/name of the compressed file
     if static_isinstance(

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -72,6 +72,7 @@ class TestUnpacking(PyironTestCase):
         compare_obj = dircmp(path_original, path_import)
         self.assertEqual(len(compare_obj.diff_files), 0)
 
+    @unittest.skip("Imports the same name fails")
     def test_unpack_to_nested_project(self):
         pr = self.pr.open("nested")
         pr_imp = pr.open("imported")

--- a/tests/archiving/test_import.py
+++ b/tests/archiving/test_import.py
@@ -72,7 +72,6 @@ class TestUnpacking(PyironTestCase):
         compare_obj = dircmp(path_original, path_import)
         self.assertEqual(len(compare_obj.diff_files), 0)
 
-    @unittest.skip("Imports the same name fails")
     def test_unpack_to_nested_project(self):
         pr = self.pr.open("nested")
         pr_imp = pr.open("imported")
@@ -105,6 +104,7 @@ class TestUnpacking(PyironTestCase):
             rmtree(pack_path)
         except Exception as err_msg:
             print(f"deleting unsuccessful: {err_msg}")
+        pr.remove(enable=True)
 
     def test_import_uncompress(self):
         self.pr.pack(destination_path=self.arch_dir, compress=False)


### PR DESCRIPTION
This PR partially solves [this problem](https://github.com/pyiron/pyiron_base/issues/1444), as it forbids to import a job whose name already exists in the project, but I make it a draft because it does not clarify why the problem is occurring in the first place.