### PR TITLE
Set job.status.running again

### DIFF
--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -913,6 +913,7 @@ class GenericJob(JobCore, HasDict):
         """
         The run static function is called by run to execute the simulation.
         """
+        self.status.running = True
         if self._job_with_calculate_function:
             execute_job_with_calculate_function(job=self)
         else:

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -801,7 +801,6 @@ def execute_job_with_external_executable(job):
         job.status.aborted = True
         job._hdf5["status"] = job.status.string
         raise ValueError("No executable set!")
-    job.status.running = True
     executable, shell = job.executable.get_input_for_subprocess_call(
         cores=job.server.cores, threads=job.server.threads, gpus=job.server.gpus
     )


### PR DESCRIPTION
Both lammps and vasp jobs currently do not set their status to running anymore, likely because of calculate function refactors.  This seemed like the quickest way to fix it.