### PR TITLE
Fix typo in HDF5Content recursive loading

### DIFF
--- a/pyiron_base/jobs/job/core.py
+++ b/pyiron_base/jobs/job/core.py
@@ -151,7 +151,7 @@ def recursive_load_from_hdf(project_hdf5: ProjectHDFio, item: str):
             # where we are looking for the data container
             container_path = "/".join(name_lst[:-i])
             # where we are looking for data in the container
-            data_path = "/".join(name_lst[-1:])
+            data_path = "/".join(name_lst[-i:])
             yield container_path, data_path
 
     try:

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -9,12 +9,17 @@ from pyiron_base.project.generic import Project
 from pyiron_base._tests import PyironTestCase
 
 test_keys = ["my", "recursive", "test", "data"]
+
+
 def _wrap(k, *vs):
     if vs == ():
         return k
     else:
         return {k: _wrap(*vs)}
+
+
 test_data = _wrap(*test_keys)
+
 
 class InspectTest(PyironTestCase):
     @classmethod
@@ -57,19 +62,23 @@ class InspectTest(PyironTestCase):
                 try:
                     val = self.ham.content["user/test/" + container_path]
                     self.assertEqual(
-                            _wrap(*test_keys[i:]), val,
-                            "HDF5Content did not return correct value from "
-                            "recursive DataContainer!"
+                        _wrap(*test_keys[i:]),
+                        val,
+                        "HDF5Content did not return correct value from "
+                        "recursive DataContainer!",
                     )
                     # last val we get will be a str
                     if i + 1 != len(test_keys):
                         self.assertIsInstance(
-                                val, DataContainer,
-                                "HDF5Content did not return a DataContainers!"
+                            val,
+                            DataContainer,
+                            "HDF5Content did not return a DataContainers!",
                         )
                 except KeyError:
-                    self.fail("HDF5Content should not raise errors in partial "
-                              "access to recursive DataContainers")
+                    self.fail(
+                        "HDF5Content should not raise errors in partial "
+                        "access to recursive DataContainers"
+                    )
 
     def test_setitem(self):
         self.ham["user/output/some_value"] = 0.3

--- a/tests/job/test_hdf5content.py
+++ b/tests/job/test_hdf5content.py
@@ -57,7 +57,6 @@ class InspectTest(PyironTestCase):
         without explicit to_object() from job.content."""
         for i in range(len(test_keys)):
             container_path = "/".join(test_keys[:i])
-            data_path = "/".join(test_keys[i:])
             with self.subTest(container_path=container_path):
                 try:
                     val = self.ham.content["user/test/" + container_path]


### PR DESCRIPTION
Previously the recursive loading of DataContainers always tried to index only with last item of the given path, instead of properly shifting the split.  This fixes the issue and adds a test.