### PR TITLE
Allow undefined pack destination

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -11,7 +11,7 @@ import os
 import posixpath
 import shutil
 import stat
-from typing import TYPE_CHECKING, Dict, Generator, Literal, Union, Optional
+from typing import TYPE_CHECKING, Dict, Generator, Literal, Optional, Union
 
 import cloudpickle
 import numpy as np

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1984,7 +1984,7 @@ class Project(ProjectPath, HasGroups):
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name
         )
-        if destination_path_abs == directory_to_transfer and not compress:
+        if destination_path == directory_to_transfer and not compress:
             raise ValueError(
                 "The destination_path cannot have the same name as the project to compress."
             )

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1981,8 +1981,8 @@ class Project(ProjectPath, HasGroups):
             destination_path_abs = destination_path_abs.split(".tar.gz")[0]
             compress = True
         directory_to_transfer = os.path.abspath(self.path)
-        assert not destination_path_ab.endswith(".tar")
-        assert not destination_path_ab.endswith(".gz")
+        assert not destination_path_abs.endswith(".tar")
+        assert not destination_path_abs.endswith(".gz")
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name
         )

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -11,7 +11,7 @@ import os
 import posixpath
 import shutil
 import stat
-from typing import TYPE_CHECKING, Dict, Generator, Literal, Union
+from typing import TYPE_CHECKING, Dict, Generator, Literal, Union, Optional
 
 import cloudpickle
 import numpy as np
@@ -1960,10 +1960,10 @@ class Project(ProjectPath, HasGroups):
 
     def pack(
         self,
-        destination_path,
-        csv_file_name="export.csv",
-        compress=True,
-        copy_all_files=False,
+        destination_path: Optional[str] = None,
+        csv_file_name: str = "export.csv",
+        compress: bool = True,
+        copy_all_files: bool = False,
     ):
         """
         Export job table to a csv file and copy (and optionally compress) the project directory.
@@ -1974,6 +1974,8 @@ class Project(ProjectPath, HasGroups):
             compress (bool): if true, the function will compress the destination_path to a tar.gz file.
             copy_all_files (bool):
         """
+        if destination_path is None:
+            destination_path = os.path.dirname(self.path)
         destination_path_abs = os.path.abspath(destination_path)
         if ".tar.gz" in destination_path_abs:
             destination_path_abs = destination_path_abs.split(".tar.gz")[0]
@@ -1982,7 +1984,7 @@ class Project(ProjectPath, HasGroups):
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name
         )
-        if destination_path_abs == directory_to_transfer:
+        if destination_path_abs == directory_to_transfer and not compress:
             raise ValueError(
                 "The destination_path cannot have the same name as the project to compress."
             )

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1981,6 +1981,8 @@ class Project(ProjectPath, HasGroups):
             destination_path_abs = destination_path_abs.split(".tar.gz")[0]
             compress = True
         directory_to_transfer = os.path.abspath(self.path)
+        assert not destination_path_ab.endswith(".tar")
+        assert not destination_path_ab.endswith(".gz")
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name
         )

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1980,11 +1980,11 @@ class Project(ProjectPath, HasGroups):
         if ".tar.gz" in destination_path_abs:
             destination_path_abs = destination_path_abs.split(".tar.gz")[0]
             compress = True
-        directory_to_transfer = os.path.dirname(self.path)
+        directory_to_transfer = os.path.abspath(self.path)
         csv_file_path = os.path.join(
             os.path.dirname(destination_path_abs), csv_file_name
         )
-        if destination_path == directory_to_transfer and not compress:
+        if destination_path_abs == directory_to_transfer and not compress:
             raise ValueError(
                 "The destination_path cannot have the same name as the project to compress."
             )

--- a/tests/unit/archiving/test_export.py
+++ b/tests/unit/archiving/test_export.py
@@ -65,6 +65,8 @@ class TestPack(PyironTestCase):
         os.remove(file_path)
         with self.assertRaises(ValueError):
             self.pr.pack(compress=False)
+        with self.assertRaises(ValueError):
+            self.pr.pack(destination_path=self.pr.path, compress=False)
 
     def test_compress(self):
         # here we check whether the packing function

--- a/tests/unit/archiving/test_export.py
+++ b/tests/unit/archiving/test_export.py
@@ -58,6 +58,14 @@ class TestPack(PyironTestCase):
         h5_file_path = self.arch_dir + "/" + self.pr.name + "/toy.h5"
         self.assertTrue(os.path.exists(h5_file_path))
 
+    def test_compress_undefined_destination(self):
+        self.pr.pack(compress=True)
+        file_path = self.pr.name + ".tar.gz"
+        self.assertTrue(os.path.exists(file_path))
+        os.remove(file_path)
+        with self.assertRaises(ValueError):
+            self.pr.pack(compress=False)
+
     def test_compress(self):
         # here we check whether the packing function
         # does the compressibility right


### PR DESCRIPTION
Following [this PR](https://github.com/pyiron/pyiron_base/pull/1570) now `pack` doesn't require a destination path.