### PR TITLE
Executable Dataclass

### DIFF
--- a/pyiron_base/dataclasses/job.py
+++ b/pyiron_base/dataclasses/job.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import List, Optional
 
 
 @dataclass

--- a/pyiron_base/dataclasses/job.py
+++ b/pyiron_base/dataclasses/job.py
@@ -4,9 +4,9 @@ from typing import List, Optional
 
 @dataclass
 class Executable:
-    version: Optional[str]
     name: str
     operation_system_nt: bool
-    executable: Optional[str]
     mpi: bool
     accepted_return_codes: List[int]
+    version: Optional[str] = None
+    executable: Optional[str] = None

--- a/pyiron_base/dataclasses/job.py
+++ b/pyiron_base/dataclasses/job.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+@dataclass
+class Executable:
+    version: Optional[str]
+    name: str
+    operation_system_nt: bool
+    executable: Optional[str]
+    mpi: bool
+    accepted_return_codes: List[int]

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -222,15 +222,15 @@ class Executable(HasDict):
         ]
         executable_class_dict = {}
         for key in data_container_keys:
-            if key in executable_dict["executable"]:
-                executable_class_dict[key] = executable_dict["executable"][key]
+            if key in executable_dict.keys():
+                executable_class_dict[key] = executable_dict[key]
             else:
                 executable_class_dict[key] = None
 
         # Backwards compatibility
-        if "executable" in executable_dict.keys():
+        if "executable" in executable_dict.keys() and isinstance(executable_dict["executable"], dict):
             for key in data_container_keys:
-                if key in executable_dict["executable"]:
+                if key in executable_dict["executable"].keys():
                     executable_class_dict[key] = executable_dict["executable"][key]
                 else:
                     executable_class_dict[key] = None

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -9,7 +9,6 @@ from pyiron_snippets.resources import ExecutableResolver
 from pyiron_base.dataclasses.job import Executable as ExecutableDataClass
 from pyiron_base.interfaces.has_dict import HasDict
 from pyiron_base.state import state
-from pyiron_base.storage.datacontainer import DataContainer
 
 """
 Executable class loading executables from static/bin/<code>/

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -228,7 +228,9 @@ class Executable(HasDict):
                 executable_class_dict[key] = None
 
         # Backwards compatibility
-        if "executable" in executable_dict.keys() and isinstance(executable_dict["executable"], dict):
+        if "executable" in executable_dict.keys() and isinstance(
+            executable_dict["executable"], dict
+        ):
             for key in data_container_keys:
                 if key in executable_dict["executable"].keys():
                     executable_class_dict[key] = executable_dict["executable"][key]

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -221,10 +221,7 @@ class Executable(HasDict):
         ]
         executable_class_dict = {}
         for key in data_container_keys:
-            if key in executable_dict.keys():
-                executable_class_dict[key] = executable_dict[key]
-            else:
-                executable_class_dict[key] = None
+            executable_class_dict[key] = executable_dict.get(key, None)
 
         # Backwards compatibility
         if "executable" in executable_dict.keys() and isinstance(

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -220,7 +220,7 @@ class Executable(HasDict):
             "mpi",
             "accepted_return_codes",
         ]
-        executable_class_dict = {}        
+        executable_class_dict = {}
         # Backwards compatibility; dict state used to be nested one level deeper
         if "executable" in executable_dict.keys() and isinstance(
             executable_dict["executable"], dict

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -228,17 +228,6 @@ class Executable(HasDict):
             executable_dict = executable_dict["executable"]
         for key in data_container_keys:
             executable_class_dict[key] = executable_dict.get(key, None)
-
-        # Backwards compatibility
-        if "executable" in executable_dict.keys() and isinstance(
-            executable_dict["executable"], dict
-        ):
-            for key in data_container_keys:
-                if key in executable_dict["executable"].keys():
-                    executable_class_dict[key] = executable_dict["executable"][key]
-                else:
-                    executable_class_dict[key] = None
-
         self.storage = ExecutableDataClass(**executable_class_dict)
 
     def get_input_for_subprocess_call(self, cores, threads, gpus=None):

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -220,7 +220,12 @@ class Executable(HasDict):
             "mpi",
             "accepted_return_codes",
         ]
-        executable_class_dict = {}
+        executable_class_dict = {}        
+        # Backwards compatibility; dict state used to be nested one level deeper
+        if "executable" in executable_dict.keys() and isinstance(
+            executable_dict["executable"], dict
+        ):
+            executable_dict = executable_dict["executable"]
         for key in data_container_keys:
             executable_class_dict[key] = executable_dict.get(key, None)
 

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -6,6 +6,7 @@ import os
 
 from pyiron_snippets.resources import ExecutableResolver
 
+from pyiron_base.dataclasses.job import Executable as ExecutableDataClass
 from pyiron_base.interfaces.has_dict import HasDict
 from pyiron_base.state import state
 from pyiron_base.storage.datacontainer import DataContainer
@@ -45,28 +46,30 @@ class Executable(HasDict):
             overwrite_nt_flag (bool):
         """
         super().__init__()
-        self.storage = DataContainer()
-        self.storage.table_name = "executable"
+        if overwrite_nt_flag:
+            operation_system_nt = False
+        else:
+            operation_system_nt = os.name == "nt"
+
+        self.storage = ExecutableDataClass(
+            version=None,
+            name=codename.lower(),
+            operation_system_nt=operation_system_nt,
+            executable=None,
+            mpi=False,
+            accepted_return_codes=[0],
+        )
 
         if path_binary_codes is None:
             path_binary_codes = state.settings.resource_paths
-        self.storage.version = None
-        self.storage.name = codename.lower()
         if module is None:
             module = self.storage.name
         self._module = module
         self.path_bin = path_binary_codes
-        if overwrite_nt_flag:
-            self.storage.operation_system_nt = False
-        else:
-            self.storage.operation_system_nt = os.name == "nt"
         self.executable_lst = self._executable_versions_list()
-        self.storage.executable = None
         self._executable_path = None
-        self.storage.mpi = False
         if self.executable_lst:
             self.version = self.default_version
-        self.storage.accepted_return_codes = [0]
 
     @property
     def accepted_return_codes(self):
@@ -205,10 +208,7 @@ class Executable(HasDict):
 
     def to_dict(self):
         executable_dict = self._type_to_dict()
-        executable_storage_dict = self.storage._type_to_dict()
-        executable_storage_dict["READ_ONLY"] = self.storage._read_only
-        executable_storage_dict.update(self.storage.to_builtin())
-        executable_dict["executable"] = executable_storage_dict
+        executable_dict.update(self.storage.__dict__)
         return executable_dict
 
     def from_dict(self, executable_dict):
@@ -220,11 +220,22 @@ class Executable(HasDict):
             "mpi",
             "accepted_return_codes",
         ]
+        executable_class_dict = {}
         for key in data_container_keys:
             if key in executable_dict["executable"]:
-                self.storage[key] = executable_dict["executable"][key]
-        if executable_dict["executable"]["READ_ONLY"]:
-            self.storage.read_only = True
+                executable_class_dict[key] = executable_dict["executable"][key]
+            else:
+                executable_class_dict[key] = None
+
+        # Backwards compatibility
+        if "executable" in executable_dict.keys():
+            for key in data_container_keys:
+                if key in executable_dict["executable"]:
+                    executable_class_dict[key] = executable_dict["executable"][key]
+                else:
+                    executable_class_dict[key] = None
+
+        self.storage = ExecutableDataClass(**executable_class_dict)
 
     def get_input_for_subprocess_call(self, cores, threads, gpus=None):
         """

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -3,10 +3,10 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
+from dataclasses import asdict
 
 from pyiron_snippets.resources import ExecutableResolver
 
-from dataclasses import asdict
 from pyiron_base.dataclasses.job import Executable as ExecutableDataClass
 from pyiron_base.interfaces.has_dict import HasDict
 from pyiron_base.state import state

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -6,6 +6,7 @@ import os
 
 from pyiron_snippets.resources import ExecutableResolver
 
+from dataclasses import asdict
 from pyiron_base.dataclasses.job import Executable as ExecutableDataClass
 from pyiron_base.interfaces.has_dict import HasDict
 from pyiron_base.state import state

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -208,7 +208,7 @@ class Executable(HasDict):
 
     def to_dict(self):
         executable_dict = self._type_to_dict()
-        executable_dict.update(self.storage.__dict__)
+        executable_dict.update(asdict(self.storage))
         return executable_dict
 
     def from_dict(self, executable_dict):

--- a/tests/unit/flex/test_executablecontainer.py
+++ b/tests/unit/flex/test_executablecontainer.py
@@ -57,8 +57,8 @@ class TestExecutableContainer(TestWithProject):
             "mpi": False,
             "accepted_return_codes": [0],
         }
-        self.assertEqual(job.executable.storage.to_builtin(), executable_dict)
-        self.assertEqual(job_reload.executable.storage.to_builtin(), executable_dict)
+        self.assertEqual(job.executable.storage.__dict__, executable_dict)
+        self.assertEqual(job_reload.executable.storage.__dict__, executable_dict)
         del JOB_CLASS_DICT["CatJob"]
 
     def test_create_job_factory_with_project(self):

--- a/tests/unit/flex/test_executablecontainer.py
+++ b/tests/unit/flex/test_executablecontainer.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 import os
 import subprocess
 import unittest

--- a/tests/unit/flex/test_executablecontainer.py
+++ b/tests/unit/flex/test_executablecontainer.py
@@ -58,8 +58,8 @@ class TestExecutableContainer(TestWithProject):
             "mpi": False,
             "accepted_return_codes": [0],
         }
-        self.assertEqual(job.executable.storage.__dict__, executable_dict)
-        self.assertEqual(job_reload.executable.storage.__dict__, executable_dict)
+        self.assertEqual(asdict(job.executable.storage), executable_dict)
+        self.assertEqual(asdict(job_reload.executable.storage), executable_dict)
         del JOB_CLASS_DICT["CatJob"]
 
     def test_create_job_factory_with_project(self):


### PR DESCRIPTION
Following https://github.com/pyiron/pyiron_base/pull/1578 this pull request replaces the `DataContainer` in the `Executable` class with a dataclass. 