### PR TITLE
Add optional dependencies: gitpython, jinja2 and pint

### DIFF
--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -1,0 +1,18 @@
+channels:
+- conda-forge
+dependencies:
+- cloudpickle =3.0.0
+- h5io_browser =0.0.15
+- h5py =3.11.0
+- monty =2024.7.12
+- numpy =1.26.4
+- pandas =2.2.2
+- psutil =6.0.0
+- pyfileindex =0.0.25
+- pyiron_snippets =0.1.2
+- executorlib =0.0.1
+- pysqa =0.1.21
+- pytables =3.9.2
+- sqlalchemy =2.0.31
+- tqdm =4.66.4
+- traitlets =5.14.3

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -23,6 +23,7 @@ jobs:
           sed -i "/${package}/s/${from}/${to}/g" binder/environment.yml
           sed -i "/${package}/s/${from}/${to}/g" .ci_support/environment.yml
           sed -i "/${package}/s/${from}/${to}/g" .ci_support/environment-docs.yml
+          sed -i "/${package}/s/${from}/${to}/g" .ci_support/environment-mini.yml
       - name: UpdateDependabotPR commit
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -1,0 +1,31 @@
+# This workflow is used to run the unittest of pyiron
+
+name: Minimal
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: '3.12'
+        miniforge-variant: Mambaforge
+        channels: conda-forge
+        channel-priority: strict
+        activate-environment: my-env
+        environment-file: .ci_support/environment-mini.yml
+        use-mamba: true
+    - name: Test
+      shell: bash -l {0}
+      timeout-minutes: 10
+      run: |
+        python .ci_support/pyironconfig.py
+        bash .ci_support/pip_install.sh
+        python -m unittest discover tests/unit

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -1008,6 +1008,7 @@ def execute_job_with_calculate_function(job):
 
 def _generate_flux_execute_string(job, database_is_disabled):
     from jinja2 import Template
+
     if not database_is_disabled:
         executable_template = Template(
             "#!/bin/bash\n"

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -19,7 +19,6 @@ from pyiron_base.utils.instance import static_isinstance
 
 try:
     import flux.job
-    from jinja2 import Template
 
     flux_available = True
 except ImportError:
@@ -1008,6 +1007,7 @@ def execute_job_with_calculate_function(job):
 
 
 def _generate_flux_execute_string(job, database_is_disabled):
+    from jinja2 import Template
     if not database_is_disabled:
         executable_template = Template(
             "#!/bin/bash\n"

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -10,7 +10,6 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-from jinja2 import Template
 from pyiron_snippets.deprecate import deprecate
 
 from pyiron_base.jobs.job.wrapper import JobWrapper
@@ -20,6 +19,7 @@ from pyiron_base.utils.instance import static_isinstance
 
 try:
     import flux.job
+    from jinja2 import Template
 
     flux_available = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["cloudpickle", "executorlib", "gitpython", "h5io", "h5py", "jinja2", "numpy", "pandas", "pint", "psutil", "pyfileindex", "pysqa", "sqlalchemy", "tables", "tqdm", "traitlets", "setuptools", "versioneer[toml]==0.29"]
+requires = ["cloudpickle", "executorlib", "h5io", "h5py", "numpy", "pandas", "psutil", "pyfileindex", "pysqa", "sqlalchemy", "tables", "tqdm", "traitlets", "setuptools", "versioneer[toml]==0.29"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -26,14 +26,11 @@ classifiers = [
 dependencies = [
     "cloudpickle==3.0.0",
     "executorlib==0.0.1",
-    "gitpython==3.1.43",
     "h5io_browser==0.0.15",
     "h5py==3.11.0",
-    "jinja2==3.1.4",
     "numpy==1.26.4",
     "monty==2024.7.12",
     "pandas==2.2.2",
-    "pint==0.24.3",
     "psutil==6.0.0",
     "pyfileindex==0.0.25",
     "pyiron_snippets==0.1.2",
@@ -54,6 +51,15 @@ Repository = "https://github.com/pyiron/pyiron_base"
 conda = [
     "conda==24.5.0",
     "conda_subprocess==0.0.4",
+]
+devel = [
+    "gitpython==3.1.43",
+]
+flux = [
+    "jinja2==3.1.4",
+]
+stats = [
+    "pint==0.24.3",
 ]
 
 [project.scripts]

--- a/tests/unit/generic/test_units.py
+++ b/tests/unit/generic/test_units.py
@@ -17,7 +17,9 @@ except ImportError:
     pint_not_available = True
 
 
-@unittest.skipIf(pint_not_available, "pint is not available, so the pint related tests are skipped.")
+@unittest.skipIf(
+    pint_not_available, "pint is not available, so the pint related tests are skipped."
+)
 class TestUnits(PyironTestCase):
     @property
     def docstring_module(self):

--- a/tests/unit/generic/test_units.py
+++ b/tests/unit/generic/test_units.py
@@ -1,16 +1,23 @@
 # coding: utf-8
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
+import unittest
 
 import numpy as np
 from pyiron_base._tests import PyironTestCase
 import pyiron_base
-from pyiron_base.utils.units import PyironUnitRegistry, UnitConverter
-import pint
 
-pint_registry = pint.UnitRegistry()
+try:
+    import pint
+    from pyiron_base.utils.units import PyironUnitRegistry, UnitConverter
+
+    pint_registry = pint.UnitRegistry()
+    pint_not_available = False
+except ImportError:
+    pint_not_available = True
 
 
+@unittest.skipIf(pint_not_available, "pint is not available, so the pint related tests are skipped.")
 class TestUnits(PyironTestCase):
     @property
     def docstring_module(self):

--- a/tests/unit/job/test_genericJob.py
+++ b/tests/unit/job/test_genericJob.py
@@ -16,6 +16,7 @@ try:
     import jinja2
 
     from pyiron_base.jobs.job.runfunction import _generate_flux_execute_string
+
     jinja2_not_available = False
 except ImportError:
     jinja2_not_available = True

--- a/tests/unit/job/test_genericJob.py
+++ b/tests/unit/job/test_genericJob.py
@@ -725,7 +725,10 @@ class TestGenericJob(TestWithFilledProject):
         with self.assertRaises(RuntimeError):
             j2.copy()
 
-    @unittest.skipIf(jinja2_not_available, "jinja2 is not available, so the jinja2 related tests are skipped.")
+    @unittest.skipIf(
+        jinja2_not_available,
+        "jinja2 is not available, so the jinja2 related tests are skipped.",
+    )
     def test_generate_flux_execute_string(self):
         job_disable = self.project.create_job(ReturnCodeJob, "job_db_disable")
         executor_str, job_name = _generate_flux_execute_string(

--- a/tests/unit/job/test_genericJob.py
+++ b/tests/unit/job/test_genericJob.py
@@ -5,13 +5,20 @@
 import contextlib
 import unittest
 import os
-from time import sleep
 from concurrent.futures import Future, ProcessPoolExecutor
 import io
 from pyiron_base.storage.parameters import GenericParameters
 from pyiron_base.jobs.job.generic import GenericJob
 from pyiron_base.jobs.job.runfunction import _generate_flux_execute_string
 from pyiron_base._tests import TestWithFilledProject, ToyJob
+
+
+try:
+    import jinja2
+
+    jinja2_not_available = False
+except ImportError:
+    jinja2_not_available = True
 
 
 class ReturnCodeJob(GenericJob):
@@ -718,6 +725,7 @@ class TestGenericJob(TestWithFilledProject):
         with self.assertRaises(RuntimeError):
             j2.copy()
 
+    @unittest.skipIf(jinja2_not_available, "jinja2 is not available, so the jinja2 related tests are skipped.")
     def test_generate_flux_execute_string(self):
         job_disable = self.project.create_job(ReturnCodeJob, "job_db_disable")
         executor_str, job_name = _generate_flux_execute_string(

--- a/tests/unit/job/test_genericJob.py
+++ b/tests/unit/job/test_genericJob.py
@@ -9,13 +9,13 @@ from concurrent.futures import Future, ProcessPoolExecutor
 import io
 from pyiron_base.storage.parameters import GenericParameters
 from pyiron_base.jobs.job.generic import GenericJob
-from pyiron_base.jobs.job.runfunction import _generate_flux_execute_string
 from pyiron_base._tests import TestWithFilledProject, ToyJob
 
 
 try:
     import jinja2
 
+    from pyiron_base.jobs.job.runfunction import _generate_flux_execute_string
     jinja2_not_available = False
 except ImportError:
     jinja2_not_available = True

--- a/tests/unit/project/test_maintenance.py
+++ b/tests/unit/project/test_maintenance.py
@@ -37,7 +37,10 @@ class TestMaintenance(TestWithFilledProject):
         self.assertEqual(array, _test_array())
         self.assertLess(job_hdf.file_size(), self.initial_toy_1_hdf_file_size)
 
-    @unittest.skipIf(git_not_available, "gitpython is not available so the gitpython related tests are skipped.")
+    @unittest.skipIf(
+        git_not_available,
+        "gitpython is not available so the gitpython related tests are skipped.",
+    )
     def test_repository_status(self):
         df = self.project.maintenance.get_repository_status()
         self.assertIn(

--- a/tests/unit/project/test_maintenance.py
+++ b/tests/unit/project/test_maintenance.py
@@ -1,6 +1,16 @@
+import unittest
+
 import numpy as np
 from pyiron_base._tests import TestWithFilledProject
 from pyiron_base import GenericJob
+
+
+try:
+    import git
+
+    git_not_available = False
+except ImportError:
+    git_not_available = True
 
 
 def _test_array(start=0):
@@ -27,6 +37,7 @@ class TestMaintenance(TestWithFilledProject):
         self.assertEqual(array, _test_array())
         self.assertLess(job_hdf.file_size(), self.initial_toy_1_hdf_file_size)
 
+    @unittest.skipIf(git_not_available, "gitpython is not available so the gitpython related tests are skipped.")
     def test_repository_status(self):
         df = self.project.maintenance.get_repository_status()
         self.assertIn(

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -6,7 +6,6 @@ import unittest
 from os.path import dirname, join, abspath, exists, islink
 import os
 import tempfile
-import pint
 import pickle
 from pyiron_base.project.generic import Project
 from pyiron_base._tests import (
@@ -19,6 +18,8 @@ from pyiron_base.jobs.job.toolkit import BaseTools
 
 
 try:
+    import pint
+
     from pyiron_base.project.size import _size_conversion
     pint_not_available = False
 except ImportError:

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -27,6 +27,14 @@ except ImportError:
     pint_not_available = True
 
 
+try:
+    import git
+
+    git_not_available = False
+except ImportError:
+    git_not_available = True
+
+
 class TestProjectData(PyironTestCase):
     @classmethod
     def setUpClass(cls):
@@ -279,6 +287,10 @@ class TestProjectOperations(TestWithFilledProject):
             pr.remove(enable=True)
             pr.state.update({"disable_database": database_disabled})
 
+    @unittest.skipIf(
+        git_not_available,
+        "gitpython is not available so the gitpython related tests are skipped.",
+    )
     def test_maintenance_get_repository_status(self):
         df = self.project.maintenance.get_repository_status()
         self.assertIn("pyiron_base", df.Module.values)

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -90,6 +90,10 @@ class TestProjectData(PyironTestCase):
 
 
 class TestProjectOperations(TestWithFilledProject):
+    @unittest.skipIf(
+        pint_not_available,
+        "pint is not installed so the pint related tests are skipped.",
+    )
     def test_size(self):
         self.assertTrue(self.project.size > 0)
 

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -9,7 +9,6 @@ import tempfile
 import pint
 import pickle
 from pyiron_base.project.generic import Project
-from pyiron_base.project.size import _size_conversion
 from pyiron_base._tests import (
     PyironTestCase,
     TestWithProject,
@@ -17,6 +16,13 @@ from pyiron_base._tests import (
     ToyJob,
 )
 from pyiron_base.jobs.job.toolkit import BaseTools
+
+
+try:
+    from pyiron_base.project.size import _size_conversion
+    pint_not_available = False
+except ImportError:
+    pint_not_available = True
 
 
 class TestProjectData(PyironTestCase):
@@ -85,6 +91,7 @@ class TestProjectOperations(TestWithFilledProject):
     def test_size(self):
         self.assertTrue(self.project.size > 0)
 
+    @unittest.skipIf(pint_not_available, "pint is not installed so the pint related tests are skipped.")
     def test__size_conversion(self):
         conv_check = {
             -2000: (-1.953125, "kibibyte"),

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -20,6 +20,7 @@ from pyiron_base.jobs.job.toolkit import BaseTools
 
 try:
     from pyiron_base.project.size import _size_conversion
+
     pint_not_available = False
 except ImportError:
     pint_not_available = True
@@ -91,7 +92,10 @@ class TestProjectOperations(TestWithFilledProject):
     def test_size(self):
         self.assertTrue(self.project.size > 0)
 
-    @unittest.skipIf(pint_not_available, "pint is not installed so the pint related tests are skipped.")
+    @unittest.skipIf(
+        pint_not_available,
+        "pint is not installed so the pint related tests are skipped.",
+    )
     def test__size_conversion(self):
         conv_check = {
             -2000: (-1.953125, "kibibyte"),


### PR DESCRIPTION
The goal is to reduce the dependency footprint for installing `pyiron_base`. This is tested with a new unit test called `Minimal` which is based only on a minimal conda environment without the optional requirements. 