### PR TITLE
Add get_input_file_dict() in GenericJob

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -57,7 +57,7 @@ jobs:
         use-mamba: true
     - name: Test
       shell: bash -l {0}
-      timeout-minutes: 5
+      timeout-minutes: 6
       run: |
         python .ci_support/pyironconfig.py
         bash .ci_support/pip_install.sh

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -43,7 +43,7 @@ from pyiron_base.jobs.job.runfunction import (
     execute_job_with_external_executable,
 )
 from pyiron_base.jobs.job.util import (
-    _copy_restart_files,
+    _get_restart_copy_dict,
     _kill_child,
     _job_store_before_copy,
     _job_reload_after_copy,
@@ -458,12 +458,12 @@ class GenericJob(JobCore, HasDict):
                 "files_to_create": {
                     "WARNING_pyiron_modified_content": "".join(content)
                 },
-                "files_to_copy": {},
+                "files_to_copy": _get_restart_copy_dict(job=self),
             }
         else:
             return {
                 "files_to_create": {},
-                "files_to_copy": {},
+                "files_to_copy": _get_restart_copy_dict(job=self),
             }
 
     def collect_output(self):
@@ -1193,7 +1193,6 @@ class GenericJob(JobCore, HasDict):
         if self._check_if_input_should_be_written():
             self.project_hdf5.create_working_directory()
             self.write_input()
-            _copy_restart_files(job=self)
         self.status.created = True
         self._calculate_predecessor()
         print(

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -41,6 +41,7 @@ from pyiron_base.jobs.job.runfunction import (
     run_job_with_runmode_modal,
     run_job_with_runmode_queue,
     execute_job_with_external_executable,
+    write_input_files_from_input_dict,
 )
 from pyiron_base.jobs.job.util import (
     _get_restart_copy_dict,
@@ -429,12 +430,10 @@ class GenericJob(JobCore, HasDict):
         Call routines that generate the code specific input files
         Returns:
         """
-        input_dict = self.get_input_file_dict()
-        for file_name, content in input_dict["files_to_create"].items():
-            with open(os.path.join(self.working_directory, file_name), "w") as f:
-                f.writelines(content)
-        for file_name, source in input_dict["files_to_copy"].items():
-            shutil.copy(source, os.path.join(self.working_directory, file_name))
+        write_input_files_from_input_dict(
+            input_dict=self.get_input_file_dict(),
+            working_directory=self.working_directory,
+        )
 
     def get_input_file_dict(self) -> dict:
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -11,7 +11,6 @@ from inspect import isclass
 import os
 import platform
 import posixpath
-import shutil
 import warnings
 
 from h5io_browser.base import _read_hdf, _write_hdf

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -11,6 +11,7 @@ from inspect import isclass
 import os
 import platform
 import posixpath
+import shutil
 import warnings
 
 from h5io_browser.base import _read_hdf, _write_hdf

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -436,10 +436,15 @@ class GenericJob(JobCore, HasDict):
         for file_name, source in input_dict["files_to_copy"].items():
             shutil.copy(source, os.path.join(self.working_directory, file_name))
 
-    def get_input_file_dict(self):
+    def get_input_file_dict(self) -> dict:
         """
-        Write the input files for the external executable. This method has to be implemented in the individual
-        hamiltonians.
+        Get an hierarchical dictionary of input files. On the first level the dictionary is divided in file_to_create
+        and files_to_copy. Both are dictionaries use the file names as keys. In file_to_create the values are strings
+        which represent the content which is going to be written to the corresponding file. In files_to_copy the values
+        are the paths to the source files to be copied.
+
+        Returns:
+            dict: hierarchical dictionary of input files
         """
         if (
             state.settings.configuration["write_work_dir_warnings"]

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -454,7 +454,9 @@ class GenericJob(JobCore, HasDict):
                 "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly).",
             ]
             return {
-                "files_to_create": {"WARNING_pyiron_modified_content": "".join(content)},
+                "files_to_create": {
+                    "WARNING_pyiron_modified_content": "".join(content)
+                },
                 "files_to_copy": {},
             }
         else:

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -425,6 +425,18 @@ class GenericJob(JobCore, HasDict):
 
     def write_input(self):
         """
+        Call routines that generate the code specific input files
+        Returns:
+        """
+        input_dict = self.get_input_file_dict()
+        for file_name, content in input_dict["files_to_create"].items():
+            with open(os.path.join(self.working_directory, file_name), "w") as f:
+                f.writelines(content)
+        for file_name, source in input_dict["files_to_copy"].items():
+            shutil.copy(source, os.path.join(self.working_directory, file_name))
+
+    def get_input_file_dict(self):
+        """
         Write the input files for the external executable. This method has to be implemented in the individual
         hamiltonians.
         """
@@ -433,18 +445,23 @@ class GenericJob(JobCore, HasDict):
             and self._write_work_dir_warnings
             and not self._python_only_job
         ):
-            with open(
-                os.path.join(self.working_directory, "WARNING_pyiron_modified_content"),
-                "w",
-            ) as f:
-                f.write(
-                    "Files in this directory are intended to be written and read by pyiron. \n\n"
-                    "pyiron may transform user input to enhance performance, thus, use these files with care!\n"
-                    "Consult the log and/or the documentation to gain further information.\n\n"
-                    "To disable writing these warning files, specify \n"
-                    "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the "
-                    "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly)."
-                )
+            content = [
+                "Files in this directory are intended to be written and read by pyiron. \n\n",
+                "pyiron may transform user input to enhance performance, thus, use these files with care!\n",
+                "Consult the log and/or the documentation to gain further information.\n\n",
+                "To disable writing these warning files, specify \n",
+                "WRITE_WORK_DIR_WARNINGS=False in the .pyiron configuration file (or set the ",
+                "PYIRONWRITEWORKDIRWARNINGS environment variable accordingly).",
+            ]
+            return {
+                "files_to_create": {"WARNING_pyiron_modified_content": "".join(content)},
+                "files_to_copy": {},
+            }
+        else:
+            return {
+                "files_to_create": {},
+                "files_to_copy": {},
+            }
 
     def collect_output(self):
         """

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import multiprocessing
 import os
 import posixpath
+import shutil
 import subprocess
 
 from jinja2 import Template
@@ -773,6 +774,14 @@ def multiprocess_wrapper(
         raise ValueError("Either job_id or file_path have to be not None.")
     with catch_signals(job_wrap.job.signal_intercept):
         job_wrap.job.run_static()
+
+
+def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
+    for file_name, content in input_dict["files_to_create"].items():
+        with open(os.path.join(working_directory, file_name), "w") as f:
+            f.writelines(content)
+    for file_name, source in input_dict["files_to_copy"].items():
+        shutil.copy(source, os.path.join(working_directory, file_name))
 
 
 def _generate_flux_execute_string(job, database_is_disabled):

--- a/pyiron_base/jobs/job/util.py
+++ b/pyiron_base/jobs/job/util.py
@@ -216,6 +216,19 @@ def _is_valid_job_name(job_name):
         )
 
 
+def _get_restart_copy_dict(job):
+    copy_dict = {}
+    for i, actual_name in enumerate(
+        [os.path.basename(f) for f in job.restart_file_list]
+    ):
+        if actual_name in job.restart_file_dict.keys():
+            new_name = job.restart_file_dict[actual_name]
+        else:
+            new_name = os.path.basename(job.restart_file_list[i])
+        copy_dict[new_name] = job.restart_file_list[i]
+    return copy_dict
+
+
 def _copy_restart_files(job):
     """
     Internal helper function to copy the files required for the restart job.
@@ -224,17 +237,11 @@ def _copy_restart_files(job):
         raise ValueError(
             "The working directory is not yet available to copy restart files"
         )
-    for i, actual_name in enumerate(
-        [os.path.basename(f) for f in job.restart_file_list]
-    ):
-        if actual_name in job.restart_file_dict.keys():
-            new_name = job.restart_file_dict[actual_name]
-            shutil.copy(
-                job.restart_file_list[i],
-                posixpath.join(job.working_directory, new_name),
-            )
-        else:
-            shutil.copy(job.restart_file_list[i], job.working_directory)
+    for file_name, source in _get_restart_copy_dict(job=job).items():
+        shutil.copy(
+            source,
+            posixpath.join(job.working_directory, file_name),
+        )
 
 
 def _kill_child(job):


### PR DESCRIPTION
Implement the `write_input()` and `get_input_file_dict()` already in `pyiron_base`. The `write_input()` function defined here can then be reused in https://github.com/pyiron/pyiron_atomistics/pull/1446 and  https://github.com/pyiron/pyiron_atomistics/pull/1447 and only the `get_input_file_dict()` function is going to be overwritten / extended. 