### PR TITLE
Introduce `pyiron_mini`

### DIFF
--- a/pyiron_base/mini.py
+++ b/pyiron_base/mini.py
@@ -157,7 +157,12 @@ def cache_clear(silently: bool = False):
     Project(path=".").remove_jobs(recursive=True, silently=silently)
 
 
-def conda_create_env(env_name: str, env_file: str, use_mamba: bool = False, global_installation: bool = True):
+def conda_create_env(
+    env_name: str,
+    env_file: str,
+    use_mamba: bool = False,
+    global_installation: bool = True,
+):
     """
     Create conda environment to execute selected pyiron tasks in a separate conda environment
 
@@ -173,5 +178,5 @@ def conda_create_env(env_name: str, env_file: str, use_mamba: bool = False, glob
         env_name=env_name,
         env_file=env_file,
         global_installation=global_installation,
-        use_mamba=use_mamba
+        use_mamba=use_mamba,
     )

--- a/pyiron_base/mini.py
+++ b/pyiron_base/mini.py
@@ -1,7 +1,7 @@
 from pyiron_base.project.generic import Project
 
 
-def warp_exe(
+def wrap_exe(
     executable_str,
     job_name=None,
     write_input_funct=None,

--- a/pyiron_base/mini.py
+++ b/pyiron_base/mini.py
@@ -1,6 +1,15 @@
 from pyiron_base.project.generic import Project
 
 
+try:
+    import os
+    from pyiron_base.project.condaenv import CondaEnvironment
+except ImportError:
+    pass
+else:
+    conda = CondaEnvironment(env_path=os.path.abspath("conda"))
+
+
 def wrap_exe(
     executable_str,
     job_name=None,
@@ -155,28 +164,3 @@ def cache_clear(silently: bool = False):
         silently (bool): Enable silent clearing without asking the user for confirmation
     """
     Project(path=".").remove_jobs(recursive=True, silently=silently)
-
-
-def conda_create_env(
-    env_name: str,
-    env_file: str,
-    use_mamba: bool = False,
-    global_installation: bool = True,
-):
-    """
-    Create conda environment to execute selected pyiron tasks in a separate conda environment
-
-    Args:
-        env_name (str): Name of the new conda environment
-        env_file (str): Path to the conda environment file (environment.yml) which includes the dependencies for the new
-                        conda environment.
-        use_mamba (bool): Use mamba rather than conda - false by default
-        global_installation (bool): Create a global conda environment rather than creating the conda environment in the
-                                    current folder - true by default
-    """
-    Project(path=".").conda_environment.create(
-        env_name=env_name,
-        env_file=env_file,
-        global_installation=global_installation,
-        use_mamba=use_mamba,
-    )

--- a/pyiron_base/mini.py
+++ b/pyiron_base/mini.py
@@ -1,0 +1,177 @@
+from pyiron_base.project.generic import Project
+
+
+def warp_exe(
+    executable_str,
+    job_name=None,
+    write_input_funct=None,
+    collect_output_funct=None,
+    input_dict=None,
+    conda_environment_path=None,
+    conda_environment_name=None,
+    input_file_lst=None,
+    automatically_rename=False,
+    execute_job=False,
+    delayed=False,
+    output_file_lst=[],
+    output_key_lst=[],
+):
+    """
+    Wrap any executable into a pyiron job object using the ExecutableContainerJob.
+
+    Args:
+        executable_str (str): call to an external executable
+        job_name (str): name of the new job object
+        write_input_funct (callable): The write input function write_input(input_dict, working_directory)
+        collect_output_funct (callable): The collect output function collect_output(working_directory)
+        input_dict (dict): Default input for the newly created job class
+        conda_environment_path (str): path of the conda environment
+        conda_environment_name (str): name of the conda environment
+        input_file_lst (list): list of files to be copied to the working directory before executing it\
+        execute_job (boolean): automatically call run() on the job object - default false
+        automatically_rename (bool): Whether to automatically rename the job at
+            save-time to append a string based on the input values. (Default is
+            False.)
+        delayed (bool): delayed execution
+        output_file_lst (list):
+        output_key_lst (list):
+
+    Example:
+
+    >>> def write_input(input_dict, working_directory="."):
+    >>>     with open(os.path.join(working_directory, "input_file"), "w") as f:
+    >>>         f.write(str(input_dict["energy"]))
+    >>>
+    >>>
+    >>> def collect_output(working_directory="."):
+    >>>     with open(os.path.join(working_directory, "output_file"), "r") as f:
+    >>>         return {"energy": float(f.readline())}
+    >>>
+    >>>
+    >>> import pyiron_base.mini as pyiron_mini
+    >>> job = pyiron_mini.wrap_exe(
+    >>>     write_input_funct=write_input,
+    >>>     collect_output_funct=collect_output,
+    >>>     input_dict={"energy": 1.0},
+    >>>     executable_str="cat input_file > output_file",
+    >>>     execute_job=True,
+    >>> )
+    >>> print(job.output)
+
+    Returns:
+        pyiron_base.jobs.flex.ExecutableContainerJob: pyiron job object
+    """
+    return Project(path=".").wrap_executable(
+        executable_str=executable_str,
+        job_name=job_name,
+        write_input_funct=write_input_funct,
+        collect_output_funct=collect_output_funct,
+        input_dict=input_dict,
+        conda_environment_path=conda_environment_path,
+        conda_environment_name=conda_environment_name,
+        input_file_lst=input_file_lst,
+        automatically_rename=automatically_rename,
+        execute_job=execute_job,
+        delayed=delayed,
+        output_file_lst=output_file_lst,
+        output_key_lst=output_key_lst,
+    )
+
+
+def wrap_py(
+    python_function,
+    *args,
+    job_name=None,
+    automatically_rename=True,
+    execute_job=False,
+    delayed=False,
+    output_file_lst=[],
+    output_key_lst=[],
+    **kwargs,
+):
+    """
+    Create a pyiron job object from any python function
+
+    Args:
+        python_function (callable): python function to create a job object from
+        *args: Arguments for the user-defined python function
+        job_name (str | None): The name for the created job. (Default is None, use
+            the name of the function.)
+        automatically_rename (bool): Whether to automatically rename the job at
+            save-time to append a string based on the input values. (Default is
+            True.)
+        delayed (bool): delayed execution
+        execute_job (boolean): automatically call run() on the job object - default false
+        **kwargs: Keyword-arguments for the user-defined python function
+
+    Returns:
+        pyiron_base.jobs.flex.pythonfunctioncontainer.PythonFunctionContainerJob: pyiron job object
+
+    Example:
+
+    >>> def test_function(a, b=8):
+    >>>     return a+b
+    >>>
+    >>> import pyiron_base.mini as pyiron_mini
+    >>> job = pyiron_mini.wrap_py(test_function)
+    >>> job.input["a"] = 4
+    >>> job.input["b"] = 5
+    >>> job.run()
+    >>> job.output
+    >>>
+    >>> pyiron_mini.wrap_py(test_function, 4, b=6)
+
+    """
+    return Project(path=".").wrap_python_function(
+        python_function=python_function,
+        *args,
+        job_name=job_name,
+        automatically_rename=automatically_rename,
+        execute_job=execute_job,
+        delayed=delayed,
+        output_file_lst=output_file_lst,
+        output_key_lst=output_key_lst,
+        **kwargs,
+    )
+
+
+def cache_list():
+    """
+    By default pyiron_mini caches the results of completed calculation. With the cache_list() function the content of
+    the cache in the current folder including sub-folders is listed.
+
+    Returns:
+        pandas.DataFrame: pyiron_mini cache in the current folder including sub-folders
+    """
+    return Project(path=".").job_table(recursive=True)
+
+
+def cache_clear(silently: bool = False):
+    """
+    By default pyiron_mini caches the results of completed calculation. With the cache_clear() function the content of
+    the cache in the current folder including sub-folders is cleared.
+
+    Args:
+        silently (bool): Enable silent clearing without asking the user for confirmation
+    """
+    Project(path=".").remove_jobs(recursive=True, silently=silently)
+
+
+def conda_create_env(env_name: str, env_file: str, use_mamba: bool = False, global_installation: bool = True):
+    """
+    Create conda environment to execute selected pyiron tasks in a separate conda environment
+
+    Args:
+        env_name (str): Name of the new conda environment
+        env_file (str): Path to the conda environment file (environment.yml) which includes the dependencies for the new
+                        conda environment.
+        use_mamba (bool): Use mamba rather than conda - false by default
+        global_installation (bool): Create a global conda environment rather than creating the conda environment in the
+                                    current folder - true by default
+    """
+    Project(path=".").conda_environment.create(
+        env_name=env_name,
+        env_file=env_file,
+        global_installation=global_installation,
+        use_mamba=use_mamba
+    )

--- a/pyiron_base/mini.py
+++ b/pyiron_base/mini.py
@@ -1,8 +1,8 @@
 from pyiron_base.project.generic import Project
 
-
 try:
     import os
+
     from pyiron_base.project.condaenv import CondaEnvironment
 except ImportError:
     pass

--- a/pyiron_base/project/condaenv.py
+++ b/pyiron_base/project/condaenv.py
@@ -26,6 +26,17 @@ class CondaEnvironment:
             )
 
     def create(self, env_name, env_file, use_mamba=False, global_installation=True):
+        """
+        Create conda environment to execute selected pyiron tasks in a separate conda environment
+
+        Args:
+            env_name (str): Name of the new conda environment
+            env_file (str): Path to the conda environment file (environment.yml) which includes the dependencies for the
+                            new conda environment.
+            use_mamba (bool): Use mamba rather than conda - false by default
+            global_installation (bool): Create a global conda environment rather than creating the conda environment in
+                                        the current folder - true by default
+        """
         exe = "mamba" if use_mamba else "conda"
         env_lst = list_all_known_prefixes()
         env_path = os.path.join(os.path.abspath(self._env_path), env_name)

--- a/tests/usecases/ADIS/notebook.ipynb
+++ b/tests/usecases/ADIS/notebook.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "source": "import os\nimport matplotlib.pyplot as plt\nimport numpy as np\nfrom ase.io import write\nfrom adis_tools.parsers import parse_pw\nfrom pyiron_base.project.delayed import draw",
+   "source": "import os\nimport matplotlib.pyplot as plt\nimport numpy as np\nfrom ase.io import write\nfrom adis_tools.parsers import parse_pw",
    "metadata": {
     "trusted": true
    },
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "source": "from ase.build import bulk\nfrom pyiron_base import Project",
+   "source": "from ase.build import bulk\nimport pyiron_base.mini as pyiron_mini",
    "metadata": {
     "trusted": true
    },
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "source": "project = Project(\"test\")\nproject.remove_jobs(recursive=True, silently=True)\npseudopotentials = {\"Al\": \"Al.pbe-n-kjpaw_psl.1.0.0.UPF\"}",
+   "source": "pyiron_mini.cache_clear(silently=True)\npseudopotentials = {\"Al\": \"Al.pbe-n-kjpaw_psl.1.0.0.UPF\"}",
    "metadata": {
     "trusted": true
    },
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "source": "structure = project.wrap_python_function(\n    python_function=bulk,   \n    delayed=True,\n    name=\"Al\",\n    a=4.05,\n    cubic=True,\n)",
+   "source": "structure = pyiron_mini.wrap_py(\n    python_function=bulk,   \n    delayed=True,\n    name=\"Al\",\n    a=4.05,\n    cubic=True,\n)",
    "metadata": {
     "trusted": true
    },
@@ -111,7 +111,7 @@
    "cell_type": "code",
    "source": [
     "# Structure optimization \n",
-    "job_qe_minimize = project.wrap_executable(\n",
+    "job_qe_minimize = pyiron_mini.wrap_exe(\n",
     "    write_input_funct=write_input,\n",
     "    collect_output_funct=collect_output,\n",
     "    input_dict={\n",
@@ -129,7 +129,7 @@
     "\n",
     "# Generate Structures\n",
     "number_of_strains = 5 \n",
-    "structure_lst = project.wrap_python_function(\n",
+    "structure_lst = pyiron_mini.wrap_py(\n",
     "    python_function=generate_structures,\n",
     "    structure=job_qe_minimize.output.structure, \n",
     "    strain_lst=np.linspace(0.9, 1.1, number_of_strains),\n",
@@ -140,7 +140,7 @@
     "# Energy Volume Curve \n",
     "energy_lst, volume_lst = [], []\n",
     "for i, structure_strain in enumerate(structure_lst):\n",
-    "    job_strain = project.wrap_executable(\n",
+    "    job_strain = pyiron_mini.wrap_exe(\n",
     "        write_input_funct=write_input,\n",
     "        collect_output_funct=collect_output,\n",
     "        input_dict={\n",
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "source": "results = project.wrap_python_function(\n    python_function=collect,\n    volume_lst=volume_lst,\n    energy_lst=energy_lst,\n    delayed=True,\n)",
+   "source": "results = pyiron_mini.wrap_py(\n    python_function=collect,\n    volume_lst=volume_lst,\n    energy_lst=energy_lst,\n    delayed=True,\n)",
    "metadata": {
     "trusted": true
    },

--- a/tests/usecases/NFDI4ING/notebook.ipynb
+++ b/tests/usecases/NFDI4ING/notebook.ipynb
@@ -24,7 +24,7 @@
   {
    "id": "9a6b906e-568c-42ec-9d4f-ce01ff638904",
    "cell_type": "code",
-   "source": "import os\nfrom pyiron_base import Project",
+   "source": "import os\nimport pyiron_base.mini as pyiron_mini",
    "metadata": {
     "trusted": true
    },
@@ -44,7 +44,7 @@
   {
    "id": "5c032fe6-230a-4e99-9eee-066ec2579632",
    "cell_type": "code",
-   "source": "# create pyiron project \npr = Project(\"workflow\")\npr.remove_jobs(recursive=True, silently=True)",
+   "source": "# clear pyiron cache\npyiron_mini.cache_clear(silently=True)",
    "metadata": {
     "trusted": true
    },
@@ -67,7 +67,7 @@
   {
    "id": "ab091954-8f31-4952-bb61-2506892b9bb3",
    "cell_type": "code",
-   "source": "# create conda environments for the proprocessing, processing and postprocessing stage \nfor k, v in {\n    \"preprocessing\": \"source/envs/preprocessing.yaml\",\n    \"processing\": \"source/envs/processing.yaml\",\n    \"postprocessing\": \"source/envs/postprocessing.yaml\"\n}.items():\n    pr.conda_environment.create(env_name=k, env_file=v, global_installation=False, use_mamba=True)",
+   "source": "# create conda environments for the proprocessing, processing and postprocessing stage \nfor k, v in {\n    \"preprocessing\": \"source/envs/preprocessing.yaml\",\n    \"processing\": \"source/envs/processing.yaml\",\n    \"postprocessing\": \"source/envs/postprocessing.yaml\"\n}.items():\n    pyiron_mini.conda_create_env(env_name=k, env_file=v, global_installation=False, use_mamba=True)",
    "metadata": {
     "trusted": true
    },
@@ -86,7 +86,7 @@
    "source": [
     "# Preprocessing\n",
     "## generate mesh\n",
-    "gmsh = pr.wrap_executable(\n",
+    "gmsh = pyiron_mini.wrap_exe(\n",
     "    executable_str=f\"gmsh -2 -setnumber domain_size {domain_size} unit_square.geo -o square.msh\",\n",
     "    conda_environment_path=pr.conda_environment.preprocessing,\n",
     "    input_file_lst=[\"source/unit_square.geo\"],\n",
@@ -105,7 +105,7 @@
    "cell_type": "code",
    "source": [
     "## convert mesh to xdmf\n",
-    "meshio = pr.wrap_executable(\n",
+    "meshio = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"meshio convert square.msh square.xdmf\",\n",
     "    conda_environment_path=pr.conda_environment.preprocessing,\n",
     "    input_file_lst=[gmsh.files.square_msh],\n",
@@ -129,7 +129,7 @@
     "    with open(os.path.join(working_directory, \"numdofs.txt\"), \"r\") as f:\n",
     "        return {\"numdofs\": int(f.read())}\n",
     "\n",
-    "poisson = pr.wrap_executable(\n",
+    "poisson = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"python poisson.py --mesh square.xdmf --degree 2 --outputfile poisson.pvd --num-dofs numdofs.txt\",\n",
     "    conda_environment_path=pr.conda_environment.processing,\n",
     "    input_file_lst=[\"source/poisson.py\", meshio.files.square_xdmf, meshio.files.square_h5],\n",
@@ -151,7 +151,7 @@
    "source": [
     "# Postprocessing\n",
     "## plot over line\n",
-    "pvbatch = pr.wrap_executable(\n",
+    "pvbatch = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"pvbatch postprocessing.py poisson.pvd plotoverline.csv\",\n",
     "    conda_environment_path=pr.conda_environment.postprocessing,\n",
     "    input_file_lst=[\"source/postprocessing.py\", poisson.files.poisson_pvd, poisson.files.poisson000000_vtu],\n",
@@ -177,7 +177,7 @@
     "        f.writelines(f\"python prepare_paper_macros.py --macro-template-file macros.tex.template --plot-data-path plotoverline.csv --domain-size {domain_size} --num-dofs {numdofs} --output-macro-file macros.tex\")\n",
     "    os.chmod(script_name, 0o744)\n",
     "\n",
-    "macros = pr.wrap_executable(\n",
+    "macros = pyiron_mini.wrap_exe(\n",
     "    input_dict={\"numdofs\": poisson.output.numdofs},\n",
     "    input_file_lst=[\"source/macros.tex.template\", \"source/prepare_paper_macros.py\", pvbatch.files.plotoverline_csv],\n",
     "    write_input_funct=write_input,\n",
@@ -197,7 +197,7 @@
    "cell_type": "code",
    "source": [
     "## compile paper\n",
-    "tectonic = pr.wrap_executable(\n",
+    "tectonic = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"tectonic paper.tex\",\n",
     "    conda_environment_path=pr.conda_environment.postprocessing,\n",
     "    input_file_lst=[\"source/paper.tex\", macros.files.macros_tex, pvbatch.files.plotoverline_csv],\n",

--- a/tests/usecases/NFDI4ING/notebook.ipynb
+++ b/tests/usecases/NFDI4ING/notebook.ipynb
@@ -67,7 +67,7 @@
   {
    "id": "ab091954-8f31-4952-bb61-2506892b9bb3",
    "cell_type": "code",
-   "source": "# create conda environments for the proprocessing, processing and postprocessing stage \nfor k, v in {\n    \"preprocessing\": \"source/envs/preprocessing.yaml\",\n    \"processing\": \"source/envs/processing.yaml\",\n    \"postprocessing\": \"source/envs/postprocessing.yaml\"\n}.items():\n    pyiron_mini.conda_create_env(env_name=k, env_file=v, global_installation=False, use_mamba=True)",
+   "source": "# create conda environments for the proprocessing, processing and postprocessing stage \nfor k, v in {\n    \"preprocessing\": \"source/envs/preprocessing.yaml\",\n    \"processing\": \"source/envs/processing.yaml\",\n    \"postprocessing\": \"source/envs/postprocessing.yaml\"\n}.items():\n    pyiron_mini.conda.create(env_name=k, env_file=v, global_installation=False, use_mamba=True)",
    "metadata": {
     "trusted": true
    },
@@ -88,7 +88,7 @@
     "## generate mesh\n",
     "gmsh = pyiron_mini.wrap_exe(\n",
     "    executable_str=f\"gmsh -2 -setnumber domain_size {domain_size} unit_square.geo -o square.msh\",\n",
-    "    conda_environment_path=pr.conda_environment.preprocessing,\n",
+    "    conda_environment_path=pyiron_mini.conda.preprocessing,\n",
     "    input_file_lst=[\"source/unit_square.geo\"],\n",
     "    delayed=True,\n",
     "    output_file_lst=[\"square.msh\"],\n",
@@ -107,7 +107,7 @@
     "## convert mesh to xdmf\n",
     "meshio = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"meshio convert square.msh square.xdmf\",\n",
-    "    conda_environment_path=pr.conda_environment.preprocessing,\n",
+    "    conda_environment_path=pyiron_mini.conda.preprocessing,\n",
     "    input_file_lst=[gmsh.files.square_msh],\n",
     "    delayed=True,\n",
     "    output_file_lst=[\"square.xdmf\", \"square.h5\"],\n",
@@ -131,7 +131,7 @@
     "\n",
     "poisson = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"python poisson.py --mesh square.xdmf --degree 2 --outputfile poisson.pvd --num-dofs numdofs.txt\",\n",
-    "    conda_environment_path=pr.conda_environment.processing,\n",
+    "    conda_environment_path=pyiron_mini.conda.processing,\n",
     "    input_file_lst=[\"source/poisson.py\", meshio.files.square_xdmf, meshio.files.square_h5],\n",
     "    delayed=True,\n",
     "    collect_output_funct=collect_output,\n",
@@ -153,7 +153,7 @@
     "## plot over line\n",
     "pvbatch = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"pvbatch postprocessing.py poisson.pvd plotoverline.csv\",\n",
-    "    conda_environment_path=pr.conda_environment.postprocessing,\n",
+    "    conda_environment_path=pyiron_mini.conda.postprocessing,\n",
     "    input_file_lst=[\"source/postprocessing.py\", poisson.files.poisson_pvd, poisson.files.poisson000000_vtu],\n",
     "    delayed=True,\n",
     "    output_file_lst=[\"plotoverline.csv\"],\n",
@@ -182,6 +182,7 @@
     "    input_file_lst=[\"source/macros.tex.template\", \"source/prepare_paper_macros.py\", pvbatch.files.plotoverline_csv],\n",
     "    write_input_funct=write_input,\n",
     "    executable_str=\"./macros.sh\",\n",
+    "    conda_environment_path=pyiron_mini.conda.postprocessing,\n",
     "    delayed=True,\n",
     "    output_file_lst=[\"macros.tex\"],\n",
     ")"
@@ -199,7 +200,7 @@
     "## compile paper\n",
     "tectonic = pyiron_mini.wrap_exe(\n",
     "    executable_str=\"tectonic paper.tex\",\n",
-    "    conda_environment_path=pr.conda_environment.postprocessing,\n",
+    "    conda_environment_path=pyiron_mini.conda.postprocessing,\n",
     "    input_file_lst=[\"source/paper.tex\", macros.files.macros_tex, pvbatch.files.plotoverline_csv],\n",
     "    delayed=True,\n",
     ")"


### PR DESCRIPTION
For users who just want to use pyiron as a workflow manager for any kind of python function or executable, `pyiron_mini` provides a minimal set of functions. You can import it as:
```python
import pyiron_base.mini as pyiron_mini
```
Then you have access to:
* `pyiron_mini.wrap_exe()` to wrap external executables.
* `pyiron_mini.wrap_py()` to wrap python functions.
* `pyiron_mini.cache_list()` to list the currently cached tasks.
* `pyiron_mini.cache_clear()` to clear the cache.
* `pyiron_mini.conda_create_env()` to create new conda environments to execute tasks in.

If `pyiron_mini` is not short enough you can also import it as `import pyiron_base.mini as pm` in that case it is as short as the `pr` we commonly use to reference a `Project` object.