### PR TITLE
[minor] remove ImportAlarm and deprecator stuff from the API

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -45,6 +45,11 @@ from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.jobs.job.toolkit import Toolkit, BaseTools
 
 
+# Internal init
+from ._version import get_versions
+from pyiron_base.utils.jedi import fix_ipython_autocomplete
+
+
 # Give clear deprecation errors for objects removed from the 0.8.4 API
 from pyiron_snippets.import_alarm import ImportAlarm as _ImportAlarm
 from pyiron_snippets.deprecate import (
@@ -87,11 +92,6 @@ def deprecate_soon(*args, **kwargs):
         f"pyiron_base.deprecate_soon (a {_deprecate_soon.__class__.__name__} instance) "
         f"is deprecated. Please use pyiron_snippets.deprecate.deprecate_soon"
     ) from None
-
-
-# Internal init
-from ._version import get_versions
-from pyiron_base.utils.jedi import fix_ipython_autocomplete
 
 
 Project.register_tools("base", BaseTools)

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -75,16 +75,16 @@ def Deprecator(*args, **kwargs):
 def deprecate(*args, **kwargs):
     # The wrapper nature makes this not so easy to automate the message
     raise ValueError(
-        "pyiron_base.deprecate is deprecated. Please use "
-        "pyiron_snippets.deprecate.deprecate"
+        f"pyiron_base.deprecate (a {_deprecate.__class__.__name__} instance) is "
+        f"deprecated. Please use pyiron_snippets.deprecate.deprecate"
     ) from None
 
 
 def deprecate_soon(*args, **kwargs):
     # The wrapper nature makes this not so easy to automate the message
     raise ValueError(
-        "pyiron_base.deprecate_soon is deprecated. Please use "
-        "pyiron_snippets.deprecate.deprecate_soon"
+        f"pyiron_base.deprecate_soon (a {_deprecate_soon.__class__.__name__} instance) "
+        f"is deprecated. Please use pyiron_snippets.deprecate.deprecate_soon"
     ) from None
 
 

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -44,9 +44,49 @@ from pyiron_base.interfaces.has_hdf import HasHDF
 
 from pyiron_base.jobs.job.toolkit import Toolkit, BaseTools
 
-# Expose snippets references in base API for backwards compatibility
-from pyiron_snippets.import_alarm import ImportAlarm
-from pyiron_snippets.deprecate import Deprecator, deprecate, deprecate_soon
+
+# Give clear deprecation errors for objects removed from the 0.8.4 API
+from pyiron_snippets.import_alarm import ImportAlarm as _ImportAlarm
+from pyiron_snippets.deprecate import (
+    Deprecator as _Deprecator,
+    deprecate as _deprecate,  # Just silently guaranteeing it's where we expect
+    deprecate_soon as _deprecate_soon  # Just silently guaranteeing it's where we expect
+)
+
+
+def _snippets_deprecation_string(obj, old_name):
+    return
+
+
+def ImportAlarm(*args, **kwargs):
+    raise ValueError(
+        f"pyiron_base.ImportAlarm is deprecated. Please use "
+        f"{_ImportAlarm.__module__}.{_ImportAlarm.__name__}"
+    ) from None
+
+
+def Deprecator(*args, **kwargs):
+    raise ValueError(
+        f"pyiron_base.Deprecator is deprecated. Please use "
+        f"{_Deprecator.__module__}.{_Deprecator.__name__}"
+    ) from None
+
+
+def deprecate(*args, **kwargs):
+    # The wrapper nature makes this not so easy to automate the message
+    raise ValueError(
+        f"pyiron_base.deprecate is deprecated. Please use "
+        f"pyiron_snippets.deprecate.deprecate"
+    ) from None
+
+
+def deprecate_soon(*args, **kwargs):
+    # The wrapper nature makes this not so easy to automate the message
+    raise ValueError(
+        f"pyiron_base.deprecate_soon is deprecated. Please use "
+        f"pyiron_snippets.deprecate.deprecate_soon"
+    ) from None
+
 
 # Internal init
 from ._version import get_versions

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -50,7 +50,8 @@ from pyiron_snippets.import_alarm import ImportAlarm as _ImportAlarm
 from pyiron_snippets.deprecate import (
     Deprecator as _Deprecator,
     deprecate as _deprecate,  # Just silently guaranteeing it's where we expect
-    deprecate_soon as _deprecate_soon,  # Just silently guaranteeing it's where we expect
+    deprecate_soon as _deprecate_soon,
+    # Just silently guaranteeing it's where we expect
 )
 
 

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -50,7 +50,7 @@ from pyiron_snippets.import_alarm import ImportAlarm as _ImportAlarm
 from pyiron_snippets.deprecate import (
     Deprecator as _Deprecator,
     deprecate as _deprecate,  # Just silently guaranteeing it's where we expect
-    deprecate_soon as _deprecate_soon  # Just silently guaranteeing it's where we expect
+    deprecate_soon as _deprecate_soon,  # Just silently guaranteeing it's where we expect
 )
 
 
@@ -75,16 +75,16 @@ def Deprecator(*args, **kwargs):
 def deprecate(*args, **kwargs):
     # The wrapper nature makes this not so easy to automate the message
     raise ValueError(
-        f"pyiron_base.deprecate is deprecated. Please use "
-        f"pyiron_snippets.deprecate.deprecate"
+        "pyiron_base.deprecate is deprecated. Please use "
+        "pyiron_snippets.deprecate.deprecate"
     ) from None
 
 
 def deprecate_soon(*args, **kwargs):
     # The wrapper nature makes this not so easy to automate the message
     raise ValueError(
-        f"pyiron_base.deprecate_soon is deprecated. Please use "
-        f"pyiron_snippets.deprecate.deprecate_soon"
+        "pyiron_base.deprecate_soon is deprecated. Please use "
+        "pyiron_snippets.deprecate.deprecate_soon"
     ) from None
 
 


### PR DESCRIPTION
With a helpful error message if you actually try to use any of them.

This follows up on @jan-janssen's [comment](https://github.com/pyiron/pyiron_base/pull/1455#pullrequestreview-2091440281), following the path of leaving the objects importable, but raising an error redirecting the user to the new location if they try to use it.

I did my best to ensure that our redirection message will stay consistent with any upstream changes in `pyiron_snippets`.

In order to seamlessly keep our downstream repositories working, it would be good to merge the following PRs to use `pyiron_snippets` before releasing these changes on `pyiron_base`:

For import alarm:
- https://github.com/pyiron/pyiron_atomistics/pull/1431
- https://github.com/pyiron/pyiron_gpl/pull/193
- https://github.com/pyiron/pyiron_continuum/pull/317
- https://github.com/pyiron/pyiron_contrib/pull/1066

For deprecator stuff:
- https://github.com/pyiron/pyiron_atomistics/pull/1432
- https://github.com/pyiron/pyiron_contrib/pull/1067