### PR TITLE
Catch all exception in pyiron table

### DIFF
--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -845,8 +845,9 @@ def always_true(_):
 
 
 def _apply_list_of_functions_on_job(input_parameters):
-    from pyiron_base.jobs.job.path import JobPath
     from pyiron_snippets.logger import logger
+
+    from pyiron_base.jobs.job.path import JobPath
 
     db_entry, function_lst, convert_to_object = input_parameters
     job = JobPath.from_db_entry(db_entry)

--- a/pyiron_base/jobs/datamining.py
+++ b/pyiron_base/jobs/datamining.py
@@ -844,15 +844,9 @@ def always_true(_):
     return True
 
 
-def _apply_function_on_job(funct, job):
-    try:
-        return funct(job)
-    except (ValueError, TypeError):
-        return {}
-
-
 def _apply_list_of_functions_on_job(input_parameters):
     from pyiron_base.jobs.job.path import JobPath
+    from pyiron_snippets.logger import logger
 
     db_entry, function_lst, convert_to_object = input_parameters
     job = JobPath.from_db_entry(db_entry)
@@ -861,7 +855,8 @@ def _apply_list_of_functions_on_job(input_parameters):
         job.set_input_to_read_only()
     diff_dict = {}
     for funct in function_lst:
-        funct_dict = _apply_function_on_job(funct, job)
-        for key, value in funct_dict.items():
-            diff_dict[key] = value
+        try:
+            diff_dict.update(funct(job))
+        except Exception as e:
+            logger.warn(f"Caught exception '{e}' when called on job {job.id}!")
     return diff_dict


### PR DESCRIPTION
Previously we caught ValueError/TypeError, but other exceptions may occur in the table functions and it's somewhat annoying if this kills a long table aggregation because a single job fails.

This also interacts a bit with [executorlib](https://github.com/pyiron/executorlib/issues/389) as the uncaught exception are apparently causing trouble with some executors.