### PR TITLE
Remove Codacy

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -62,9 +62,3 @@ jobs:
     - name: Coveralls
       if: matrix.label == 'linux-64-py-3-11'
       uses: coverallsapp/github-action@v2
-    - name: Codacy
-      if:  matrix.label == 'linux-64-py-3-11' && github.event_name != 'push'
-      continue-on-error: True
-      shell: bash -l {0}
-      run: |
-        python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
As we now have `ruff` for linting we no longer need `codacy` in particular as those tests tend to fail frequently. 