### PR TITLE
wrap_python_function(): Allow calling the function directly

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -60,10 +60,13 @@ class PythonFunctionContainerJob(PythonTemplateJob):
         self.input.update(get_function_parameter_dict(funct=funct))
         self._function = funct
 
-    def __call__(self, *args, **kwargs):
+    def set_input(self, *args, **kwargs):
         self.input.update(
             inspect.signature(self._function).bind(*args, **kwargs).arguments
         )
+
+    def __call__(self, *args, **kwargs):
+        self.set_input(*args, **kwargs)
         self.run()
         return self.output["result"]
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -482,18 +482,20 @@ class Project(ProjectPath, HasGroups):
         return table
 
     def wrap_python_function(
-        self, python_function, job_name=None, automatically_rename=True
+        self, python_function, *args, job_name=None, automatically_rename=True, **kwargs
     ):
         """
         Create a pyiron job object from any python function
 
         Args:
             python_function (callable): python function to create a job object from
+            *args: Arguments for the user-defined python function
             job_name (str | None): The name for the created job. (Default is None, use
                 the name of the function.)
             automatically_rename (bool): Whether to automatically rename the job at
                 save-time to append a string based on the input values. (Default is
                 True.)
+            **kwargs: Keyword-arguments for the user-defined python function
 
         Returns:
             pyiron_base.jobs.flex.pythonfunctioncontainer.PythonFunctionContainerJob: pyiron job object
@@ -520,7 +522,7 @@ class Project(ProjectPath, HasGroups):
         )
         job._automatically_rename_on_save_using_input = automatically_rename
         job.python_function = python_function
-        return job
+        return job(*args, **kwargs)
 
     def get_child_ids(self, job_specifier, project=None):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -482,7 +482,7 @@ class Project(ProjectPath, HasGroups):
         return table
 
     def wrap_python_function(
-        self, python_function, *args, job_name=None, automatically_rename=True, **kwargs
+        self, python_function, *args, job_name=None, automatically_rename=True, execute_job=False, **kwargs
     ):
         """
         Create a pyiron job object from any python function
@@ -495,6 +495,7 @@ class Project(ProjectPath, HasGroups):
             automatically_rename (bool): Whether to automatically rename the job at
                 save-time to append a string based on the input values. (Default is
                 True.)
+            execute_job (boolean): automatically call run() on the job object - default false
             **kwargs: Keyword-arguments for the user-defined python function
 
         Returns:
@@ -522,10 +523,13 @@ class Project(ProjectPath, HasGroups):
         )
         job._automatically_rename_on_save_using_input = automatically_rename
         job.python_function = python_function
-        if not args and len(kwargs) == 0:
-            return job
+        if args or len(kwargs) != 0:
+            job.set_input(*args, **kwargs)
+        if execute_job:
+            job.run()
+            return job.output["result"]
         else:
-            return job(*args, **kwargs)
+            return job
 
     def get_child_ids(self, job_specifier, project=None):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -482,7 +482,13 @@ class Project(ProjectPath, HasGroups):
         return table
 
     def wrap_python_function(
-        self, python_function, *args, job_name=None, automatically_rename=True, execute_job=False, **kwargs
+        self,
+        python_function,
+        *args,
+        job_name=None,
+        automatically_rename=True,
+        execute_job=False,
+        **kwargs,
     ):
         """
         Create a pyiron job object from any python function

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -522,7 +522,10 @@ class Project(ProjectPath, HasGroups):
         )
         job._automatically_rename_on_save_using_input = automatically_rename
         job.python_function = python_function
-        return job(*args, **kwargs)
+        if not args and len(kwargs) == 0:
+            return job
+        else:
+            return job(*args, **kwargs)
 
     def get_child_ids(self, job_specifier, project=None):
         """

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -43,6 +43,14 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertEqual(job_reload.input["b"], 6)
         self.assertEqual(job_reload.output["result"], 11)
 
+    def test_direct_function_call(self):
+        result = self.project.wrap_python_function(my_function, 5, b=6)
+        self.assertEqual(result, 11)
+        job_reload = self.project.load(self.project.get_job_ids()[-1])
+        self.assertEqual(job_reload.input["a"], 5)
+        self.assertEqual(job_reload.input["b"], 6)
+        self.assertEqual(job_reload.output["result"], 11)
+
     def test_with_executor(self):
         with ProcessPoolExecutor() as exe:
             job = self.project.wrap_python_function(my_sleep_funct)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -46,7 +46,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.project.remove_job(job_reload.job_name)
 
     def test_direct_function_call(self):
-        result = self.project.wrap_python_function(my_function, 7, b=8)
+        result = self.project.wrap_python_function(my_function, 7, b=8, execute_job=True)
         self.assertEqual(result, 15)
         job_reload = self.project.load(self.project.get_job_ids()[-1])
         self.assertEqual(job_reload.input["a"], 7)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -46,7 +46,9 @@ class TestPythonFunctionContainer(TestWithProject):
         self.project.remove_job(job_reload.job_name)
 
     def test_direct_function_call(self):
-        result = self.project.wrap_python_function(my_function, 7, b=8, execute_job=True)
+        result = self.project.wrap_python_function(
+            my_function, 7, b=8, execute_job=True
+        )
         self.assertEqual(result, 15)
         job_reload = self.project.load(self.project.get_job_ids()[-1])
         self.assertEqual(job_reload.input["a"], 7)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -32,6 +32,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertEqual(job_reload.input["a"], 4)
         self.assertEqual(job_reload.input["b"], 5)
         self.assertEqual(job_reload.output["result"], 9)
+        self.project.remove_job(job.job_name)
 
     def test_as_function(self):
         my_function_as_job = self.project.wrap_python_function(my_function)
@@ -42,14 +43,16 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertEqual(job_reload.input["a"], 5)
         self.assertEqual(job_reload.input["b"], 6)
         self.assertEqual(job_reload.output["result"], 11)
+        self.project.remove_job(job_reload.job_name)
 
     def test_direct_function_call(self):
-        result = self.project.wrap_python_function(my_function, 5, b=6)
-        self.assertEqual(result, 11)
+        result = self.project.wrap_python_function(my_function, 7, b=8)
+        self.assertEqual(result, 15)
         job_reload = self.project.load(self.project.get_job_ids()[-1])
-        self.assertEqual(job_reload.input["a"], 5)
-        self.assertEqual(job_reload.input["b"], 6)
-        self.assertEqual(job_reload.output["result"], 11)
+        self.assertEqual(job_reload.input["a"], 7)
+        self.assertEqual(job_reload.input["b"], 8)
+        self.assertEqual(job_reload.output["result"], 15)
+        self.project.remove_job(job_reload.job_name)
 
     def test_with_executor(self):
         with ProcessPoolExecutor() as exe:
@@ -62,6 +65,7 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertFalse(job.server.future.done())
             self.assertIsNone(job.server.future.result())
             self.assertTrue(job.server.future.done())
+            self.project.remove_job(job.job_name)
 
     @unittest.skipIf(
         os.name == "nt", "Starting subprocesses on windows take a long time."
@@ -79,6 +83,7 @@ class TestPythonFunctionContainer(TestWithProject):
         sleep(1)
         self.assertTrue(job.status.aborted)
         self.assertEqual(job["status"], "aborted")
+        self.project.remove_job(job.job_name)
 
     @unittest.skipIf(sys.version_info < (3, 11), reason="requires python3.11 or higher")
     def test_with_executor_wait(self):
@@ -92,6 +97,7 @@ class TestPythonFunctionContainer(TestWithProject):
             self.assertFalse(job.server.future.done())
             self.project.wait_for_job(job=job, interval_in_s=0.01, max_iterations=1000)
             self.assertTrue(job.server.future.done())
+            self.project.remove_job(job.job_name)
 
     def test_with_internal_executor(self):
         job = self.project.wrap_python_function(my_function_exe)
@@ -114,6 +120,7 @@ class TestPythonFunctionContainer(TestWithProject):
         job.run()
         self.assertEqual(job.output["result"], [6, 8, 10, 12])
         self.assertTrue(job.status.finished)
+        self.project.remove_job(job.job_name)
 
     def test_name_options(self):
         with self.subTest("Auto name and rename"):


### PR DESCRIPTION
Example:
```python
from pyiron_base import Project

def my_function(a, b):
    return a + b

pr = Project("test")
print(pr.wrap_python_function(my_function, a=1, b=2))
>>> 3
```

Previous syntax: 
```python
print(pr.wrap_python_function(my_function)(a=1, b=2))
>>> 3
```