### PR TITLE
Rename decorator from @pyiron_job to @job

### DIFF
--- a/pyiron_base/__init__.py
+++ b/pyiron_base/__init__.py
@@ -29,7 +29,7 @@ from pyiron_base.jobs.master.generic import GenericMaster, get_function_from_str
 from pyiron_base.jobs.master.interactivewrapper import InteractiveWrapper
 from pyiron_base.jobs.master.list import ListMaster
 from pyiron_base.jobs.master.parallel import JobGenerator, ParallelMaster
-from pyiron_base.project.decorator import pyiron_job
+from pyiron_base.project.decorator import job
 from pyiron_base.project.external import Notebook, dump, load
 from pyiron_base.project.generic import Creator, Project
 from pyiron_base.state import state

--- a/pyiron_base/project/decorator.py
+++ b/pyiron_base/project/decorator.py
@@ -6,7 +6,7 @@ from pyiron_base.project.generic import Project
 
 
 # The combined decorator
-def pyiron_job(
+def job(
     funct: Optional[callable] = None,
     *,
     host: Optional[str] = None,
@@ -38,13 +38,13 @@ def pyiron_job(
         callable: The decorated functions
 
     Example:
-        >>> from pyiron_base import pyiron_job, Project
+        >>> from pyiron_base import job, Project
         >>>
-        >>> @pyiron_job
+        >>> @job
         >>> def my_function_a(a, b=8):
         >>>     return a + b
         >>>
-        >>> @pyiron_job(cores=2)
+        >>> @job(cores=2)
         >>> def my_function_b(a, b=8):
         >>>     return a + b
         >>>

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -1,5 +1,5 @@
 from pyiron_base._tests import TestWithProject
-from pyiron_base import pyiron_job
+from pyiron_base import job
 import unittest
 
 
@@ -8,11 +8,11 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.project.remove_jobs(recursive=True, silently=True)
 
     def test_delayed(self):
-        @pyiron_job()
+        @job()
         def my_function_a(a, b=8):
             return a + b
 
-        @pyiron_job(cores=2)
+        @job(cores=2)
         def my_function_b(a, b=8):
             return a + b
 
@@ -24,11 +24,11 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.assertEqual(len(edges_lst), 6)
 
     def test_delayed_simple(self):
-        @pyiron_job
+        @job
         def my_function_a(a, b=8):
             return a + b
 
-        @pyiron_job
+        @job
         def my_function_b(a, b=8):
             return a + b
 

--- a/tests/usecases/ADIS/notebook.ipynb
+++ b/tests/usecases/ADIS/notebook.ipynb
@@ -20,7 +20,7 @@
     "from ase.build import bulk\n",
     "from ase.io import write\n",
     "from adis_tools.parsers import parse_pw\n",
-    "from pyiron_base import pyiron_job, Project"
+    "from pyiron_base import job, Project"
    ]
   },
   {
@@ -75,7 +75,7 @@
    },
    "outputs": [],
    "source": [
-    "@pyiron_job(output_key_lst=[\"energy\", \"volume\", \"structure\"])\n",
+    "@job(output_key_lst=[\"energy\", \"volume\", \"structure\"])\n",
     "def calculate_qe(working_directory, input_dict):\n",
     "    write_input(\n",
     "        input_dict=input_dict,\n",
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "@pyiron_job\n",
+    "@job\n",
     "def generate_structures(structure, strain_lst):\n",
     "    structure_lst = []\n",
     "    for strain in strain_lst:\n",
@@ -122,7 +122,7 @@
    },
    "outputs": [],
    "source": [
-    "@pyiron_job\n",
+    "@job\n",
     "def plot_energy_volume_curve(volume_lst, energy_lst):\n",
     "    plt.plot(volume_lst, energy_lst)\n",
     "    plt.xlabel(\"Volume\")\n",


### PR DESCRIPTION
A shorter decorator simplifies the workflow development.