### PR TITLE
[minor] Recursive to/from_dict

### DIFF
--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -112,6 +112,7 @@ class HasDict(ABC):
             obj_dict (dict): data previously returned from :meth:`.to_dict`
             version (str): version tag written together with the data
         """
+
         def load(inner_dict):
             if not isinstance(inner_dict, dict):
                 return inner_dict

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -178,7 +178,7 @@ class HasDictfromHDF(HasDict, HasHDF):
         # interface
         group_name = self._get_hdf_group_name()
         if group_name is not None:
-            hdf = DummyHDFio(None, "/", {self._get_hdf_group_name(): obj_dict})
+            hdf = DummyHDFio(None, "/", {group_name: obj_dict})
         else:
             hdf = DummyHDFio(None, "/", obj_dict)
         self.from_hdf(hdf)

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -657,8 +657,8 @@ class TableJob(GenericJob):
                 hdf5_output.file_name, key=hdf5_output.h5_path + "/table"
             )
 
-    def to_dict(self):
-        job_dict = super().to_dict()
+    def _to_dict(self):
+        job_dict = super()._to_dict()
         job_dict["input/bool_dict"] = {
             "enforce_update": self._enforce_update,
             "convert_to_object": self._pyiron_table.convert_to_object,
@@ -683,10 +683,10 @@ class TableJob(GenericJob):
             )
         return job_dict
 
-    def from_dict(self, job_dict):
-        super().from_dict(job_dict=job_dict)
-        if "project" in job_dict["input"].keys():
-            project_dict = job_dict["input"]["project"]
+    def _from_dict(self, obj_dict, version=None):
+        super()._from_dict(obj_dict=obj_dict, version=version)
+        if "project" in obj_dict["input"].keys():
+            project_dict = obj_dict["input"]["project"]
             if os.path.exists(project_dict["path"]):
                 project = self.project.__class__(
                     path=project_dict["path"],
@@ -700,18 +700,18 @@ class TableJob(GenericJob):
                 self._logger.warning(
                     f"Could not instantiate analysis_project, no such path {project_dict['path']}."
                 )
-        if "filter" in job_dict["input"].keys():
+        if "filter" in obj_dict["input"].keys():
             self.pyiron_table.filter_function = _from_pickle(
-                job_dict["input"], "filter"
+                obj_dict["input"], "filter"
             )
-        if "db_filter" in job_dict["input"].keys():
+        if "db_filter" in obj_dict["input"].keys():
             self.pyiron_table.db_filter_function = _from_pickle(
-                job_dict["input"], "db_filter"
+                obj_dict["input"], "db_filter"
             )
-        bool_dict = job_dict["input"]["bool_dict"]
+        bool_dict = obj_dict["input"]["bool_dict"]
         self._enforce_update = bool_dict["enforce_update"]
         self._pyiron_table.convert_to_object = bool_dict["convert_to_object"]
-        self._pyiron_table.add._from_hdf(job_dict["input"])
+        self._pyiron_table.add._from_hdf(obj_dict["input"])
 
     def to_hdf(self, hdf=None, group_name=None):
         """

--- a/pyiron_base/jobs/flex/executablecontainer.py
+++ b/pyiron_base/jobs/flex/executablecontainer.py
@@ -141,14 +141,14 @@ class ExecutableContainerJob(TemplateJob):
             collect_output_funct=self._collect_output_funct,
         )
 
-    def to_dict(self) -> dict:
+    def _to_dict(self) -> dict:
         """
         Convert the job object to a dictionary representation.
 
         Returns:
             dict: A dictionary representation of the job object.
         """
-        job_dict = super().to_dict()
+        job_dict = super()._to_dict()
         if self._write_input_funct is not None:
             job_dict["write_input_function"] = np.void(
                 cloudpickle.dumps(self._write_input_funct)
@@ -159,20 +159,20 @@ class ExecutableContainerJob(TemplateJob):
             )
         return job_dict
 
-    def from_dict(self, job_dict: dict):
+    def _from_dict(self, obj_dict: dict, version=None):
         """
         Load the job attributes from a dictionary representation.
 
         Args:
-            job_dict (dict): A dictionary containing the job attributes.
+            obj_dict (dict): A dictionary containing the job attributes.
 
         """
-        super().from_dict(job_dict=job_dict)
-        if "write_input_function" in job_dict.keys():
+        super()._from_dict(obj_dict=obj_dict)
+        if "write_input_function" in obj_dict.keys():
             self._write_input_funct = cloudpickle.loads(
-                job_dict["write_input_function"]
+                obj_dict["write_input_function"]
             )
-        if "write_input_function" in job_dict.keys():
+        if "write_input_function" in obj_dict.keys():
             self._collect_output_funct = cloudpickle.loads(
-                job_dict["collect_output_function"]
+                obj_dict["collect_output_function"]
             )

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -71,31 +71,31 @@ class PythonFunctionContainerJob(PythonTemplateJob):
         self.run()
         return self.output["result"]
 
-    def to_dict(self) -> dict:
+    def _to_dict(self) -> dict:
         """
         Convert the job object to a dictionary representation.
 
         Returns:
             dict: The dictionary representation of the job object.
         """
-        job_dict = super().to_dict()
+        job_dict = super()._to_dict()
         job_dict["function"] = np.void(cloudpickle.dumps(self._function))
         job_dict["_automatically_rename_on_save_using_input"] = (
             self._automatically_rename_on_save_using_input
         )
         return job_dict
 
-    def from_dict(self, job_dict: dict) -> None:
+    def _from_dict(self, obj_dict: dict, version=None) -> None:
         """
         Load the job object from a dictionary representation.
 
         Args:
-            job_dict (dict): The dictionary representation of the job object.
+            obj_dict (dict): The dictionary representation of the job object.
         """
-        super().from_dict(job_dict=job_dict)
-        self._function = cloudpickle.loads(job_dict["function"])
+        super()._from_dict(obj_dict=obj_dict)
+        self._function = cloudpickle.loads(obj_dict["function"])
         self._automatically_rename_on_save_using_input = bool(
-            job_dict["_automatically_rename_on_save_using_input"]
+            obj_dict["_automatically_rename_on_save_using_input"]
         )
 
     def save(self):

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -51,6 +51,8 @@ class Executable(HasDict):
         else:
             operation_system_nt = os.name == "nt"
 
+        if codename is None:
+            breakpoint()
         self.storage = ExecutableDataClass(
             version=None,
             name=codename.lower(),
@@ -206,10 +208,14 @@ class Executable(HasDict):
         else:
             self.storage.mpi = False
 
+    @classmethod
+    def instantiate(cls, obj_dict: dict, version: str = None) -> "Self":
+        return cls(codename=obj_dict["name"])
+
     def _to_dict(self):
         return asdict(self.storage)
 
-    def from_dict(self, executable_dict):
+    def _from_dict(self, obj_dict, version=None):
         data_container_keys = [
             "version",
             "name",
@@ -220,12 +226,10 @@ class Executable(HasDict):
         ]
         executable_class_dict = {}
         # Backwards compatibility; dict state used to be nested one level deeper
-        if "executable" in executable_dict.keys() and isinstance(
-            executable_dict["executable"], dict
-        ):
-            executable_dict = executable_dict["executable"]
+        if "executable" in obj_dict.keys() and isinstance(obj_dict["executable"], dict):
+            obj_dict = obj_dict["executable"]
         for key in data_container_keys:
-            executable_class_dict[key] = executable_dict.get(key, None)
+            executable_class_dict[key] = obj_dict.get(key, None)
         self.storage = ExecutableDataClass(**executable_class_dict)
 
     def get_input_for_subprocess_call(self, cores, threads, gpus=None):

--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -51,8 +51,6 @@ class Executable(HasDict):
         else:
             operation_system_nt = os.name == "nt"
 
-        if codename is None:
-            breakpoint()
         self.storage = ExecutableDataClass(
             version=None,
             name=codename.lower(),

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -566,23 +566,23 @@ class Server(
         return asdict(self._data)
         return server_dict
 
-    def from_dict(self, server_dict):
+    def _from_dict(self, obj_dict, version=None):
         # backwards compatibility
-        if "new_h5" in server_dict.keys():
-            server_dict["new_hdf"] = server_dict.pop("new_h5") == 1
+        if "new_h5" in obj_dict.keys():
+            obj_dict["new_hdf"] = obj_dict.pop("new_h5") == 1
         for key in ["conda_environment_name", "conda_environment_path", "qid"]:
-            if key not in server_dict.keys():
-                server_dict[key] = None
-        if "accept_crash" not in server_dict.keys():
-            server_dict["accept_crash"] = False
-        if "additional_arguments" not in server_dict.keys():
-            server_dict["additional_arguments"] = {}
+            if key not in obj_dict.keys():
+                obj_dict[key] = None
+        if "accept_crash" not in obj_dict.keys():
+            obj_dict["accept_crash"] = False
+        if "additional_arguments" not in obj_dict.keys():
+            obj_dict["additional_arguments"] = {}
 
         # Reload dataclass
         for key in ["NAME", "TYPE", "OBJECT", "VERSION", "DICT_VERSION"]:
-            if key in server_dict.keys():
-                del server_dict[key]
-        self._data = ServerDataClass(**server_dict)
+            if key in obj_dict.keys():
+                del obj_dict[key]
+        self._data = ServerDataClass(**obj_dict)
         self._run_mode = Runmode(mode=self._data.run_mode)
 
     @deprecate(message="Use job.server.to_dict() instead of to_hdf()", version=0.9)
@@ -609,9 +609,9 @@ class Server(
         """
         if group_name is not None:
             with hdf.open(group_name) as hdf_group:
-                self.from_dict(server_dict=hdf_group["server"])
+                self.from_dict(obj_dict=hdf_group["server"])
         else:
-            self.from_dict(server_dict=hdf["server"])
+            self.from_dict(obj_dict=hdf["server"])
 
     def db_entry(self):
         """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1174,14 +1174,14 @@ class GenericJob(JobCore, HasDict):
             data_dict["files_to_compress"] = self._files_to_remove
         return data_dict
 
-    def from_dict(self, job_dict):
-        self._type_from_dict(type_dict=job_dict)
-        if "import_directory" in job_dict.keys():
-            self._import_directory = job_dict["import_directory"]
-        self._server.from_dict(server_dict=job_dict["server"])
-        if "executable" in job_dict.keys() and job_dict["executable"] is not None:
-            self.executable.from_dict(job_dict["executable"])
-        input_dict = job_dict["input"]
+    def _from_dict(self, obj_dict, version=None):
+        self._type_from_dict(type_dict=obj_dict)
+        if "import_directory" in obj_dict.keys():
+            self._import_directory = obj_dict["import_directory"]
+        self._server = obj_dict["server"]
+        if "executable" in obj_dict.keys() and obj_dict["executable"] is not None:
+            self._executable = obj_dict["executable"]
+        input_dict = obj_dict["input"]
         if "generic_dict" in input_dict.keys():
             generic_dict = input_dict["generic_dict"]
             self._restart_file_list = generic_dict["restart_file_list"]
@@ -1242,7 +1242,7 @@ class GenericJob(JobCore, HasDict):
             exe_dict = self._hdf5["executable/executable"].to_object().to_builtin()
             exe_dict["READ_ONLY"] = self._hdf5["executable/executable/READ_ONLY"]
             job_dict["executable"] = {"executable": exe_dict}
-        self.from_dict(job_dict=job_dict)
+        self.from_dict(obj_dict=job_dict)
 
     def save(self):
         """

--- a/pyiron_base/jobs/job/template.py
+++ b/pyiron_base/jobs/job/template.py
@@ -78,14 +78,14 @@ class TemplateJob(GenericJob, HasStorage):
     def output(self):
         return self.storage.output
 
-    def to_dict(self):
-        job_dict = super().to_dict()
-        job_dict["input/data"] = self.storage.input.to_builtin()
+    def _to_dict(self):
+        job_dict = super()._to_dict()
+        job_dict["input/data"] = self.storage.input.to_dict()
         return job_dict
 
-    def from_dict(self, job_dict):
-        super().from_dict(job_dict=job_dict)
-        input_dict = job_dict["input"]
+    def _from_dict(self, obj_dict, version=None):
+        super()._from_dict(obj_dict=obj_dict, version=version)
+        input_dict = obj_dict["input"]
         if "data" in input_dict.keys():
             self.storage.input.update(input_dict["data"])
 

--- a/pyiron_base/jobs/script.py
+++ b/pyiron_base/jobs/script.py
@@ -278,21 +278,21 @@ class ScriptJob(GenericJob):
         """
         self._enable_mpi4py = True
 
-    def from_dict(self, job_dict: dict) -> None:
+    def _from_dict(self, obj_dict, version=None) -> None:
         """
         Load job attributes from a dictionary.
 
         Args:
-            job_dict (dict): The dictionary containing the job attributes.
+            obj_dict (dict): The dictionary containing the job attributes.
         """
-        super().from_dict(job_dict=job_dict)
-        if "parallel" in job_dict["input"].keys():
-            self._enable_mpi4py = job_dict["input"]["parallel"]
-        path = job_dict["input"]["path"]
+        super()._from_dict(obj_dict=obj_dict)
+        if "parallel" in obj_dict["input"].keys():
+            self._enable_mpi4py = obj_dict["input"]["parallel"]
+        path = obj_dict["input"]["path"]
         if path is not None:
             self.script_path = path
-        if "custom_dict" in job_dict["input"].keys():
-            self.input.update(job_dict["input"]["custom_dict"])
+        if "custom_dict" in obj_dict["input"].keys():
+            self.input.update(obj_dict["input"]["custom_dict"])
 
     def get_input_parameter_dict(self):
         """
@@ -360,14 +360,14 @@ class ScriptJob(GenericJob):
         super().set_input_to_read_only()
         self.input.read_only = True
 
-    def to_dict(self) -> dict:
+    def _to_dict(self) -> dict:
         """
         Convert the job object to a dictionary.
 
         Returns:
             dict: A dictionary representation of the job object.
         """
-        job_dict = super().to_dict()
+        job_dict = super()._to_dict()
         job_dict["input/path"] = self._script_path
         job_dict["input/parallel"] = self._enable_mpi4py
         job_dict["input/custom_dict"] = self.input.to_builtin()

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -1029,11 +1029,11 @@ class DataContainer(DataContainerBase, HasHDF, HasDict):
     def _to_dict(self):
         return {"data": self.to_builtin(), "READ_ONLY": self.read_only}
 
-    def from_dict(self, data_dict):
+    def _from_dict(self, obj_dict, version=None):
         with self.unlocked():
             self.clear()
-            self.update(data_dict["data"], wrap=True)
-        self.read_only = data_dict.get("READ_ONLY", False)
+            self.update(obj_dict["data"], wrap=True)
+        self.read_only = obj_dict.get("READ_ONLY", False)
 
 
 HDFStub.register(DataContainer, lambda h, g: h[g].to_object(lazy=True))

--- a/pyiron_base/storage/parameters.py
+++ b/pyiron_base/storage/parameters.py
@@ -511,7 +511,7 @@ class GenericParameters(HasDict):
         """
         return {"data_dict": self._dataset}
 
-    def from_dict(self, obj_dict, version: str = None):
+    def _from_dict(self, obj_dict, version: str = None):
         """
         Reload GenericParameters from dictionary
 

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -316,7 +316,7 @@ class TestServerHDF(unittest.TestCase):
         hdf_dict_empty = server_empty.to_dict()
         hdf_dict_full = server_full.to_dict()
         server_from_hdf = Server()
-        server_from_hdf.from_dict(server_dict=hdf_dict_full)
+        server_from_hdf.from_dict(obj_dict=hdf_dict_full)
         self.assertEqual(hdf_dict_full["gpus"], 10)
         self.assertTrue(hdf_dict_empty["gpus"] is None)
         self.assertEqual(server_from_hdf.gpus, 10)


### PR DESCRIPTION
Adds a create_from_dict function that takes the output of HasDict.to_dict and turns it into a live object, similar to our earlier to_object() method on ProjectHDFio.
Adds an instantiate class method to HasDict to support this, this allows HasDictfromHDF to work and will be useful for dataclasses in the future. HasDict.to_dict now goes over the contents of what is returned from _to_dict and automatically converts any HasDict/HasHDF objects it finds. I haven't used this in downstream code yet to keep the change small, but in principle this will allow GenericJob/DataContainer to stop calling to_dict on their children explicitly and let the generic interface handle it.

The rest of the changes are renaming everything to _from_dict/_to_dict and normalizing the argument name to obj_dict.

This allows to store "abitrary" objects again in the input/outputs of TemplateJobs.

Separate PR for easier review.  I will add extra unit tests, but it worked already in my local notebook tests.