### PR TITLE
Add wrap() function which combines wrap_executable() and wrap_python_function()

### DIFF
--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -11,7 +11,17 @@ import os
 import posixpath
 import shutil
 import stat
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Literal, Optional, Union, Callable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Literal,
+    Optional,
+    Union,
+)
 
 import cloudpickle
 import numpy as np
@@ -746,8 +756,11 @@ class Project(ProjectPath, HasGroups):
         """
         if isinstance(executable, str):
             if len(args) != 0 or len(kwargs) != 0:
-                raise TypeError("For executables of type string the following arguments are not supported:", args,
-                                kwargs)
+                raise TypeError(
+                    "For executables of type string the following arguments are not supported:",
+                    args,
+                    kwargs,
+                )
             return self.wrap_executable(
                 executable_str=executable,
                 job_name=job_name,
@@ -765,19 +778,29 @@ class Project(ProjectPath, HasGroups):
             )
         elif isinstance(executable, Callable):
             if write_input_funct is not None:
-                raise TypeError("The write_input_funct() function is only supported for executables of type string.")
+                raise TypeError(
+                    "The write_input_funct() function is only supported for executables of type string."
+                )
             elif collect_output_funct is not None:
-                raise TypeError("The collect_output_funct() function is only supported for executables of type string.")
+                raise TypeError(
+                    "The collect_output_funct() function is only supported for executables of type string."
+                )
             elif input_dict is not None:
-                raise TypeError("The input_dict dictionary is only supported for executables of type string.")
+                raise TypeError(
+                    "The input_dict dictionary is only supported for executables of type string."
+                )
             elif conda_environment_path is not None:
                 raise TypeError(
-                    "The conda_environment_path parameter is only supported for executables of type string.")
+                    "The conda_environment_path parameter is only supported for executables of type string."
+                )
             elif conda_environment_name is not None:
                 raise TypeError(
-                    "The conda_environment_name parameter is only supported for executables of type string.")
+                    "The conda_environment_name parameter is only supported for executables of type string."
+                )
             elif input_file_lst is not None:
-                raise TypeError("The input_file_lst parameter is only supported for executables of type string.")
+                raise TypeError(
+                    "The input_file_lst parameter is only supported for executables of type string."
+                )
             print(executable, args, kwargs)
             return self.wrap_python_function(
                 executable,
@@ -791,7 +814,9 @@ class Project(ProjectPath, HasGroups):
                 **kwargs,
             )
         else:
-            raise TypeError("The executable has to be either of type string or of type callable.")
+            raise TypeError(
+                "The executable has to be either of type string or of type callable."
+            )
 
     def get_child_ids(
         self, job_specifier: Union[str, int], project: Optional["Project"] = None

--- a/tests/unit/flex/test_wrap.py
+++ b/tests/unit/flex/test_wrap.py
@@ -1,0 +1,63 @@
+import os
+from pyiron_base._tests import TestWithProject
+
+
+def my_function(a, b=8):
+    return a + b
+
+
+def write_input(input_dict, working_directory="."):
+    with open(os.path.join(working_directory, "input_file"), "w") as f:
+        f.write(str(input_dict["energy"]))
+
+
+def collect_output(working_directory="."):
+    with open(os.path.join(working_directory, "output_file"), "r") as f:
+        return {"energy": float(f.readline())}
+
+
+class TestWrap(TestWithProject):
+    def test_executable(self):
+        job = self.project.wrap(
+            job_name="Cat_Job_energy_1_0",
+            write_input_funct=write_input,
+            collect_output_funct=collect_output,
+            input_dict={"energy": 2.0},
+            executable="cat input_file > output_file",
+        )
+        job.run()
+        self.assertEqual(job.output["stdout"], "")
+        self.assertEqual(job.output.energy, 2.0)
+        self.assertTrue(job.status.finished)
+
+    def test_executable_errors(self):
+        with self.assertRaises(TypeError):
+            self.project.wrap(
+                executable="cat input_file > output_file",
+                a=1
+            )
+        with self.assertRaises(TypeError):
+            self.project.wrap(
+                "cat input_file > output_file",
+                1,
+            )
+
+    def test_python_function(self):
+        job = self.project.wrap(my_function, 4, 5)
+        job.run()
+        self.assertEqual(job.output["result"], 9)
+        self.assertTrue(job.status.finished)
+
+    def test_python_function_error(self):
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, write_input_funct=write_input)
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, collect_output_funct=collect_output)
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, input_dict={"a": 1})
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, conda_environment_path="test/path")
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, conda_environment_name="test")
+        with self.assertRaises(TypeError):
+            self.project.wrap(executable=my_function, input_file_lst=["test"])

--- a/tests/unit/flex/test_wrap.py
+++ b/tests/unit/flex/test_wrap.py
@@ -32,10 +32,7 @@ class TestWrap(TestWithProject):
 
     def test_executable_errors(self):
         with self.assertRaises(TypeError):
-            self.project.wrap(
-                executable="cat input_file > output_file",
-                a=1
-            )
+            self.project.wrap(executable="cat input_file > output_file", a=1)
         with self.assertRaises(TypeError):
             self.project.wrap(
                 "cat input_file > output_file",
@@ -52,11 +49,15 @@ class TestWrap(TestWithProject):
         with self.assertRaises(TypeError):
             self.project.wrap(executable=my_function, write_input_funct=write_input)
         with self.assertRaises(TypeError):
-            self.project.wrap(executable=my_function, collect_output_funct=collect_output)
+            self.project.wrap(
+                executable=my_function, collect_output_funct=collect_output
+            )
         with self.assertRaises(TypeError):
             self.project.wrap(executable=my_function, input_dict={"a": 1})
         with self.assertRaises(TypeError):
-            self.project.wrap(executable=my_function, conda_environment_path="test/path")
+            self.project.wrap(
+                executable=my_function, conda_environment_path="test/path"
+            )
         with self.assertRaises(TypeError):
             self.project.wrap(executable=my_function, conda_environment_name="test")
         with self.assertRaises(TypeError):


### PR DESCRIPTION
@samwaseda and I had a discussion about simplifying the user interface of `executorlib` and `pyiron_base`. The primary question is: Should we provide two separate functions, one to wrap external executables which have to be executed in a separate subprocess and one for python functions, or should both be combined in a single function. The argument for combining both is that it simplifies the interface for the user, because from their perspective it makes no difference what they execute, it should behave in the same way for external executables and python functions. The argument for keeping both separated is that they return technically different objects depending on whether the input is a string for the external executable command or a python function.

In this pull request I implement a general `wrap()` function which combines `wrap_executable()` and `wrap_python_function()`. If this pull request gets merged, then we could move `wrap_executable()` and `wrap_python_function()` to hidden functions.