### PR TITLE
Always write input files

### DIFF
--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -71,16 +71,11 @@ def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
         input_dict (dict): hierarchical input dictionary with files_to_create and files_to_copy.
         working_directory (str): path to the working directory
     """
-    if len(os.listdir(working_directory)) == 0:
-        for file_name, content in input_dict["files_to_create"].items():
-            with open(os.path.join(working_directory, file_name), "w") as f:
-                f.writelines(content)
-        for file_name, source in input_dict["files_to_copy"].items():
-            shutil.copy(source, os.path.join(working_directory, file_name))
-    else:
-        state.logger.info(
-            "The working directory is not empty, assuming that input has already been written."
-        )
+    for file_name, content in input_dict["files_to_create"].items():
+        with open(os.path.join(working_directory, file_name), "w") as f:
+            f.writelines(content)
+    for file_name, source in input_dict["files_to_copy"].items():
+        shutil.copy(source, os.path.join(working_directory, file_name))
 
 
 class CalculateFunctionCaller:

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -71,6 +71,11 @@ def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
         input_dict (dict): hierarchical input dictionary with files_to_create and files_to_copy.
         working_directory (str): path to the working directory
     """
+    existing_files = set(os.listdir(working_directory))
+    if len(existing_files.intersection(input_dict["files_to_create"])) > 0 \
+            or len(existing_files.intersection(input_dict["files_to_copy"])) > 0:
+        state.logger.info("Some files to be created already exist, assuming that input has already been written.")
+        return
     for file_name, content in input_dict["files_to_create"].items():
         with open(os.path.join(working_directory, file_name), "w") as f:
             f.writelines(content)

--- a/pyiron_base/jobs/job/runfunction.py
+++ b/pyiron_base/jobs/job/runfunction.py
@@ -72,9 +72,13 @@ def write_input_files_from_input_dict(input_dict: dict, working_directory: str):
         working_directory (str): path to the working directory
     """
     existing_files = set(os.listdir(working_directory))
-    if len(existing_files.intersection(input_dict["files_to_create"])) > 0 \
-            or len(existing_files.intersection(input_dict["files_to_copy"])) > 0:
-        state.logger.info("Some files to be created already exist, assuming that input has already been written.")
+    if (
+        len(existing_files.intersection(input_dict["files_to_create"])) > 0
+        or len(existing_files.intersection(input_dict["files_to_copy"])) > 0
+    ):
+        state.logger.info(
+            "Some files to be created already exist, assuming that input has already been written."
+        )
         return
     for file_name, content in input_dict["files_to_create"].items():
         with open(os.path.join(working_directory, file_name), "w") as f:


### PR DESCRIPTION
This check always fails for submitted jobs and currently prevents lammps jobs to be submitted to the queue.  For some reason vasp jobs still work, but I'll leave that for someone else to figure out.