### PR TITLE
Files: Fix windows compatibility

### DIFF
--- a/pyiron_base/jobs/job/extension/files.py
+++ b/pyiron_base/jobs/job/extension/files.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 from itertools import islice
 from typing import Generator, List, Optional, Union
 

--- a/pyiron_base/jobs/job/extension/files.py
+++ b/pyiron_base/jobs/job/extension/files.py
@@ -100,7 +100,7 @@ class FileBrowser:
     __slots__ = ("_working_directory",)
 
     def __init__(self, working_directory: str):
-        self._working_directory = working_directory
+        self._working_directory = os.path.abspath(os.path.expanduser(working_directory))
 
     def _get_file_dict(self) -> dict:
         return {
@@ -150,12 +150,12 @@ class FileBrowser:
             working_directory=self._working_directory,
             include_archive=False,
         ):
-            return File(posixpath.join(self._working_directory, item))
+            return File(os.path.join(self._working_directory, item))
         elif item in _working_directory_list_files(
             working_directory=self._working_directory,
             include_archive=True,
         ):
-            return File(posixpath.join(self._working_directory, item))
+            return File(os.path.join(self._working_directory, item))
         else:
             raise FileNotFoundError(item)
 

--- a/tests/unit/flex/test_executablecontainer.py
+++ b/tests/unit/flex/test_executablecontainer.py
@@ -126,10 +126,7 @@ class TestExecutableContainer(TestWithProject):
                 "error.out",
             )
         )
-        if os.name != "nt":
-            self.assertEqual(str(job.files.error_out), output_file_path)
-        else:
-            self.assertEqual(job.files.error_out, output_file_path.replace("\\", "/"))
+        self.assertEqual(str(job.files.error_out), output_file_path)
 
     def test_create_job_factory_typeerror(self):
         create_catjob = create_job_factory(

--- a/tests/unit/flex/test_wrap_executable.py
+++ b/tests/unit/flex/test_wrap_executable.py
@@ -29,7 +29,9 @@ class TestWrapExecutable(TestWithProject):
         self.assertTrue(python_version_step.status.finished)
         self.assertEqual(
             python_version_step.files.error_out,
-            os.path.join(os.path.abspath(python_version_step.working_directory), "error.out"),
+            os.path.join(
+                os.path.abspath(python_version_step.working_directory), "error.out"
+            ),
         )
 
     def test_cat(self):

--- a/tests/unit/flex/test_wrap_executable.py
+++ b/tests/unit/flex/test_wrap_executable.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 from pyiron_base._tests import TestWithProject
 
 
@@ -30,7 +29,7 @@ class TestWrapExecutable(TestWithProject):
         self.assertTrue(python_version_step.status.finished)
         self.assertEqual(
             python_version_step.files.error_out,
-            posixpath.join(python_version_step.working_directory, "error.out"),
+            os.path.join(os.path.abspath(python_version_step.working_directory), "error.out"),
         )
 
     def test_cat(self):


### PR DESCRIPTION
```
======================================================================
FAIL: test_load_guess_group (sphinx.test_base.TestSphinx.test_load_guess_group)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\pyiron_base\pyiron_atomistics\tests\sphinx\test_base.py", line 452, in test_load_guess_group
    self.assertEqual(guess.rho.file, '"' + rho_file + '"')
AssertionError: '"C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp0wjq4yqz\\rho.sxb"' != '"C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmp0wjq4yqz/rho.sxb"'
- "C:\Users\RUNNER~1\AppData\Local\Temp\tmp0wjq4yqz\rho.sxb"
?                                                  ^
+ "C:\Users\RUNNER~1\AppData\Local\Temp\tmp0wjq4yqz/rho.sxb"
?                                                  ^


======================================================================
FAIL: test_run_complete (vasp.test_vasp.TestVasp.test_run_complete)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\a\pyiron_base\pyiron_atomistics\tests\vasp\test_vasp.py", line 423, in test_run_complete
    self.assertTrue(
AssertionError: False is not true

----------------------------------------------------------------------
```