### PR TITLE
Update integration tests and a new one for notebooks

### DIFF
--- a/.github/workflows/atomistic-notebooks-compat.yml
+++ b/.github/workflows/atomistic-notebooks-compat.yml
@@ -1,6 +1,6 @@
 # This workflow is used to check the compatibility with the pyiron_atomistics
 
-name: Compatibility with pyiron_atomistics
+name: Compatibility with pyiron_atomistics Notebooks
 
 on:
   push:
@@ -14,32 +14,23 @@ jobs:
       github.event_name == 'push' ||
       ( github.event_name == 'pull_request'  && contains(github.event.pull_request.labels.*.name, 'integration' ))
     
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        include:
-          - operating-system: macos-latest
-            python-version: '3.12'
-
-          - operating-system: windows-latest
-            python-version: '3.12'
-
-          - operating-system: ubuntu-latest
-            python-version: '3.12'
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_atomistics ../pyiron_atomistics
+        cp ../pyiron_atomistics/.ci_support/environment.yml environment.yml
+        tail --lines=+4 ../pyiron_atomistics/.ci_support/environment-notebooks.yml >> environment.yml
         echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
         miniforge-version: latest
         condarc-file: .condarc
-        environment-file: ../pyiron_atomistics/.ci_support/environment.yml
+        environment-file: environment.yml
     - name: Tests
       shell: bash -l {0}
       timeout-minutes: 30
@@ -50,5 +41,4 @@ jobs:
         cd ../pyiron_base
         pip install . --no-deps --no-build-isolation
         cd ../pyiron_atomistics
-        python .ci_support/pyironconfig.py
-        python -m unittest discover tests/
+        ./.ci_support/build_notebooks.sh

--- a/.github/workflows/atomistics-compat.yml
+++ b/.github/workflows/atomistics-compat.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_atomistics ../pyiron_atomistics
         echo -e "channels:\n  - conda-forge\n" > .condarc

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Merge environment
+      shell: bash -l {0}
       run: |
         git clone https://github.com/pyiron/pyiron_contrib ../pyiron_contrib
         echo -e "channels:\n  - conda-forge\n" > .condarc

--- a/.github/workflows/contrib-compat.yml
+++ b/.github/workflows/contrib-compat.yml
@@ -19,9 +19,6 @@ jobs:
     - name: Merge environment
       run: |
         git clone https://github.com/pyiron/pyiron_contrib ../pyiron_contrib
-        grep -v "pyiron_base" ../pyiron_contrib/.ci_support/environment.yml > ../pyiron_contrib/environment.yml
-        cp .ci_support/environment.yml environment.yml
-        tail --lines=+4 ../pyiron_contrib/environment.yml >> environment.yml
         echo -e "channels:\n  - conda-forge\n" > .condarc
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v3
@@ -29,7 +26,7 @@ jobs:
         python-version: '3.11'
         miniforge-version: latest
         condarc-file: .condarc
-        environment-file: environment.yml
+        environment-file: ../pyiron_contrib/.ci_support/environment.yml
     - name: Test
       shell: bash -l {0}
       timeout-minutes: 30


### PR DESCRIPTION
Previously we tried to install the deps of atomistics/contrib on top of the base environment, now we install those dependencies first and then add pyiron_base HEAD without dependencies.
The former breaks when there are incompatible versions, the latter can break if base actually needs features or whole modules from its own environment, but we're betting that that's rarer.

Squashed and rebased from #1613