### PR TITLE
Backwards compatible loading of server/executable

### DIFF
--- a/pyiron_base/jobs/job/extension/executable.py
+++ b/pyiron_base/jobs/job/extension/executable.py
@@ -208,7 +208,11 @@ class Executable(HasDict):
 
     @classmethod
     def instantiate(cls, obj_dict: dict, version: str = None) -> "Self":
-        return cls(codename=obj_dict["name"])
+        try:
+            codename = obj_dict["name"]
+        except KeyError:
+            codename = obj_dict["executable"]["name"]
+        return cls(codename=codename)
 
     def _to_dict(self):
         return asdict(self.storage)

--- a/pyiron_base/jobs/job/extension/server/generic.py
+++ b/pyiron_base/jobs/job/extension/server/generic.py
@@ -8,7 +8,7 @@ Server object class which is connected to each job containing the technical deta
 import numbers
 import socket
 from concurrent.futures import Executor, Future
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from typing import Union
 
 from pyiron_snippets.deprecate import deprecate
@@ -564,7 +564,6 @@ class Server(
     def _to_dict(self):
         self._data.run_mode = self._run_mode.mode
         return asdict(self._data)
-        return server_dict
 
     def _from_dict(self, obj_dict, version=None):
         # backwards compatibility
@@ -578,9 +577,11 @@ class Server(
         if "additional_arguments" not in obj_dict.keys():
             obj_dict["additional_arguments"] = {}
 
-        # Reload dataclass
-        for key in ["NAME", "TYPE", "OBJECT", "VERSION", "DICT_VERSION"]:
-            if key in obj_dict.keys():
+        # Reload dataclass and discard unknown keys
+        server_fields = tuple(f.name for f in fields(ServerDataClass))
+        # force tuple otherwise dict complains about changing size
+        for key in tuple(obj_dict):
+            if key not in server_fields:
                 del obj_dict[key]
         self._data = ServerDataClass(**obj_dict)
         self._run_mode = Runmode(mode=self._data.run_mode)

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1178,9 +1178,20 @@ class GenericJob(JobCore, HasDict):
         self._type_from_dict(type_dict=obj_dict)
         if "import_directory" in obj_dict.keys():
             self._import_directory = obj_dict["import_directory"]
-        self._server = obj_dict["server"]
+        # Backwards compatibility: Previously server and executable were stored
+        # as plain dicts, but now they are dicts with additional info so that
+        # HasDict can load them automatically.
+        # We need to check whether that was possible with the instance check
+        # below and if not, call from_dict ourselves.
+        if isinstance(server := obj_dict["server"], Server):
+            self._server = server
+        else:
+            self._server.from_dict(server)
         if "executable" in obj_dict.keys() and obj_dict["executable"] is not None:
-            self._executable = obj_dict["executable"]
+            if isinstance(executable := obj_dict["executable"], Executable):
+                self._executable = executable
+            else:
+                self.executable.from_dict(executable)
         input_dict = obj_dict["input"]
         if "generic_dict" in input_dict.keys():
             generic_dict = input_dict["generic_dict"]


### PR DESCRIPTION
The issue in https://github.com/pyiron/pyiron_atomistics/pull/1531 is caused by the fact that the dictionaries stored for servers/executables in HDF5 changed slightly and I assumed in #1602 that they would always be automatically loaded by the new HasDict functions.  But that only works when the newer dictionaries are written, the older representation doesn't have the type information that allows HasDict to automatically load them, so `GenericJob._from_dict` assigned the plain dictionaries which then triggered the actual errors seen in CI.

With these changes I can load older Calphy and Vasp jobs again.