### PR TITLE
Separate execute_subprocess() function

### DIFF
--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -614,6 +614,45 @@ def run_time_decorator(func):
     return wrapper
 
 
+def execute_subprocess(
+    executable, shell, conda_environment_name=None, conda_environment_path=None
+):
+    job_crashed, out = False, None
+    if conda_environment_name is None and conda_environment_path is None:
+        out = subprocess.run(
+            executable,
+            cwd=job.project_hdf5.working_directory,
+            shell=shell,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            check=True,
+            env=os.environ.copy(),
+        ).stdout
+    else:
+        import conda_subprocess
+
+        if job.server.conda_environment_name is not None:
+            prefix_name = job.server.conda_environment_name
+            prefix_path = None
+        else:
+            prefix_name = None
+            prefix_path = job.server.conda_environment_path
+
+        out = conda_subprocess.run(
+            executable,
+            cwd=job.project_hdf5.working_directory,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            check=True,
+            prefix_name=prefix_name,
+            prefix_path=prefix_path,
+        ).stdout
+
+    return out
+
+
 @run_time_decorator
 def execute_job_with_external_executable(job):
     """
@@ -634,45 +673,15 @@ def execute_job_with_external_executable(job):
         cores=job.server.cores, threads=job.server.threads, gpus=job.server.gpus
     )
     job_crashed, out = False, None
-    if (
-        job.server.conda_environment_name is None
-        and job.server.conda_environment_path is None
-    ):
-        try:
-            out = subprocess.run(
-                executable,
-                cwd=job.project_hdf5.working_directory,
-                shell=shell,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                check=True,
-                env=os.environ.copy(),
-            ).stdout
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            job_crashed, out = handle_failed_job(job=job, error=e)
-    else:
-        import conda_subprocess
-
-        if job.server.conda_environment_name is not None:
-            prefix_name = job.server.conda_environment_name
-            prefix_path = None
-        else:
-            prefix_name = None
-            prefix_path = job.server.conda_environment_path
-        try:
-            out = conda_subprocess.run(
-                executable,
-                cwd=job.project_hdf5.working_directory,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                check=True,
-                prefix_name=prefix_name,
-                prefix_path=prefix_path,
-            ).stdout
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            job_crashed, out = handle_failed_job(job=job, error=e)
+    try:
+        execute_subprocess(
+            executable=executable,
+            shell=shell,
+            conda_environment_name=job.server.conda_environment_name,
+            conda_environment_path=job.server.conda_environment_path,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        job_crashed, out = handle_failed_job(job=job, error=e)
 
     job._logger.info(
         "{}, status: {}, output: {}".format(job.job_info_str, job.status, out)

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -622,7 +622,6 @@ def execute_subprocess(
     conda_environment_name: Optional[str] = None,
     conda_environment_path: Optional[str] = None,
 ) -> str:
-    job_crashed, out = False, None
     if conda_environment_name is None and conda_environment_path is None:
         out = subprocess.run(
             executable,

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 import posixpath
 import subprocess
+from typing import Optional
 
 from jinja2 import Template
 from pyiron_snippets.deprecate import deprecate
@@ -615,13 +616,17 @@ def run_time_decorator(func):
 
 
 def execute_subprocess(
-    executable, shell, conda_environment_name=None, conda_environment_path=None
-):
+    executable: str,
+    shell: bool,
+    working_directory: str,
+    conda_environment_name: Optional[str] = None,
+    conda_environment_path: Optional[str] = None,
+) -> str:
     job_crashed, out = False, None
     if conda_environment_name is None and conda_environment_path is None:
         out = subprocess.run(
             executable,
-            cwd=job.project_hdf5.working_directory,
+            cwd=working_directory,
             shell=shell,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -641,7 +646,7 @@ def execute_subprocess(
 
         out = conda_subprocess.run(
             executable,
-            cwd=job.project_hdf5.working_directory,
+            cwd=working_directory,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,
@@ -677,6 +682,7 @@ def execute_job_with_external_executable(job):
         execute_subprocess(
             executable=executable,
             shell=shell,
+            working_directory=job.working_directory,
             conda_environment_name=job.server.conda_environment_name,
             conda_environment_path=job.server.conda_environment_path,
         )

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -636,12 +636,10 @@ def execute_subprocess(
     else:
         import conda_subprocess
 
-        if job.server.conda_environment_name is not None:
-            prefix_name = job.server.conda_environment_name
-            prefix_path = None
+        if conda_environment_name is not None:
+            conda_environment_path = None
         else:
-            prefix_name = None
-            prefix_path = job.server.conda_environment_path
+            conda_environment_name = None
 
         out = conda_subprocess.run(
             executable,
@@ -650,8 +648,8 @@ def execute_subprocess(
             stderr=subprocess.STDOUT,
             universal_newlines=True,
             check=True,
-            prefix_name=prefix_name,
-            prefix_path=prefix_path,
+            prefix_name=conda_environment_name,
+            prefix_path=conda_environment_path,
         ).stdout
 
     return out

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -676,7 +676,7 @@ def execute_job_with_external_executable(job):
     )
     job_crashed, out = False, None
     try:
-        execute_subprocess(
+        out = execute_subprocess(
             executable=executable,
             shell=shell,
             working_directory=job.working_directory,

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -638,8 +638,6 @@ def execute_subprocess(
 
         if conda_environment_name is not None:
             conda_environment_path = None
-        else:
-            conda_environment_name = None
 
         out = conda_subprocess.run(
             executable,


### PR DESCRIPTION
Primarily in preparation in for https://github.com/pyiron/pyiron_base/pull/1477 the `execute_subprocess()` function is separated from the `execute_job_with_external_executable()` function. In contrast to the `execute_job_with_external_executable()` function the `execute_subprocess()` function does not require a `job` object as input which simplifies the integration with `concurrent.futures.Executors`. 