### PR TITLE
Rename the result() call to pull() - for consistency with pyiron_workflow

### DIFF
--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -184,7 +184,7 @@ def recursive_dict_resolve(input_dict: dict) -> dict:
     output_dict = {}
     for k, v in input_dict.items():
         if isinstance(v, DelayedObject):
-            output_dict[k] = v.result()
+            output_dict[k] = v.pull()
         elif isinstance(v, dict):
             output_dict[k] = recursive_dict_resolve(input_dict=v)
         elif isinstance(v, list):
@@ -252,7 +252,7 @@ class DelayedObject:
     def get_file_result(self):
         return getattr(self._result.files, self._output_file)
 
-    def result(self):
+    def pull(self):
         if self._result is None:
             self._result = evaluate_function(
                 funct=self._function, input_dict=self._input

--- a/tests/flex/test_executablecontainer.py
+++ b/tests/flex/test_executablecontainer.py
@@ -262,12 +262,12 @@ class TestExecutableContainer(TestWithProject):
             output_file_lst=["result.txt"],
             output_key_lst=["result"],
         )
-        self.assertEqual(w.output.result.result(), 7)
+        self.assertEqual(w.output.result.pull(), 7)
         nodes_dict, edges_lst = w.get_graph()
         self.assertEqual(len(nodes_dict), 12)
         self.assertEqual(len(edges_lst), 18)
-        job_w = w.result()
-        job_z = z.result()
+        job_w = w.pull()
+        job_z = z.pull()
         self.assertEqual(job_w.output.result, 7)
         self.project.remove_job(job_z.job_name)
         self.project.remove_job(job_w.job_name)

--- a/tests/flex/test_pythonfunctioncontainer.py
+++ b/tests/flex/test_pythonfunctioncontainer.py
@@ -214,7 +214,7 @@ class TestPythonFunctionContainer(TestWithProject):
         d = self.project.wrap_python_function(
             python_function=my_function, a=c, b=3, delayed=True
         )
-        self.assertEqual(d.result(), 6)
+        self.assertEqual(d.pull(), 6)
         nodes_dict, edges_lst = d.get_graph()
         self.assertEqual(len(nodes_dict), 5)
         self.assertEqual(len(edges_lst), 4)

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -677,7 +677,7 @@ class TestGenericJob(TestWithFilledProject):
         j.server.executor = ProcessPoolExecutor()
         self.assertTrue(j.server.run_mode.executor)
         j.run()
-        j.server.future.result()
+        j.server.future.pull()
         self.assertTrue(j.server.future.done())
         self.assertTrue(j.status.finished)
 

--- a/tests/job/test_genericJob.py
+++ b/tests/job/test_genericJob.py
@@ -677,7 +677,7 @@ class TestGenericJob(TestWithFilledProject):
         j.server.executor = ProcessPoolExecutor()
         self.assertTrue(j.server.run_mode.executor)
         j.run()
-        j.server.future.pull()
+        j.server.future.result()
         self.assertTrue(j.server.future.done())
         self.assertTrue(j.status.finished)
 


### PR DESCRIPTION
For consistency with `pyiron_workflow` and to minimise the confusion with `concurrent.futures.Future` I renamed the `result()` call on the `DelayedObject` to a `pull()` call. 