### PR TITLE
Interactive: Set status to aborted when job failed

### DIFF
--- a/pyiron_base/jobs/job/interactive.py
+++ b/pyiron_base/jobs/job/interactive.py
@@ -387,7 +387,10 @@ class _WithInteractiveOpen:
         return self._job
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        return self._job.interactive_close()
+        job_status = self._job.status.string
+        job_closed = self._job.interactive_close()
+        self._job.status.string = job_status
+        return job_closed
 
     def __getattr__(self, attr):
         error_message = (


### PR DESCRIPTION
Example: 
```python
from pyiron_atomistics import Project

pr = Project("test")
job = pr.create.job.Lammps("lmp")
job.structure = pr.create.structure.ase.bulk("Al", cubic=True)
job.potential = '2005--Mendelev-M-I--Al-Fe--LAMMPS--ipr1'
with job.interactive_open() as job_int:
    job_int.structure = pr.create.structure.ase.bulk("Au", cubic=True)
    job_int.run()
```
The job fails because `Au` is not included in the `Al` potential and it correctly raises an `ValueError`. Still if we check the status of the job afterwards it is listed as finished: 
```python
pr.job_table()
```
This is now fixed so the job is correctly reported as `aborted`. 

This was initially reported by @HaithamGaafer . 