### PR TITLE
not use relpath by default

### DIFF
--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -38,7 +38,7 @@ def update_project(project_instance, directory_to_transfer, archive_directory, d
 
 
 def copy_files_to_archive(
-    directory_to_transfer, archive_directory, compress=True, copy_all_files=False
+    directory_to_transfer, archive_directory, compress=True, copy_all_files=False, arcname=None
 ):
     """
     Copy files from a directory to an archive, optionally compressing the archive.
@@ -67,6 +67,10 @@ def copy_files_to_archive(
             copy_h5_files(origin, destination)
 
     assert isinstance(archive_directory, str) and ".tar.gz" not in archive_directory
+    if arcname is None:
+        arcname = os.path.relpath(
+            os.path.abspath(archive_directory), os.getcwd()
+        )
     dir_name_transfer = getdir(path=directory_to_transfer)
     if not compress:
         copy_files(
@@ -81,9 +85,7 @@ def copy_files_to_archive(
             with tarfile.open(f"{archive_directory}.tar.gz", "w:gz") as tar:
                 tar.add(
                     temp_dir,
-                    arcname=os.path.relpath(
-                        os.path.abspath(archive_directory), os.getcwd()
-                    ),
+                    arcname=arcname,
                 )
 
 

--- a/pyiron_base/project/archiving/export_archive.py
+++ b/pyiron_base/project/archiving/export_archive.py
@@ -38,7 +38,11 @@ def update_project(project_instance, directory_to_transfer, archive_directory, d
 
 
 def copy_files_to_archive(
-    directory_to_transfer, archive_directory, compress=True, copy_all_files=False, arcname=None
+    directory_to_transfer,
+    archive_directory,
+    compress=True,
+    copy_all_files=False,
+    arcname=None,
 ):
     """
     Copy files from a directory to an archive, optionally compressing the archive.
@@ -68,9 +72,7 @@ def copy_files_to_archive(
 
     assert isinstance(archive_directory, str) and ".tar.gz" not in archive_directory
     if arcname is None:
-        arcname = os.path.relpath(
-            os.path.abspath(archive_directory), os.getcwd()
-        )
+        arcname = os.path.relpath(os.path.abspath(archive_directory), os.getcwd())
     dir_name_transfer = getdir(path=directory_to_transfer)
     if not compress:
         copy_files(

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1975,11 +1975,13 @@ class Project(ProjectPath, HasGroups):
             copy_all_files (bool):
         """
         if destination_path is None:
-            destination_path = os.path.dirname(self.path)
-        destination_path_abs = os.path.abspath(destination_path)
-        if ".tar.gz" in destination_path_abs:
-            destination_path_abs = destination_path_abs.split(".tar.gz")[0]
+            destination_path = self.path
+        if os.path.isabs(destination_path):
+            destination_path = os.path.relpath(destination_path, os.getcwd())
+        if ".tar.gz" in destination_path:
+            destination_path = destination_path.split(".tar.gz")[0]
             compress = True
+        destination_path_abs = os.path.abspath(destination_path)
         directory_to_transfer = os.path.abspath(self.path)
         assert not destination_path_abs.endswith(".tar")
         assert not destination_path_abs.endswith(".gz")
@@ -1995,6 +1997,7 @@ class Project(ProjectPath, HasGroups):
             destination_path_abs,
             compress=compress,
             copy_all_files=copy_all_files,
+            arcname=destination_path,
         )
         df = export_archive.export_database(
             self, directory_to_transfer, destination_path_abs


### PR DESCRIPTION
This is mainly because windows tests fail when I try to determine `arcname` using `relpath`. I guess this PR will fix the problems that I encountered in [this PR](https://github.com/pyiron/pyiron_base/pull/1589) and [this PR](https://github.com/pyiron/pyiron_base/pull/1558)