### PR TITLE
Only reset the job status for failed interactive jobs

### DIFF
--- a/pyiron_base/jobs/job/interactive.py
+++ b/pyiron_base/jobs/job/interactive.py
@@ -389,7 +389,8 @@ class _WithInteractiveOpen:
     def __exit__(self, exc_type, exc_val, exc_tb):
         job_status = self._job.status.string
         job_closed = self._job.interactive_close()
-        self._job.status.string = job_status
+        if job_status in ["aborted"]:
+            self._job.status.string = job_status
         return job_closed
 
     def __getattr__(self, attr):


### PR DESCRIPTION
This corrects the issue introduced in https://github.com/pyiron/pyiron_base/pull/1604