### PR TITLE
Remove automatic recursive to_dict/from_dict again

### DIFF
--- a/.github/workflows/atomistic-notebooks-compat.yml
+++ b/.github/workflows/atomistic-notebooks-compat.yml
@@ -1,6 +1,6 @@
 # This workflow is used to check the compatibility with the pyiron_atomistics
 
-name: Compatibility with pyiron_atomistics
+name: Compatibility with pyiron_atomistics Notebooks
 
 on:
   push:
@@ -14,32 +14,23 @@ jobs:
       github.event_name == 'push' ||
       ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
     
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        include:
-          - operating-system: macos-latest
-            python-version: '3.12'
-
-          - operating-system: windows-latest
-            python-version: '3.12'
-
-          - operating-system: ubuntu-latest
-            python-version: '3.12'
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_atomistics ../pyiron_atomistics
+        cp ../pyiron_atomistics/.ci_support/environment.yml environment.yml
+        tail --lines=+4 ../pyiron_atomistics/.ci_support/environment-notebooks.yml >> environment.yml
         echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
         miniforge-version: latest
         condarc-file: .condarc
-        environment-file: ../pyiron_atomistics/.ci_support/environment.yml
+        environment-file: environment.yml
     - name: Tests
       shell: bash -l {0}
       timeout-minutes: 30
@@ -50,5 +41,4 @@ jobs:
         cd ../pyiron_base
         pip install . --no-deps --no-build-isolation
         cd ../pyiron_atomistics
-        python .ci_support/pyironconfig.py
-        python -m unittest discover tests/
+        ./.ci_support/build_notebooks.sh

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_atomistics ../pyiron_atomistics
         echo -e "channels:\n  - conda-forge\n" > .condarc

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_contrib ../pyiron_contrib
         echo -e "channels:\n  - conda-forge\n" > .condarc

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -19,9 +19,6 @@ jobs:
     - name: Merge environment
       run: |
         git clone https://github.com/pyiron/pyiron_contrib ../pyiron_contrib
-        grep -v "pyiron_base" ../pyiron_contrib/.ci_support/environment.yml > ../pyiron_contrib/environment.yml
-        cp .ci_support/environment.yml environment.yml
-        tail --lines=+4 ../pyiron_contrib/environment.yml >> environment.yml
         echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
@@ -29,7 +26,7 @@ jobs:
         python-version: '3.11'
         miniforge-version: latest
         condarc-file: .condarc
-        environment-file: environment.yml
+        environment-file: ../pyiron_contrib/.ci_support/environment.yml
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -77,19 +77,20 @@ def _split_children_dict(obj_dict: dict[str, Any]) -> dict[str, Any | dict[str, 
     plain.update(subs)
     return plain
 
+
 def _from_dict_children(obj_dict: dict) -> dict:
     def load(inner_dict):
         # object is a not a dict, so nothing to do
         if not isinstance(inner_dict, dict):
             return inner_dict
         # if object is a dict but doesn't have type information, recurse through it to load any sub dicts that might
-        if not all(
-            k in inner_dict for k in ("NAME", "TYPE", "OBJECT", "DICT_VERSION")
-        ):
+        if not all(k in inner_dict for k in ("NAME", "TYPE", "OBJECT", "DICT_VERSION")):
             return {k: load(v) for k, v in inner_dict.items()}
         # object has type info, so just load it
         return create_from_dict(inner_dict)
+
     return {k: load(v) for k, v in obj_dict.items()}
+
 
 def _join_children_dict(children: dict[str, dict[str, Any]]) -> dict[str, Any]:
     """
@@ -104,10 +105,9 @@ def _join_children_dict(children: dict[str, dict[str, Any]]) -> dict[str, Any]:
     writing to ProjectHDFio.write_dict_to_hdf
     """
     return {
-        "/".join((k1, k2)): v2
-        for k1, v1 in children.items()
-        for k2, v2 in v1.items()
+        "/".join((k1, k2)): v2 for k1, v1 in children.items() for k2, v2 in v1.items()
     }
+
 
 def _to_dict_children(obj_dict: dict) -> dict:
     """

--- a/pyiron_base/interfaces/has_dict.py
+++ b/pyiron_base/interfaces/has_dict.py
@@ -76,10 +76,9 @@ def _join_children_dict(children: dict[str, dict[str, Any]]) -> dict[str, Any]:
     See also :func:`._split_children_dict`.
     """
     return {
-        "/".join((k1, k2)): v2
-        for k1, v1 in children.items()
-        for k2, v2 in v1.items()
+        "/".join((k1, k2)): v2 for k1, v1 in children.items() for k2, v2 in v1.items()
     }
+
 
 def _split_children_dict(obj_dict: dict[str, Any]) -> dict[str, Any | dict[str, Any]]:
     """
@@ -108,6 +107,7 @@ def _from_dict_children(obj_dict: dict) -> dict:
     Args:
         obj_dict (dict): data previously returned from :meth:`.to_dict`
     """
+
     def load(inner_dict):
         # object is a not a dict, so nothing to do
         if not isinstance(inner_dict, dict):
@@ -119,6 +119,7 @@ def _from_dict_children(obj_dict: dict) -> dict:
         return create_from_dict(inner_dict)
 
     return {k: load(v) for k, v in obj_dict.items()}
+
 
 def _to_dict_children(obj_dict: dict) -> dict:
     """

--- a/pyiron_base/jobs/job/generic.py
+++ b/pyiron_base/jobs/job/generic.py
@@ -1172,26 +1172,16 @@ class GenericJob(JobCore, HasDict):
             data_dict["files_to_compress"] = self._files_to_compress
         if len(self._files_to_remove) > 0:
             data_dict["files_to_compress"] = self._files_to_remove
+        data_dict["HDF_VERSION"] = self.__version__
         return data_dict
 
     def _from_dict(self, obj_dict, version=None):
         self._type_from_dict(type_dict=obj_dict)
         if "import_directory" in obj_dict.keys():
             self._import_directory = obj_dict["import_directory"]
-        # Backwards compatibility: Previously server and executable were stored
-        # as plain dicts, but now they are dicts with additional info so that
-        # HasDict can load them automatically.
-        # We need to check whether that was possible with the instance check
-        # below and if not, call from_dict ourselves.
-        if isinstance(server := obj_dict["server"], Server):
-            self._server = server
-        else:
-            self._server.from_dict(server)
+        self._server.from_dict(obj_dict["server"])
         if "executable" in obj_dict.keys() and obj_dict["executable"] is not None:
-            if isinstance(executable := obj_dict["executable"], Executable):
-                self._executable = executable
-            else:
-                self.executable.from_dict(executable)
+            self.executable.from_dict(obj_dict["executable"])
         input_dict = obj_dict["input"]
         if "generic_dict" in input_dict.keys():
             generic_dict = input_dict["generic_dict"]

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -13,7 +13,12 @@ from collections.abc import Mapping, MutableMapping, Sequence, Set
 import numpy as np
 import pandas
 
-from pyiron_base.interfaces.has_dict import HasDict, HasDictfromHDF, _to_dict_children, _from_dict_children
+from pyiron_base.interfaces.has_dict import (
+    HasDict,
+    HasDictfromHDF,
+    _from_dict_children,
+    _to_dict_children,
+)
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.interfaces.lockable import Lockable, sentinel

--- a/pyiron_base/storage/datacontainer.py
+++ b/pyiron_base/storage/datacontainer.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping, MutableMapping, Sequence, Set
 import numpy as np
 import pandas
 
-from pyiron_base.interfaces.has_dict import HasDict, HasDictfromHDF
+from pyiron_base.interfaces.has_dict import HasDict, HasDictfromHDF, _to_dict_children, _from_dict_children
 from pyiron_base.interfaces.has_groups import HasGroups
 from pyiron_base.interfaces.has_hdf import HasHDF
 from pyiron_base.interfaces.lockable import Lockable, sentinel
@@ -1034,9 +1034,10 @@ class DataContainer(DataContainerBase, HasHDF, HasDict):
         order = list(data)
         data["READ_ONLY"] = self.read_only
         data["KEY_ORDER"] = order
-        return data
+        return _to_dict_children(data)
 
     def _from_dict(self, obj_dict, version=None):
+        obj_dict = _from_dict_children(obj_dict)
         if version == "0.2.0":
             order = obj_dict.pop("KEY_ORDER")
         else:


### PR DESCRIPTION
This turned out to have negative interactions when writing and reading objects from GenericJob which currently employs a mixture of to_hdf and newer to_dict interfaces.  When reading the objects again the recursive strategy can get confused which interface to use.  Since it is anyway mostly relevant for the DataContainer, I have extracted this functionality into stand- alone functions that operate on the obj_dicts.  Classes that wish to use it and do not confuse the two interfaces can call these functions in their implementations of _to_dict and _from_dict as done by DataContainer now.