### PR TITLE
Fix support for functions without arguments

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -147,7 +147,10 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             with self._get_executor(max_workers=self.server.cores) as exe:
                 output = self._function(**input_dict, executor=exe)
         else:
-            output = self._function(**self.input.to_builtin())
+            if len(self.input.to_builtin()) > 0:
+                output = self._function(**self.input.to_builtin())
+            else:
+                output = self._function()
         self.output.update({"result": output})
         self.to_hdf()
         self.status.finished = True

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -150,6 +150,10 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             if len(self.input.to_builtin()) > 0:
                 output = self._function(**self.input.to_builtin())
             else:
+                # An empty DataContainer returns a list rather than a dict, so **self.input.to_builtin()
+                # results in "TypeError: argument after ** must be a mapping, not list".
+                # As a workaround, when the input DataContainer is empty the function is called without
+                # arguments (*args) or keyword-arguments (**kwargs)
                 output = self._function()
         self.output.update({"result": output})
         self.to_hdf()

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -147,14 +147,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
             with self._get_executor(max_workers=self.server.cores) as exe:
                 output = self._function(**input_dict, executor=exe)
         else:
-            if len(self.input.to_builtin()) > 0:
-                output = self._function(**self.input.to_builtin())
-            else:
-                # An empty DataContainer returns a list rather than a dict, so **self.input.to_builtin()
-                # results in "TypeError: argument after ** must be a mapping, not list".
-                # As a workaround, when the input DataContainer is empty the function is called without
-                # arguments (*args) or keyword-arguments (**kwargs)
-                output = self._function()
+            output = self._function(**self.input)
         self.output.update({"result": output})
         self.to_hdf()
         self.status.finished = True

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -7,7 +7,6 @@ The project object is the central import point of pyiron - all other objects can
 
 from __future__ import annotations
 
-import inspect
 import os
 import posixpath
 import shutil
@@ -667,11 +666,7 @@ class Project(ProjectPath, HasGroups):
             )
             job._automatically_rename_on_save_using_input = automatically_rename
             job.python_function = python_function
-            nr_parameters = len(inspect.signature(python_function).parameters)
-            if not args and len(kwargs) == 0 and nr_parameters > 0:
-                return job
-            else:
-                return job(*args, **kwargs)
+            return job(*args, **kwargs)
 
         if delayed:
             return DelayedObject(

--- a/pyiron_base/project/generic.py
+++ b/pyiron_base/project/generic.py
@@ -7,6 +7,7 @@ The project object is the central import point of pyiron - all other objects can
 
 from __future__ import annotations
 
+import inspect
 import os
 import posixpath
 import shutil
@@ -666,7 +667,8 @@ class Project(ProjectPath, HasGroups):
             )
             job._automatically_rename_on_save_using_input = automatically_rename
             job.python_function = python_function
-            if not args and len(kwargs) == 0:
+            nr_parameters = len(inspect.signature(python_function).parameters)
+            if not args and len(kwargs) == 0 and nr_parameters > 0:
                 return job
             else:
                 return job(*args, **kwargs)

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -47,6 +47,13 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertEqual(job_reload.output["result"], "hello")
         self.project.remove_job(job.job_name)
 
+    def test_as_job_without_arguments_delayed(self):
+        delayed_obj = self.project.wrap_python_function(
+            python_function=my_function_str,
+            delayed=True,
+        )
+        self.assertEqual(delayed_obj.pull(), "hello")
+
     def test_as_function(self):
         my_function_as_job = self.project.wrap_python_function(my_function)
         self.assertEqual(my_function_as_job(a=5, b=6), 11)

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -10,6 +10,10 @@ def my_function(a, b=8):
     return a + b
 
 
+def my_function_str():
+    return "hello"
+
+
 def my_sleep_funct(a, b=8, sleep_time=0.01):
     sleep(sleep_time)
     return a + b
@@ -32,6 +36,15 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertEqual(job_reload.input["a"], 4)
         self.assertEqual(job_reload.input["b"], 5)
         self.assertEqual(job_reload.output["result"], 9)
+        self.project.remove_job(job.job_name)
+
+    def test_as_job_without_arguments(self):
+        job = self.project.wrap_python_function(my_function_str)
+        job.run()
+        self.assertEqual(job.output["result"], "hello")
+        self.assertTrue(job.status.finished)
+        job_reload = self.project.load(job.job_name)
+        self.assertEqual(job_reload.output["result"], "hello")
         self.project.remove_job(job.job_name)
 
     def test_as_function(self):


### PR DESCRIPTION
Example:
```python
import subprocess
from pyiron_base import Project 

def get_python_version():
    return subprocess.check_output("python --version", shell=True, universal_newlines=True)

pr = Project("test")
python_version = pr.wrap_python_function(
    python_function=get_python_version,
    delayed=True,
)
python_version.pull()
>>> 'Python 3.12.5\n'
```