### PR TITLE
Implement decorators in `pyiron_base`

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -29,6 +29,7 @@ from pyiron_base.jobs.master.generic import GenericMaster, get_function_from_str
 from pyiron_base.jobs.master.interactivewrapper import InteractiveWrapper
 from pyiron_base.jobs.master.list import ListMaster
 from pyiron_base.jobs.master.parallel import JobGenerator, ParallelMaster
+from pyiron_base.project.decorator import pyiron_job, pyiron_job_simple
 from pyiron_base.project.external import Notebook, dump, load
 from pyiron_base.project.generic import Creator, Project
 from pyiron_base.state import state

--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -29,7 +29,7 @@ from pyiron_base.jobs.master.generic import GenericMaster, get_function_from_str
 from pyiron_base.jobs.master.interactivewrapper import InteractiveWrapper
 from pyiron_base.jobs.master.list import ListMaster
 from pyiron_base.jobs.master.parallel import JobGenerator, ParallelMaster
-from pyiron_base.project.decorator import pyiron_job, pyiron_job_simple
+from pyiron_base.project.decorator import pyiron_job
 from pyiron_base.project.external import Notebook, dump, load
 from pyiron_base.project.generic import Creator, Project
 from pyiron_base.state import state

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -53,6 +53,7 @@ def pyiron_job(
         >>> d = my_function_b(a=c, b=3, pyiron_project=pr)
         >>> print(d.pull())
 
+        Output: 6
     """
 
     def get_delayed_object(

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -1,7 +1,8 @@
 import inspect
 from typing import Optional
-from pyiron_base.project.generic import Project
+
 from pyiron_base.jobs.job.extension.server.generic import Server
+from pyiron_base.project.generic import Project
 
 
 def pyiron_job(
@@ -39,7 +40,9 @@ def pyiron_job(
                 new_hdf=new_hdf,
             )
             return delayed_job_object
+
         return function
+
     return pyiron_job_function
 
 
@@ -50,14 +53,15 @@ def pyiron_job_simple(funct) -> callable:
         resource_dict: dict = {},
         output_file_lst: list = [],
         output_key_lst: list = [],
-        **kwargs
+        **kwargs,
     ):
         resource_default_dict = {
             k: v.default for k, v in inspect.signature(Server).parameters.items()
         }
         resource_dict.update(
             {
-                k:v for k, v in resource_default_dict.items()
+                k: v
+                for k, v in resource_default_dict.items()
                 if k not in resource_dict.keys()
             }
         )
@@ -74,4 +78,5 @@ def pyiron_job_simple(funct) -> callable:
         )
         delayed_job_object._server = Server(**resource_dict)
         return delayed_job_object
+
     return function

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -64,13 +64,9 @@ def pyiron_job(
         resource_default_dict: dict,
         **kwargs,
     ):
-        pyiron_resource_dict.update(
-            {
-                k: v
-                for k, v in resource_default_dict.items()
-                if k not in pyiron_resource_dict.keys()
-            }
-        )
+        for k, v in resource_default_dict.items():
+            if k not in pyiron_resource_dict:
+                pyiron_resource_dict[k] = v
         delayed_job_object = pyiron_project.wrap_python_function(
             python_function=python_function,
             *args,

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -54,6 +54,7 @@ def pyiron_job(
         >>> print(d.pull())
 
     """
+
     def get_delayed_object(
         *args,
         pyiron_project: Project,

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -5,7 +5,10 @@ from pyiron_base.jobs.job.extension.server.generic import Server
 from pyiron_base.project.generic import Project
 
 
+# The combined decorator
 def pyiron_job(
+    funct: Optional[callable] = None,
+    *,
     project: Project = Project("."),
     host: Optional[str] = None,
     queue: Optional[str] = None,
@@ -17,10 +20,11 @@ def pyiron_job(
     output_file_lst: list = [],
     output_key_lst: list = [],
 ):
-    def pyiron_job_function(funct) -> callable:
+    # This is the actual decorator function that applies to the decorated function
+    def pyiron_job_function(f) -> callable:
         def function(*args, **kwargs):
             delayed_job_object = project.wrap_python_function(
-                python_function=funct,
+                python_function=f,
                 *args,
                 job_name=None,
                 automatically_rename=True,
@@ -40,43 +44,46 @@ def pyiron_job(
                 new_hdf=new_hdf,
             )
             return delayed_job_object
+        return function
+
+    # If funct is None, it means the decorator is called with arguments (like @pyiron_job(...))
+    if funct is None:
+        return pyiron_job_function
+
+    # If funct is not None, it means the decorator is called without parentheses (like @pyiron_job)
+    else:
+        # Assume this usage and handle the decorator like `pyiron_job_simple`
+        def function(
+            *args,
+            project: Project = Project("."),
+            resource_dict: dict = {},
+            output_file_lst: list = [],
+            output_key_lst: list = [],
+            **kwargs,
+        ):
+            resource_default_dict = {
+                k: v.default for k, v in inspect.signature(Server).parameters.items()
+            }
+            resource_dict.update(
+                {
+                    k: v
+                    for k, v in resource_default_dict.items()
+                    if k not in resource_dict.keys()
+                }
+            )
+            delayed_job_object = project.wrap_python_function(
+                python_function=funct,
+                *args,
+                job_name=None,
+                automatically_rename=True,
+                execute_job=False,
+                delayed=True,
+                output_file_lst=output_file_lst,
+                output_key_lst=output_key_lst,
+                **kwargs,
+            )
+            delayed_job_object._server = Server(**resource_dict)
+            return delayed_job_object
 
         return function
 
-    return pyiron_job_function
-
-
-def pyiron_job_simple(funct) -> callable:
-    def function(
-        *args,
-        project: Project = Project("."),
-        resource_dict: dict = {},
-        output_file_lst: list = [],
-        output_key_lst: list = [],
-        **kwargs,
-    ):
-        resource_default_dict = {
-            k: v.default for k, v in inspect.signature(Server).parameters.items()
-        }
-        resource_dict.update(
-            {
-                k: v
-                for k, v in resource_default_dict.items()
-                if k not in resource_dict.keys()
-            }
-        )
-        delayed_job_object = project.wrap_python_function(
-            python_function=funct,
-            *args,
-            job_name=None,
-            automatically_rename=True,
-            execute_job=False,
-            delayed=True,
-            output_file_lst=output_file_lst,
-            output_key_lst=output_key_lst,
-            **kwargs,
-        )
-        delayed_job_object._server = Server(**resource_dict)
-        return delayed_job_object
-
-    return function

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -19,6 +19,41 @@ def pyiron_job(
     output_file_lst: list = [],
     output_key_lst: list = [],
 ):
+    """
+    Decorator to create a pyiron job object from any python function
+
+    Args:
+        funct (callable): python function to create a job object from
+        host (str): the hostname of the current system.
+        queue (str): the queue selected for a current simulation.
+        cores (int): the number of cores selected for the current simulation.
+        threads (int): the number of threads selected for the current simulation.
+        gpus (int): the number of gpus selected for the current simulation.
+        run_mode (str): the run mode of the job ['modal', 'non_modal', 'queue', 'manual']
+        new_hdf (bool): defines whether a subjob should be stored in the same HDF5 file or in a new one.
+        output_file_lst (list):
+        output_key_lst (list):
+
+    Returns:
+        callable: The decorated functions
+
+    Example:
+        >>> from pyiron_base import pyiron_job, Project
+        >>>
+        >>> @pyiron_job
+        >>> def my_function_a(a, b=8):
+        >>>     return a + b
+        >>>
+        >>> @pyiron_job(cores=2)
+        >>> def my_function_b(a, b=8):
+        >>>     return a + b
+        >>>
+        >>> pr = Project("test")
+        >>> c = my_function_a(a=1, b=2, pyiron_project=pr)
+        >>> d = my_function_b(a=c, b=3, pyiron_project=pr)
+        >>> print(d.pull())
+
+    """
     def get_delayed_object(
         *args,
         pyiron_project: Project,

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -1,0 +1,77 @@
+import inspect
+from typing import Optional
+from pyiron_base.project.generic import Project
+from pyiron_base.jobs.job.extension.server.generic import Server
+
+
+def pyiron_job(
+    project: Project = Project("."),
+    host: Optional[str] = None,
+    queue: Optional[str] = None,
+    cores: int = 1,
+    threads: int = 1,
+    gpus: Optional[int] = None,
+    run_mode: str = "modal",
+    new_hdf: bool = True,
+    output_file_lst: list = [],
+    output_key_lst: list = [],
+):
+    def pyiron_job_function(funct) -> callable:
+        def function(*args, **kwargs):
+            delayed_job_object = project.wrap_python_function(
+                python_function=funct,
+                *args,
+                job_name=None,
+                automatically_rename=True,
+                execute_job=False,
+                delayed=True,
+                output_file_lst=output_file_lst,
+                output_key_lst=output_key_lst,
+                **kwargs,
+            )
+            delayed_job_object._server = Server(
+                host=host,
+                queue=queue,
+                cores=cores,
+                threads=threads,
+                gpus=gpus,
+                run_mode=run_mode,
+                new_hdf=new_hdf,
+            )
+            return delayed_job_object
+        return function
+    return pyiron_job_function
+
+
+def pyiron_job_simple(funct) -> callable:
+    def function(
+        *args,
+        project: Project = Project("."),
+        resource_dict: dict = {},
+        output_file_lst: list = [],
+        output_key_lst: list = [],
+        **kwargs
+    ):
+        resource_default_dict = {
+            k: v.default for k, v in inspect.signature(Server).parameters.items()
+        }
+        resource_dict.update(
+            {
+                k:v for k, v in resource_default_dict.items()
+                if k not in resource_dict.keys()
+            }
+        )
+        delayed_job_object = project.wrap_python_function(
+            python_function=funct,
+            *args,
+            job_name=None,
+            automatically_rename=True,
+            execute_job=False,
+            delayed=True,
+            output_file_lst=output_file_lst,
+            output_key_lst=output_key_lst,
+            **kwargs,
+        )
+        delayed_job_object._server = Server(**resource_dict)
+        return delayed_job_object
+    return function

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -25,7 +25,7 @@ def pyiron_job(
         python_function: callable,
         pyiron_resource_dict: dict,
         resource_default_dict: dict,
-        **kwargs
+        **kwargs,
     ):
         pyiron_resource_dict.update(
             {
@@ -51,10 +51,7 @@ def pyiron_job(
     # This is the actual decorator function that applies to the decorated function
     def pyiron_job_function(f) -> callable:
         def function(
-            *args,
-            pyiron_project: Project,
-            pyiron_resource_dict: dict = {},
-            **kwargs
+            *args, pyiron_project: Project, pyiron_resource_dict: dict = {}, **kwargs
         ):
             resource_default_dict = {
                 "host": None,
@@ -71,7 +68,7 @@ def pyiron_job(
                 pyiron_project=pyiron_project,
                 pyiron_resource_dict=pyiron_resource_dict,
                 resource_default_dict=resource_default_dict,
-                **kwargs
+                **kwargs,
             )
 
         return function
@@ -98,7 +95,7 @@ def pyiron_job(
                 pyiron_project=pyiron_project,
                 pyiron_resource_dict=pyiron_resource_dict,
                 resource_default_dict=resource_default_dict,
-                **kwargs
+                **kwargs,
             )
 
         return function

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -44,6 +44,7 @@ def pyiron_job(
                 new_hdf=new_hdf,
             )
             return delayed_job_object
+
         return function
 
     # If funct is None, it means the decorator is called with arguments (like @pyiron_job(...))
@@ -86,4 +87,3 @@ def pyiron_job(
             return delayed_job_object
 
         return function
-

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -9,7 +9,6 @@ from pyiron_base.project.generic import Project
 def pyiron_job(
     funct: Optional[callable] = None,
     *,
-    project: Project = Project("."),
     host: Optional[str] = None,
     queue: Optional[str] = None,
     cores: int = 1,
@@ -20,30 +19,60 @@ def pyiron_job(
     output_file_lst: list = [],
     output_key_lst: list = [],
 ):
+    def get_delayed_object(
+        *args,
+        pyiron_project: Project,
+        python_function: callable,
+        pyiron_resource_dict: dict,
+        resource_default_dict: dict,
+        **kwargs
+    ):
+        pyiron_resource_dict.update(
+            {
+                k: v
+                for k, v in resource_default_dict.items()
+                if k not in pyiron_resource_dict.keys()
+            }
+        )
+        delayed_job_object = pyiron_project.wrap_python_function(
+            python_function=python_function,
+            *args,
+            job_name=None,
+            automatically_rename=True,
+            execute_job=False,
+            delayed=True,
+            output_file_lst=output_file_lst,
+            output_key_lst=output_key_lst,
+            **kwargs,
+        )
+        delayed_job_object._server = Server(**pyiron_resource_dict)
+        return delayed_job_object
+
     # This is the actual decorator function that applies to the decorated function
     def pyiron_job_function(f) -> callable:
-        def function(*args, **kwargs):
-            delayed_job_object = project.wrap_python_function(
-                python_function=f,
+        def function(
+            *args,
+            pyiron_project: Project,
+            pyiron_resource_dict: dict = {},
+            **kwargs
+        ):
+            resource_default_dict = {
+                "host": None,
+                "queue": None,
+                "cores": 1,
+                "threads": 1,
+                "gpus": None,
+                "run_mode": "modal",
+                "new_hdf": True,
+            }
+            return get_delayed_object(
                 *args,
-                job_name=None,
-                automatically_rename=True,
-                execute_job=False,
-                delayed=True,
-                output_file_lst=output_file_lst,
-                output_key_lst=output_key_lst,
-                **kwargs,
+                python_function=f,
+                pyiron_project=pyiron_project,
+                pyiron_resource_dict=pyiron_resource_dict,
+                resource_default_dict=resource_default_dict,
+                **kwargs
             )
-            delayed_job_object._server = Server(
-                host=host,
-                queue=queue,
-                cores=cores,
-                threads=threads,
-                gpus=gpus,
-                run_mode=run_mode,
-                new_hdf=new_hdf,
-            )
-            return delayed_job_object
 
         return function
 
@@ -56,34 +85,20 @@ def pyiron_job(
         # Assume this usage and handle the decorator like `pyiron_job_simple`
         def function(
             *args,
-            project: Project = Project("."),
-            resource_dict: dict = {},
-            output_file_lst: list = [],
-            output_key_lst: list = [],
+            pyiron_project: Project,
+            pyiron_resource_dict: dict = {},
             **kwargs,
         ):
             resource_default_dict = {
                 k: v.default for k, v in inspect.signature(Server).parameters.items()
             }
-            resource_dict.update(
-                {
-                    k: v
-                    for k, v in resource_default_dict.items()
-                    if k not in resource_dict.keys()
-                }
-            )
-            delayed_job_object = project.wrap_python_function(
-                python_function=funct,
+            return get_delayed_object(
                 *args,
-                job_name=None,
-                automatically_rename=True,
-                execute_job=False,
-                delayed=True,
-                output_file_lst=output_file_lst,
-                output_key_lst=output_key_lst,
-                **kwargs,
+                python_function=funct,
+                pyiron_project=pyiron_project,
+                pyiron_resource_dict=pyiron_resource_dict,
+                resource_default_dict=resource_default_dict,
+                **kwargs
             )
-            delayed_job_object._server = Server(**resource_dict)
-            return delayed_job_object
 
         return function

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -39,5 +39,6 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.assertEqual(len(nodes_dict), 6)
         self.assertEqual(len(edges_lst), 6)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -1,5 +1,6 @@
 from pyiron_base._tests import TestWithProject
-from pyiron_base import pyiron_job, pyiron_job_simple
+from pyiron_base import pyiron_job
+import unittest
 
 
 class TestPythonFunctionDecorator(TestWithProject):
@@ -23,11 +24,11 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.assertEqual(len(edges_lst), 6)
 
     def test_delayed_simple(self):
-        @pyiron_job_simple
+        @pyiron_job
         def my_function_a(a, b=8):
             return a + b
 
-        @pyiron_job_simple
+        @pyiron_job
         def my_function_b(a, b=8):
             return a + b
 
@@ -37,3 +38,6 @@ class TestPythonFunctionDecorator(TestWithProject):
         nodes_dict, edges_lst = d.get_graph()
         self.assertEqual(len(nodes_dict), 6)
         self.assertEqual(len(edges_lst), 6)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -8,16 +8,16 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.project.remove_jobs(recursive=True, silently=True)
 
     def test_delayed(self):
-        @pyiron_job(project=self.project)
+        @pyiron_job()
         def my_function_a(a, b=8):
             return a + b
 
-        @pyiron_job(project=self.project, cores=2)
+        @pyiron_job(cores=2)
         def my_function_b(a, b=8):
             return a + b
 
-        c = my_function_a(a=1, b=2)
-        d = my_function_b(a=c, b=3)
+        c = my_function_a(a=1, b=2, pyiron_project=self.project)
+        d = my_function_b(a=c, b=3, pyiron_project=self.project)
         self.assertEqual(d.pull(), 6)
         nodes_dict, edges_lst = d.get_graph()
         self.assertEqual(len(nodes_dict), 6)
@@ -32,8 +32,8 @@ class TestPythonFunctionDecorator(TestWithProject):
         def my_function_b(a, b=8):
             return a + b
 
-        c = my_function_a(a=1, b=2, project=self.project)
-        d = my_function_b(a=c, b=3, project=self.project, resource_dict={"cores": 2})
+        c = my_function_a(a=1, b=2, pyiron_project=self.project)
+        d = my_function_b(a=c, b=3, pyiron_project=self.project, pyiron_resource_dict={"cores": 2})
         self.assertEqual(d.pull(), 6)
         nodes_dict, edges_lst = d.get_graph()
         self.assertEqual(len(nodes_dict), 6)

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -33,7 +33,9 @@ class TestPythonFunctionDecorator(TestWithProject):
             return a + b
 
         c = my_function_a(a=1, b=2, pyiron_project=self.project)
-        d = my_function_b(a=c, b=3, pyiron_project=self.project, pyiron_resource_dict={"cores": 2})
+        d = my_function_b(
+            a=c, b=3, pyiron_project=self.project, pyiron_resource_dict={"cores": 2}
+        )
         self.assertEqual(d.pull(), 6)
         nodes_dict, edges_lst = d.get_graph()
         self.assertEqual(len(nodes_dict), 6)

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -1,0 +1,39 @@
+from pyiron_base._tests import TestWithProject
+from pyiron_base import pyiron_job, pyiron_job_simple
+
+
+class TestPythonFunctionDecorator(TestWithProject):
+    def tearDown(self):
+        self.project.remove_jobs(recursive=True, silently=True)
+
+    def test_delayed(self):
+        @pyiron_job(project=self.project)
+        def my_function_a(a, b=8):
+            return a + b
+
+        @pyiron_job(project=self.project, cores=2)
+        def my_function_b(a, b=8):
+            return a + b
+
+        c = my_function_a(a=1, b=2)
+        d = my_function_b(a=c, b=3)
+        self.assertEqual(d.pull(), 6)
+        nodes_dict, edges_lst = d.get_graph()
+        self.assertEqual(len(nodes_dict), 6)
+        self.assertEqual(len(edges_lst), 6)
+
+    def test_delayed_simple(self):
+        @pyiron_job_simple
+        def my_function_a(a, b=8):
+            return a + b
+
+        @pyiron_job_simple
+        def my_function_b(a, b=8):
+            return a + b
+
+        c = my_function_a(a=1, b=2, project=self.project)
+        d = my_function_b(a=c, b=3, project=self.project, resource_dict={"cores": 2})
+        self.assertEqual(d.pull(), 6)
+        nodes_dict, edges_lst = d.get_graph()
+        self.assertEqual(len(nodes_dict), 6)
+        self.assertEqual(len(edges_lst), 6)


### PR DESCRIPTION
First implementation with decorator arguments:
```python
from pyiron_base import pyiron_job, Project

pr = Project("test")

@pyiron_job(project=pr, cores=2)
def my_function(a, b=8):
    return a + b

c = my_function(a=1, b=2)
d = my_function(a=c, b=3)
d.pull()
>>> 6
```

The disadvantage of this approach is that the decorator requires the `()` even without parameters: 
```python
@pyiron_job()
def my_function(a, b=8):
    return a + b
```

To address this limitation I created a second implementation: 
```python
from pyiron_base import pyiron_job_simple, Project

@pyiron_job_simple
def my_function(a, b=8):
    return a + b

pr = Project("test")
c = my_function(a=1, b=2, project=pr)
d = my_function(a=c, b=3, project=pr, resource_dict={"cores": 2})
d.pull()
>>> 6
```
