### PR TITLE
ScriptJob: Replace write_input() with get_input_file_dict()

### DIFF
--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -290,17 +290,21 @@ class ScriptJob(GenericJob):
         if "custom_dict" in job_dict["input"].keys():
             self.input.update(job_dict["input"]["custom_dict"])
 
-    def write_input(self):
+    def get_input_file_dict(self):
         """
-        Copy the script to the working directory - only python scripts and jupyter notebooks are supported
+        Get an hierarchical dictionary of input files. On the first level the dictionary is divided in file_to_create
+        and files_to_copy. Both are dictionaries use the file names as keys. In file_to_create the values are strings
+        which represent the content which is going to be written to the corresponding file. In files_to_copy the values
+        are the paths to the source files to be copied.
+
+        Returns:
+            dict: hierarchical dictionary of input files
         """
-        super().write_input()
+        input_file_dict = super().get_input_file_dict()
         if self._script_path is not None:
-            file_name = os.path.basename(self._script_path)
-            shutil.copyfile(
-                src=self._script_path,
-                dst=os.path.join(self.working_directory, file_name),
-            )
+            input_file_dict["files_to_copy"][
+                os.path.basename(self._script_path)
+            ] = self._script_path
             self.executable = self._executable_command(
                 working_directory=self.working_directory,
                 script_path=self._script_path,

--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -313,6 +313,7 @@ class ScriptJob(GenericJob):
             )
             if self._enable_mpi4py:
                 self.executable._mpi = True
+        return input_file_dict
 
     def collect_output(self):
         """

--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -6,7 +6,6 @@ Jobclass to execute python scripts and jupyter notebooks
 """
 
 import os
-import shutil
 from pyiron_base.jobs.job.generic import GenericJob
 from pyiron_base.storage.datacontainer import DataContainer
 
@@ -302,9 +301,9 @@ class ScriptJob(GenericJob):
         """
         input_file_dict = super().get_input_file_dict()
         if self._script_path is not None:
-            input_file_dict["files_to_copy"][
-                os.path.basename(self._script_path)
-            ] = self._script_path
+            input_file_dict["files_to_copy"][os.path.basename(self._script_path)] = (
+                self._script_path
+            )
             self.executable = self._executable_command(
                 working_directory=self.working_directory,
                 script_path=self._script_path,

--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -301,9 +301,10 @@ class ScriptJob(GenericJob):
         """
         input_file_dict = super().get_input_file_dict()
         if self._script_path is not None:
-            input_file_dict["files_to_copy"][os.path.basename(self._script_path)] = (
-                self._script_path
-            )
+            files_to_copy_dict = {
+                os.path.basename(self._script_path): self._script_path
+            }
+            input_file_dict["files_to_copy"].update(files_to_copy_dict)
             self.executable = self._executable_command(
                 working_directory=self.working_directory,
                 script_path=self._script_path,


### PR DESCRIPTION
Using the `write_input()` function implemented in `GenericJob` https://github.com/pyiron/pyiron_base/pull/1472 also for the `ScriptJob` class. So in the `ScriptJob` class we only need to implement the `get_input_file_dict()` function. This is again in preparation for https://github.com/pyiron/pyiron_base/pull/1480 