### PR TITLE
[patch] Add warning when the same job is imported multiple times with `unpack`

### DIFF
--- a/pyiron_base/database/generic.py
+++ b/pyiron_base/database/generic.py
@@ -7,11 +7,11 @@ DatabaseAccess class deals with accessing the database
 
 import os
 import re
+import warnings
 from datetime import datetime
 from queue import Empty as QueueEmpty
 from queue import SimpleQueue
 from threading import Lock, Thread
-import warnings
 
 import numpy as np
 import pandas
@@ -611,11 +611,14 @@ class DatabaseAccess(IsDatabase):
         Args:
             par_dict (dict): Dictionary with the item values and column names as keys
         """
-        return len(
-            self.get_items_dict(
-                {"job": par_dict["job"], "project": par_dict["project"]}
+        return (
+            len(
+                self.get_items_dict(
+                    {"job": par_dict["job"], "project": par_dict["project"]}
+                )
             )
-        ) > 0
+            > 0
+        )
 
     # Item functions
     def add_item_dict(self, par_dict, check_duplicates=False):

--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -83,7 +83,9 @@ def import_jobs(project_instance, archive_directory, df, compressed=True):
             entry["timestop"] = pandas.to_datetime(entry["timestop"])
         if "username" not in entry:
             entry["username"] = state.settings.login_user
-        job_id = pr_import.db.add_item_dict(par_dict=entry)
+        job_id = pr_import.db.add_item_dict(
+            par_dict=entry, check_duplicates=True
+        )
         job_id_lst.append(job_id)
 
     # Update parent and master ids

--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -83,9 +83,7 @@ def import_jobs(project_instance, archive_directory, df, compressed=True):
             entry["timestop"] = pandas.to_datetime(entry["timestop"])
         if "username" not in entry:
             entry["username"] = state.settings.login_user
-        job_id = pr_import.db.add_item_dict(
-            par_dict=entry, check_duplicates=True
-        )
+        job_id = pr_import.db.add_item_dict(par_dict=entry, check_duplicates=True)
         job_id_lst.append(job_id)
 
     # Update parent and master ids


### PR DESCRIPTION
In the current format the following code would import the same job `test` twice.

```python
from pyiron_base import Project


pr = Project("TEST")
job = pr.create_job(ToyJob, "test")
job.run()
pr.pack("archive")
pr = Project("import")
pr.unpack("archive")
pr.unpack("archive")
```

And with this PR it does not import the same job and issues a warning.