### PR TITLE
Inspect csv file without uncompressing `.tar.gz`

### DIFF
--- a/pyiron_base/project/archiving/import_archive.py
+++ b/pyiron_base/project/archiving/import_archive.py
@@ -1,9 +1,9 @@
+import io
 import os
 import posixpath
 import tarfile
 import tempfile
 from shutil import copytree
-import io
 
 import numpy as np
 import pandas

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1981,18 +1981,20 @@ class Project(ProjectPath, HasGroups):
             df=export_archive.export_database(self.job_table()),
         )
 
-    def unpack_csv(self, tar_path: str, csv_file: str = "export.csv"):
+    def unpack_csv(self, tar_path: str):
         """
-        Import job table from a csv file and copy the content of a project directory from a given path.
+        Import job table from a csv file and copy the content of a project
+        directory from a given path.
 
         Args:
-            tar_path (str): the relative path of a directory from which the project directory is copied.
+            tar_path (str): the relative path of a directory from which the
+                project directory is copied.
             csv_file (str): the name of the csv file.
 
         Returns:
             pandas.DataFrame: job table
         """
-        return import_archive.inspect_csv(tar_path=tar_path, csv_file=csv_file)
+        return import_archive.inspect_csv(tar_path=tar_path, csv_file="export.csv")
 
     def unpack(self, origin_path, **kwargs):
         """

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -1981,6 +1981,19 @@ class Project(ProjectPath, HasGroups):
             df=export_archive.export_database(self.job_table()),
         )
 
+    def unpack_csv(self, tar_path: str, csv_file: str = "export.csv"):
+        """
+        Import job table from a csv file and copy the content of a project directory from a given path.
+
+        Args:
+            tar_path (str): the relative path of a directory from which the project directory is copied.
+            csv_file (str): the name of the csv file.
+
+        Returns:
+            pandas.DataFrame: job table
+        """
+        return import_archive.inspect_csv(tar_path=tar_path, csv_file=csv_file)
+
     def unpack(self, origin_path, **kwargs):
         """
         by this function, job table is imported from a given csv file,

--- a/tests/unit/archiving/test_import.py
+++ b/tests/unit/archiving/test_import.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from pyiron_base import Project
-from pandas._testing import assert_frame_equal
+import pandas as pd
 from filecmp import dircmp
 from shutil import rmtree, copytree
 import tarfile
@@ -58,7 +58,7 @@ class TestUnpacking(PyironTestCase):
         df_original.drop("id", inplace=True, axis=1)
         df_import["hamversion"] = float(df_import["hamversion"])
         df_original["hamversion"] = float(df_original["hamversion"])
-        assert_frame_equal(df_original, df_import)
+        pd._testing.assert_frame_equal(df_original, df_import)
 
     def test_import_compressed(self):
         path_original = self.pr.path
@@ -192,6 +192,9 @@ class TestUnpackingBackwardsCompatibility(PyironTestCase):
             dirs_exist_ok=True,
         )
         pr = Project("old_tar")
+        df = pr.unpack_csv("test_pack.tar.gz", "export.csv")
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(len(df), 1)
         pr.unpack(origin_path="test_pack.tar.gz")
         job = pr.load("toy")
         self.assertEqual(job.job_name, "toy")

--- a/tests/unit/archiving/test_import.py
+++ b/tests/unit/archiving/test_import.py
@@ -47,6 +47,11 @@ class TestUnpacking(PyironTestCase):
         super().tearDown()
         self.imp_pr.remove_jobs(recursive=True, silently=True)
 
+    def test_inspect(self):
+        df = self.pr.unpack_csv(self.arch_dir_comp + ".tar.gz")
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(len(df), 1)
+
     def test_import_csv(self):
         df_original = self.pr.job_table()
         df_import = self.imp_pr.job_table()
@@ -192,9 +197,7 @@ class TestUnpackingBackwardsCompatibility(PyironTestCase):
             dirs_exist_ok=True,
         )
         pr = Project("old_tar")
-        df = pr.unpack_csv("test_pack.tar.gz", "export.csv")
-        self.assertIsInstance(df, pd.DataFrame)
-        self.assertEqual(len(df), 1)
+        self.assertRaises(FileNotFoundError, pr.unpack_csv, "test_pack.tar.gz")
         pr.unpack(origin_path="test_pack.tar.gz")
         job = pr.load("toy")
         self.assertEqual(job.job_name, "toy")


### PR DESCRIPTION
Closes #1626 

This was a feature requested by @jan-janssen but I’m not really sure how much I like the interface. Feel free to leave a comment if you have a better name in mind.