### PR TITLE
PythonFunctionContainerJob: Use calculate() function

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -21,7 +21,7 @@ def get_hash(binary):
 
 
 class PythonCalculateFunctionCaller:
-    __slots__ = ("funct")
+    __slots__ = "funct"
 
     def __init__(
         self,
@@ -46,7 +46,6 @@ class PythonCalculateFunctionCaller:
                              the execution raised an accepted error.
         """
         return None, {"result": self.funct(*args, **kwargs)}, False
-
 
 
 class PythonFunctionContainerJob(PythonTemplateJob):

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -135,7 +135,11 @@ class PythonFunctionContainerJob(PythonTemplateJob):
         Returns:
             callable: calculate() functione
         """
-        return PythonCalculateFunctionCaller(funct=self._function)
+        return PythonCalculateFunctionCaller(
+            funct=self._function,
+            executor_type=self._executor_type,
+            cores=self.server.cores,
+        )
 
     def to_dict(self):
         job_dict = super().to_dict()

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -56,7 +56,9 @@ class PythonCalculateFunctionCaller:
         ):
             if "executor" in kwargs.keys():
                 del kwargs["executor"]
-            with get_executor(executor_type=self._executor_type, max_workers=self._cores) as exe:
+            with get_executor(
+                executor_type=self._executor_type, max_workers=self._cores
+            ) as exe:
                 result = self._function(*args, executor=exe, **kwargs)
         else:
             result = self._function(*args, **kwargs)

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -108,7 +108,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             and "executor" in inspect.signature(self._function).parameters.keys()
         ):
             input_dict = self.input.to_builtin()
-            del input_dict["executor"]
+            input_dict["executor"] = self._get_executor(max_workers=self.server.cores)
             return input_dict
         else:
             return self.input.to_builtin()

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -6,8 +6,8 @@ from typing import Tuple
 import cloudpickle
 import numpy as np
 
-from pyiron_base.jobs.job.template import PythonTemplateJob
 from pyiron_base.jobs.job.generic import get_executor
+from pyiron_base.jobs.job.template import PythonTemplateJob
 
 
 def get_function_parameter_dict(funct):

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1647,13 +1647,8 @@ class GenericError(object):
 
 def get_executor(executor_type=None, max_workers=None):
     if executor_type is None:
-        raise ValueError(
-            "No executor type defined - Please set self.executor_type."
-        )
-    elif (
-        executor_type == "pympipool.Executor"
-        and platform.system() == "Darwin"
-    ):
+        raise ValueError("No executor type defined - Please set self.executor_type.")
+    elif executor_type == "pympipool.Executor" and platform.system() == "Darwin":
         # The Mac firewall might prevent connections based on the network address - especially Github CI
         return import_class(executor_type)(
             max_cores=max_workers, hostname_localhost=True

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -82,7 +82,7 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertTrue(job.server.run_mode.executor)
             job.run()
             self.assertFalse(job.server.future.done())
-            self.project.wait_for_job(job=job, interval_in_s=0.01, max_iterations=1000)
+            self.project.wait_for_job(job=job, interval_in_s=0.01, max_iterations=1500)
             self.assertTrue(job.server.future.done())
 
     def test_with_internal_executor(self):


### PR DESCRIPTION
Rather than having a custom `run_static()` function for the `PythonFunctionContainerJob`, it now implements the `get_calculate_function()` function and the `calculate_kwargs` property, just like all the new job classes. This required moving the `_get_executor()` function from the `GenericJob` to a static function. 