### PR TITLE
Add underscore to separate job name

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -111,9 +111,13 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             None
         """
         if self._automatically_rename_on_save_using_input:
-            self.job_name = self.job_name + "_" + get_hash(
-                binary=cloudpickle.dumps(
-                    {"fn": self._function, "kwargs": self.input.to_builtin()}
+            self.job_name = (
+                self.job_name
+                + "_"
+                + get_hash(
+                    binary=cloudpickle.dumps(
+                        {"fn": self._function, "kwargs": self.input.to_builtin()}
+                    )
                 )
             )
 

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -111,7 +111,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             None
         """
         if self._automatically_rename_on_save_using_input:
-            self.job_name = self.job_name + get_hash(
+            self.job_name = self.job_name + "_" + get_hash(
                 binary=cloudpickle.dumps(
                     {"fn": self._function, "kwargs": self.input.to_builtin()}
                 )


### PR DESCRIPTION
This confuses me a lot when I see the hash attached to my job name