### PR TITLE
ExecutableContainerJob: Fix copying of restart files

### DIFF
--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -2,7 +2,10 @@ import cloudpickle
 import numpy as np
 
 from pyiron_base.jobs.job.template import TemplateJob
-from pyiron_base.jobs.job.runfunction import CalculateFunctionCaller, write_input_files_from_input_dict
+from pyiron_base.jobs.job.runfunction import (
+    CalculateFunctionCaller,
+    write_input_files_from_input_dict,
+)
 
 
 class ExecutableContainerJob(TemplateJob):
@@ -115,6 +118,7 @@ class ExecutableContainerJob(TemplateJob):
         Returns:
             callable: calculate() functione
         """
+
         def get_combined_write_input_funct(input_job_dict, write_input_funct):
             def write_input_combo_funct(working_directory, input_dict):
                 write_input_files_from_input_dict(

--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -2,7 +2,7 @@ import cloudpickle
 import numpy as np
 
 from pyiron_base.jobs.job.template import TemplateJob
-from pyiron_base.jobs.job.runfunction import CalculateFunctionCaller
+from pyiron_base.jobs.job.runfunction import CalculateFunctionCaller, write_input_files_from_input_dict
 
 
 class ExecutableContainerJob(TemplateJob):
@@ -115,8 +115,24 @@ class ExecutableContainerJob(TemplateJob):
         Returns:
             callable: calculate() functione
         """
+        def get_combined_write_input_funct(input_job_dict, write_input_funct):
+            def write_input_combo_funct(working_directory, input_dict):
+                write_input_files_from_input_dict(
+                    input_dict=input_job_dict,
+                    working_directory=working_directory,
+                )
+                write_input_funct(
+                    working_directory=working_directory,
+                    input_dict=input_dict,
+                )
+
+            return write_input_combo_funct
+
         return CalculateFunctionCaller(
-            write_input_funct=self._write_input_funct,
+            write_input_funct=get_combined_write_input_funct(
+                input_job_dict=self.get_input_parameter_dict(),
+                write_input_funct=self._write_input_funct,
+            ),
             collect_output_funct=self._collect_output_funct,
         )
 

--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -115,16 +115,17 @@ class ExecutableContainerJob(TemplateJob):
         Returns:
             callable: calculate() functione
         """
-        def get_combined_write_input_funct(input_job_dict, write_input_funct):
+        def get_combined_write_input_funct(input_job_dict, write_input_funct=None):
             def write_input_combo_funct(working_directory, input_dict):
                 write_input_files_from_input_dict(
                     input_dict=input_job_dict,
                     working_directory=working_directory,
                 )
-                write_input_funct(
-                    working_directory=working_directory,
-                    input_dict=input_dict,
-                )
+                if write_input_funct is not None:
+                    write_input_funct(
+                        working_directory=working_directory,
+                        input_dict=input_dict,
+                    )
 
             return write_input_combo_funct
 

--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -1,11 +1,11 @@
 import cloudpickle
 import numpy as np
 
-from pyiron_base.jobs.job.template import TemplateJob
 from pyiron_base.jobs.job.runfunction import (
     CalculateFunctionCaller,
     write_input_files_from_input_dict,
 )
+from pyiron_base.jobs.job.template import TemplateJob
 
 
 class ExecutableContainerJob(TemplateJob):

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -202,6 +202,10 @@ class TestExecutableContainer(TestWithProject):
         sleep(1)
         self.assertTrue(job.status.aborted)
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "shell script test is skipped on windows.",
+    )
     def test_series_of_jobs(self):
         z = self.project.wrap_executable(
             job_name="job_xy",


### PR DESCRIPTION
When the user defines the `write_input()` function then this typically does not contain a call to `super().write_input()` so the restart files are not copied. This is now fixed by extending the user-defined `write_input()` function to also copy the restart files. 