### PR TITLE
Fix windows paths

### DIFF
--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import tarfile
 import tempfile
 from shutil import copytree
@@ -57,8 +58,8 @@ def import_jobs(project_instance, archive_directory):
 
     pr_import = project_instance.open(os.curdir)
     df["project"] = [
-        os.path.normpath(
-            os.path.join(pr_import.project_path, os.path.relpath(p, common_path))
+        posixpath.normpath(
+            posixpath.join(pr_import.project_path, posixpath.relpath(p, common_path))
         )
         + "/"
         for p in df["project"].values
@@ -105,8 +106,8 @@ def transfer_files(origin_path: str, project_path: str):
         str: Common path.
     """
     df = get_dataframe(origin_path=origin_path)
-    common_path = os.path.commonpath(list(df["project"]))
-    copytree(os.path.join(origin_path, common_path), project_path, dirs_exist_ok=True)
+    common_path = posixpath.commonpath(list(df["project"]))
+    copytree(posixpath.join(origin_path, common_path), project_path, dirs_exist_ok=True)
     return df, common_path
 
 


### PR DESCRIPTION
@samwaseda I was able to fix the `windows` tests in `pyiron_atomistics` by switching from `os.path` to `posixpath`. I ran the tests in a separate repository https://github.com/jan-janssen/debug-pyiron-stack 