### PR TITLE
Executable: drop old code argument

### DIFF
--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -31,7 +31,6 @@ class Executable(HasDict):
         path_binary_codes=None,
         codename=None,
         module=None,
-        code=None,
         overwrite_nt_flag=False,
     ):
         """
@@ -49,11 +48,6 @@ class Executable(HasDict):
         if path_binary_codes is None:
             path_binary_codes = state.settings.resource_paths
         self.storage.version = None
-        if code is not None:  # Backwards compatibility
-            if not isinstance(code.__name__, str):
-                raise TypeError("The codename should be a string.")
-            codename = code.__name__
-            module = code.__module__.split(".")[1]
         if codename is not None and module is not None:
             self.storage.name = codename.lower()
             code_path_lst = [


### PR DESCRIPTION
Was superceded by codename/module and last touched 4 years ago.  I have looked around and could not find any call sites in base/atomistics/contrib/potentialfit that still used this argument.