### PR TITLE
Add write_input() before transferring files to remote

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -168,7 +168,6 @@ class GenericJob(JobCore, HasDict):
         self._process = None
         self._compress_by_default = False
         self._job_with_calculate_function = False
-        self._input_is_written = False
         self._write_work_dir_warnings = True
         self.interactive_cache = None
         self.error = GenericError(working_directory=self.project_hdf5.working_directory)
@@ -633,15 +632,10 @@ class GenericJob(JobCore, HasDict):
         Call routines that generate the code specific input files
         Returns:
         """
-        if not self._input_is_written:
-            write_input_files_from_input_dict(
-                input_dict=self.get_input_parameter_dict(),
-                working_directory=self.working_directory,
-            )
-        else:
-            self._logger.info(
-                "write_input was called, but input has already been written."
-            )
+        write_input_files_from_input_dict(
+            input_dict=self.get_input_parameter_dict(),
+            working_directory=self.working_directory,
+        )
 
     def _internal_copy_to(
         self,
@@ -1172,7 +1166,6 @@ class GenericJob(JobCore, HasDict):
             "restart_file_dict": self._restart_file_dict,
             "exclude_nodes_hdf": self._exclude_nodes_hdf,
             "exclude_groups_hdf": self._exclude_groups_hdf,
-            "input_is_written": self._input_is_written,
         }
         data_dict["server"] = self._server.to_dict()
         self._executable_activate_mpi()
@@ -1202,7 +1195,6 @@ class GenericJob(JobCore, HasDict):
             self._restart_file_dict = generic_dict["restart_file_dict"]
             self._exclude_nodes_hdf = generic_dict["exclude_nodes_hdf"]
             self._exclude_groups_hdf = generic_dict["exclude_groups_hdf"]
-            self._input_is_written = generic_dict["input_is_written"]
         # Backwards compatbility
         if "restart_file_list" in input_dict.keys():
             self._restart_file_list = input_dict["restart_file_list"]

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -168,6 +168,7 @@ class GenericJob(JobCore, HasDict):
         self._process = None
         self._compress_by_default = False
         self._job_with_calculate_function = False
+        self._input_is_written = False
         self._write_work_dir_warnings = True
         self.interactive_cache = None
         self.error = GenericError(working_directory=self.project_hdf5.working_directory)
@@ -632,10 +633,15 @@ class GenericJob(JobCore, HasDict):
         Call routines that generate the code specific input files
         Returns:
         """
-        write_input_files_from_input_dict(
-            input_dict=self.get_input_parameter_dict(),
-            working_directory=self.working_directory,
-        )
+        if not self._input_is_written:
+            write_input_files_from_input_dict(
+                input_dict=self.get_input_parameter_dict(),
+                working_directory=self.working_directory,
+            )
+        else:
+            self._logger.info(
+                "write_input was called, but input has already been written."
+            )
 
     def _internal_copy_to(
         self,
@@ -1166,6 +1172,7 @@ class GenericJob(JobCore, HasDict):
             "restart_file_dict": self._restart_file_dict,
             "exclude_nodes_hdf": self._exclude_nodes_hdf,
             "exclude_groups_hdf": self._exclude_groups_hdf,
+            "input_is_written": self._input_is_written,
         }
         data_dict["server"] = self._server.to_dict()
         self._executable_activate_mpi()
@@ -1195,6 +1202,7 @@ class GenericJob(JobCore, HasDict):
             self._restart_file_dict = generic_dict["restart_file_dict"]
             self._exclude_nodes_hdf = generic_dict["exclude_nodes_hdf"]
             self._exclude_groups_hdf = generic_dict["exclude_groups_hdf"]
+            self._input_is_written = generic_dict["input_is_written"]
         # Backwards compatbility
         if "restart_file_list" in input_dict.keys():
             self._restart_file_list = input_dict["restart_file_list"]

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -486,6 +486,7 @@ def run_job_with_runmode_queue(job):
             + job.project_hdf5.h5_path
             + " --submit"
         )
+        job.write_input()
         state.queue_adapter.transfer_file_to_remote(
             file=job.project_hdf5.file_name, transfer_back=False
         )

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -1,14 +1,14 @@
 # coding: utf-8
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
-from concurrent.futures import ProcessPoolExecutor
-from datetime import datetime
 import multiprocessing
 import os
 import posixpath
 import shutil
 import subprocess
-from typing import Optional, List, Tuple
+from concurrent.futures import ProcessPoolExecutor
+from datetime import datetime
+from typing import List, Optional, Tuple
 
 from jinja2 import Template
 from pyiron_snippets.deprecate import deprecate
@@ -17,7 +17,6 @@ from pyiron_base.jobs.job.wrapper import JobWrapper
 from pyiron_base.state import state
 from pyiron_base.state.signal import catch_signals
 from pyiron_base.utils.instance import static_isinstance
-
 
 try:
     import flux.job
@@ -486,6 +485,7 @@ def run_job_with_runmode_queue(job):
             + job.project_hdf5.h5_path
             + " --submit"
         )
+        job.project_hdf5.create_working_directory()
         job.write_input()
         state.queue_adapter.transfer_file_to_remote(
             file=job.project_hdf5.file_name, transfer_back=False

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -72,11 +72,16 @@ def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
         input_dict (dict): hierarchical input dictionary with files_to_create and files_to_copy.
         working_directory (str): path to the working directory
     """
-    for file_name, content in input_dict["files_to_create"].items():
-        with open(os.path.join(working_directory, file_name), "w") as f:
-            f.writelines(content)
-    for file_name, source in input_dict["files_to_copy"].items():
-        shutil.copy(source, os.path.join(working_directory, file_name))
+    if len(os.listdir(working_directory)) != 0:
+        for file_name, content in input_dict["files_to_create"].items():
+            with open(os.path.join(working_directory, file_name), "w") as f:
+                f.writelines(content)
+        for file_name, source in input_dict["files_to_copy"].items():
+            shutil.copy(source, os.path.join(working_directory, file_name))
+    else:
+        state.logger.info(
+            "The working directory is not empty, assuming that input has already been written."
+        )
 
 
 class CalculateFunctionCaller:

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -72,7 +72,7 @@ def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
         input_dict (dict): hierarchical input dictionary with files_to_create and files_to_copy.
         working_directory (str): path to the working directory
     """
-    if len(os.listdir(working_directory)) != 0:
+    if len(os.listdir(working_directory)) == 0:
         for file_name, content in input_dict["files_to_create"].items():
             with open(os.path.join(working_directory, file_name), "w") as f:
                 f.writelines(content)


### PR DESCRIPTION
This pull request addresses the issue raised by @Leimeroth in https://github.com/pyiron/pyiron_atomistics/issues/1471 that the remote submission for `LAMMPS` jobs failed after the switch to using the `calculate()` function. While it is not exactly clear why the `VASP` job works fine, the work around in this branch fixes the issue for `LAMMPS`.