### PR TITLE
[patch] Remove redundant conversion of project name

### DIFF
--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -76,7 +76,7 @@ def copy_files_to_archive(
         copy_all_files (bool): if True include job output files in archive, otherwise just include .h5 files; default False
     """
 
-    assert ".tar.gz" not archive_directory
+    assert ".tar.gz" not in archive_directory
     # print("directory to transfer: "+directory_to_transfer)
     if not copy_all_files:
         pfi = PyFileIndex(path=directory_to_transfer, filter_function=filter_function)

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -76,6 +76,7 @@ def copy_files_to_archive(
         copy_all_files (bool): if True include job output files in archive, otherwise just include .h5 files; default False
     """
 
+    assert ".tar.gz" not archive_directory
     # print("directory to transfer: "+directory_to_transfer)
     if not copy_all_files:
         pfi = PyFileIndex(path=directory_to_transfer, filter_function=filter_function)

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -130,7 +130,7 @@ def export_database(pr, directory_to_transfer, archive_directory):
         for job_id in df.parentid
     ]
     df["project"] = update_project(
-        pr,
+        project_instance=pr,
         directory_to_transfer=directory_to_transfer,
         archive_directory=archive_directory,
         df=df,

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -107,10 +107,11 @@ def copy_files_to_archive(
         compress_dir(archive_directory)
 
 
-def export_database(df, directory_to_transfer, archive_directory):
+def export_database(pr, directory_to_transfer, archive_directory):
     # here we first check wether the archive directory is a path
     # or a project object
     directory_to_transfer = os.path.basename(directory_to_transfer)
+    df = pr.job_table()
     job_ids_sorted = sorted(df.id.values)
     new_job_ids = list(range(len(job_ids_sorted)))
     job_translate_dict = {j: n for j, n in zip(job_ids_sorted, new_job_ids)}
@@ -127,7 +128,7 @@ def export_database(df, directory_to_transfer, archive_directory):
         for job_id in df.parentid
     ]
     df["project"] = update_project(
-        project_instance,
+        pr,
         directory_to_transfer=directory_to_transfer,
         archive_directory=archive_directory,
         df=df,

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -107,12 +107,10 @@ def copy_files_to_archive(
         compress_dir(archive_directory)
 
 
-def export_database(project_instance, directory_to_transfer, archive_directory):
+def export_database(df, directory_to_transfer, archive_directory):
     # here we first check wether the archive directory is a path
     # or a project object
     directory_to_transfer = os.path.basename(directory_to_transfer)
-    pr = project_instance.open(os.curdir)
-    df = pr.job_table()
     job_ids_sorted = sorted(df.id.values)
     new_job_ids = list(range(len(job_ids_sorted)))
     job_translate_dict = {j: n for j, n in zip(job_ids_sorted, new_job_ids)}

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -76,7 +76,7 @@ def copy_files_to_archive(
         copy_all_files (bool): if True include job output files in archive, otherwise just include .h5 files; default False
     """
 
-    assert ".tar.gz" not in archive_directory
+    assert isinstance(archive_directory, str) and ".tar.gz" not in archive_directory
     # print("directory to transfer: "+directory_to_transfer)
     if not copy_all_files:
         pfi = PyFileIndex(path=directory_to_transfer, filter_function=filter_function)
@@ -111,7 +111,7 @@ def copy_files_to_archive(
 def export_database(pr, directory_to_transfer, archive_directory):
     # here we first check wether the archive directory is a path
     # or a project object
-    assert ".tar.gz" not in archive_directory
+    assert isinstance(archive_directory, str) and ".tar.gz" not in archive_directory
     directory_to_transfer = os.path.basename(directory_to_transfer)
     df = pr.job_table()
     job_ids_sorted = sorted(df.id.values)

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -75,10 +75,6 @@ def copy_files_to_archive(
         compressed (bool): if True compress archive_directory as a tarball; default True
         copy_all_files (bool): if True include job output files in archive, otherwise just include .h5 files; default False
     """
-    if archive_directory[-7:] == ".tar.gz":
-        archive_directory = archive_directory[:-7]
-        if not compressed:
-            compressed = True
 
     # print("directory to transfer: "+directory_to_transfer)
     if not copy_all_files:
@@ -114,24 +110,6 @@ def copy_files_to_archive(
 def export_database(project_instance, directory_to_transfer, archive_directory):
     # here we first check wether the archive directory is a path
     # or a project object
-    if isinstance(archive_directory, str):
-        if archive_directory[-7:] == ".tar.gz":
-            archive_directory = archive_directory[:-7]
-        archive_directory = os.path.basename(archive_directory)
-    # if the archive_directory is a project
-    elif static_isinstance(
-        obj=archive_directory.__class__,
-        obj_type=[
-            "pyiron_base.project.generic.Project",
-        ],
-    ):
-        archive_directory = archive_directory.path
-    else:
-        raise RuntimeError(
-            """the given path for exporting to,
-            does not have the correct format paths as string
-            or pyiron Project objects are expected"""
-        )
     directory_to_transfer = os.path.basename(directory_to_transfer)
     pr = project_instance.open(os.curdir)
     df = pr.job_table()

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -111,6 +111,7 @@ def copy_files_to_archive(
 def export_database(pr, directory_to_transfer, archive_directory):
     # here we first check wether the archive directory is a path
     # or a project object
+    assert ".tar.gz" not in archive_directory
     directory_to_transfer = os.path.basename(directory_to_transfer)
     df = pr.job_table()
     job_ids_sorted = sorted(df.id.values)

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1994,7 +1994,7 @@ class Project(ProjectPath, HasGroups):
             copy_all_files=copy_all_files,
         )
         df = export_archive.export_database(
-            self.job_table(), directory_to_transfer, destination_path_abs
+            self, directory_to_transfer, destination_path_abs
         )
         df.to_csv(csv_file_path)
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1975,6 +1975,10 @@ class Project(ProjectPath, HasGroups):
             copy_all_files (bool):
         """
         destination_path_abs = os.path.abspath(destination_path)
+        if ".tar.gz" in destination_path_abs:
+            destination_path_abs = destination_path_abs.split(".tar.gz")[0]
+            if not compressed:
+                compressed = True
         directory_to_transfer = os.path.dirname(self.path)
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1994,7 +1994,7 @@ class Project(ProjectPath, HasGroups):
             copy_all_files=copy_all_files,
         )
         df = export_archive.export_database(
-            self, directory_to_transfer, destination_path_abs
+            self.job_table(), directory_to_transfer, destination_path_abs
         )
         df.to_csv(csv_file_path)
 

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1977,8 +1977,7 @@ class Project(ProjectPath, HasGroups):
         destination_path_abs = os.path.abspath(destination_path)
         if ".tar.gz" in destination_path_abs:
             destination_path_abs = destination_path_abs.split(".tar.gz")[0]
-            if not compressed:
-                compressed = True
+            compress = True
         directory_to_transfer = os.path.dirname(self.path)
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name

--- a/tests/unit/archiving/test_export.py
+++ b/tests/unit/archiving/test_export.py
@@ -46,7 +46,7 @@ class TestPack(PyironTestCase):
         df_read["timestart"] = pd.to_datetime(df_read["timestart"])
         df_read["hamversion"] = float(df_read["hamversion"])
         df_exp = export_database(
-            self.pr.job_table(), directory_to_transfer, "archive_folder"
+            self.pr, directory_to_transfer, "archive_folder"
         ).dropna(axis=1)
         df_exp["hamversion"] = float(df_exp["hamversion"])
         assert_frame_equal(df_exp, df_read)

--- a/tests/unit/archiving/test_export.py
+++ b/tests/unit/archiving/test_export.py
@@ -46,7 +46,7 @@ class TestPack(PyironTestCase):
         df_read["timestart"] = pd.to_datetime(df_read["timestart"])
         df_read["hamversion"] = float(df_read["hamversion"])
         df_exp = export_database(
-            self.pr, directory_to_transfer, "archive_folder"
+            self.pr.job_table(), directory_to_transfer, "archive_folder"
         ).dropna(axis=1)
         df_exp["hamversion"] = float(df_exp["hamversion"])
         assert_frame_equal(df_exp, df_read)


### PR DESCRIPTION
Trying to make smaller PRs to make [this PR](https://github.com/pyiron/pyiron_base/pull/1440) lighter. I guess this one is a small patch