### PR TITLE
Change wrap function status when job starts running

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -88,6 +88,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
         super().save()
 
     def run_static(self):
+        self.status.running = True
         if (
             self._executor_type is not None
             and "executor" in inspect.signature(self._function).parameters.keys()


### PR DESCRIPTION
Currently it looks like it goes directly from `submitted` to `finished` which I find is super confusing.