### PR TITLE
Add support for the Python Workflow Definition

### DIFF
--- a/pyiron_base/project/universal.py
+++ b/pyiron_base/project/universal.py
@@ -12,15 +12,14 @@ def _remove_server_obj(nodes_dict, edges_lst):
 
 def _get_nodes(connection_dict, delayed_object_updated_dict):
     return {
-        connection_dict[k]: v._python_function
-        if isinstance(v, DelayedObject) else v
+        connection_dict[k]: v._python_function if isinstance(v, DelayedObject) else v
         for k, v in delayed_object_updated_dict.items()
     }
 
 
 def _get_unique_objects(nodes_dict, edges_lst):
     delayed_object_dict = {
-        k:v for k, v in nodes_dict.items() if isinstance(v, DelayedObject)
+        k: v for k, v in nodes_dict.items() if isinstance(v, DelayedObject)
     }
     unique_lst = []
     delayed_object_updated_dict, match_dict = {}, {}
@@ -35,9 +34,9 @@ def _get_unique_objects(nodes_dict, edges_lst):
         if not match:
             unique_lst.append(dobj)
             delayed_object_updated_dict[dobj] = delayed_object_dict[dobj]
-    delayed_object_updated_dict.update({
-        k:v for k, v in nodes_dict.items() if not isinstance(v, DelayedObject)
-    })
+    delayed_object_updated_dict.update(
+        {k: v for k, v in nodes_dict.items() if not isinstance(v, DelayedObject)}
+    )
     return delayed_object_updated_dict, match_dict
 
 
@@ -68,31 +67,38 @@ def _get_edges_dict(edges_lst, nodes_dict, connection_dict, lookup_dict):
         if connection_name not in existing_connection_lst:
             output = nodes_dict[output_name]
             if isinstance(output, DelayedObject):
-                edges_dict_lst.append({
-                    "target": target,
-                    "targetHandle": target_handle,
-                    "source": connection_dict[output_name],
-                    "sourceHandle": output._output_key,
-                })
+                edges_dict_lst.append(
+                    {
+                        "target": target,
+                        "targetHandle": target_handle,
+                        "source": connection_dict[output_name],
+                        "sourceHandle": output._output_key,
+                    }
+                )
             else:
-                edges_dict_lst.append({
-                    "target": target,
-                    "targetHandle": target_handle,
-                    "source": connection_dict[output_name],
-                    "sourceHandle": None,
-                })
+                edges_dict_lst.append(
+                    {
+                        "target": target,
+                        "targetHandle": target_handle,
+                        "source": connection_dict[output_name],
+                        "sourceHandle": None,
+                    }
+                )
             existing_connection_lst.append(connection_name)
     return edges_dict_lst
 
 
 def _get_kwargs(lst):
-    return {t['targetHandle']: {'source': t['source'], 'sourceHandle': t['sourceHandle']} for t in lst}
+    return {
+        t["targetHandle"]: {"source": t["source"], "sourceHandle": t["sourceHandle"]}
+        for t in lst
+    }
 
 
 def _group_edges(edges_lst):
-    edges_sorted_lst = sorted(edges_lst, key=lambda x: x['target'], reverse=True)
+    edges_sorted_lst = sorted(edges_lst, key=lambda x: x["target"], reverse=True)
     total_lst, tmp_lst = [], []
-    target_id = edges_sorted_lst[0]['target']
+    target_id = edges_sorted_lst[0]["target"]
     for ed in edges_sorted_lst:
         if target_id == ed["target"]:
             tmp_lst.append(ed)
@@ -107,16 +113,18 @@ def _group_edges(edges_lst):
 def _get_source_handles(edges_lst):
     source_handle_dict = {}
     for ed in edges_lst:
-        if ed['source'] not in source_handle_dict.keys():
-            source_handle_dict[ed['source']] = [ed['sourceHandle']]
+        if ed["source"] not in source_handle_dict.keys():
+            source_handle_dict[ed["source"]] = [ed["sourceHandle"]]
         else:
-            source_handle_dict[ed['source']].append(ed['sourceHandle'])
+            source_handle_dict[ed["source"]].append(ed["sourceHandle"])
     return source_handle_dict
 
 
 def _get_source(nodes_dict, delayed_object_dict, source, sourceHandle):
     if source in delayed_object_dict.keys():
-        return delayed_object_dict[source].__getattr__("output").__getattr__(sourceHandle)
+        return (
+            delayed_object_dict[source].__getattr__("output").__getattr__(sourceHandle)
+        )
     else:
         return nodes_dict[source]
 

--- a/pyiron_base/project/universal.py
+++ b/pyiron_base/project/universal.py
@@ -1,0 +1,173 @@
+from pyiron_base.project.decorator import job
+from pyiron_base.project.delayed import DelayedObject
+
+
+def _remove_server_obj(nodes_dict, edges_lst):
+    server_lst = [k for k in nodes_dict.keys() if k.startswith("server_obj_")]
+    for s in server_lst:
+        del nodes_dict[s]
+        edges_lst = [ep for ep in edges_lst if s not in ep]
+    return nodes_dict, edges_lst
+
+
+def _get_nodes(connection_dict, delayed_object_updated_dict):
+    return {
+        connection_dict[k]: v._python_function
+        if isinstance(v, DelayedObject) else v
+        for k, v in delayed_object_updated_dict.items()
+    }
+
+
+def _get_unique_objects(nodes_dict, edges_lst):
+    delayed_object_dict = {
+        k:v for k, v in nodes_dict.items() if isinstance(v, DelayedObject)
+    }
+    unique_lst = []
+    delayed_object_updated_dict, match_dict = {}, {}
+    for dobj in delayed_object_dict.keys():
+        match = False
+        for obj in unique_lst:
+            if delayed_object_dict[dobj]._input == delayed_object_dict[obj]._input:
+                delayed_object_updated_dict[obj] = delayed_object_dict[obj]
+                match_dict[dobj] = obj
+                match = True
+                break
+        if not match:
+            unique_lst.append(dobj)
+            delayed_object_updated_dict[dobj] = delayed_object_dict[dobj]
+    delayed_object_updated_dict.update({
+        k:v for k, v in nodes_dict.items() if not isinstance(v, DelayedObject)
+    })
+    return delayed_object_updated_dict, match_dict
+
+
+def _get_connection_dict(delayed_object_updated_dict, match_dict):
+    new_obj_dict = {}
+    connection_dict = {}
+    lookup_dict = {}
+    for i, [k, v] in enumerate(delayed_object_updated_dict.items()):
+        new_obj_dict[i] = v
+        connection_dict[k] = i
+        lookup_dict[i] = k
+
+    for k, v in match_dict.items():
+        if v in connection_dict.keys():
+            connection_dict[k] = connection_dict[v]
+
+    return connection_dict, lookup_dict
+
+
+def _get_edges_dict(edges_lst, nodes_dict, connection_dict, lookup_dict):
+    edges_dict_lst = []
+    existing_connection_lst = []
+    for ep in edges_lst:
+        input_name, output_name = ep
+        target = connection_dict[input_name]
+        target_handle = "_".join(output_name.split("_")[:-1])
+        connection_name = lookup_dict[target] + "_" + target_handle
+        if connection_name not in existing_connection_lst:
+            output = nodes_dict[output_name]
+            if isinstance(output, DelayedObject):
+                edges_dict_lst.append({
+                    "target": target,
+                    "targetHandle": target_handle,
+                    "source": connection_dict[output_name],
+                    "sourceHandle": output._output_key,
+                })
+            else:
+                edges_dict_lst.append({
+                    "target": target,
+                    "targetHandle": target_handle,
+                    "source": connection_dict[output_name],
+                    "sourceHandle": None,
+                })
+            existing_connection_lst.append(connection_name)
+    return edges_dict_lst
+
+
+def _group_edges(edges_lst):
+    edges_sorted_lst = sorted(edges_lst, key=lambda x: x['target'], reverse=True)
+    total_lst, tmp_lst = [], []
+    target_id = edges_sorted_lst[0]['target']
+    for ed in edges_sorted_lst:
+        if target_id == ed["target"]:
+            tmp_lst.append(ed)
+        else:
+            total_lst.append((target_id, get_kwargs(lst=tmp_lst)))
+            target_id = ed["target"]
+            tmp_lst = [ed]
+    total_lst.append((target_id, get_kwargs(lst=tmp_lst)))
+    return total_lst
+
+
+def _get_source_handles(edges_lst):
+    source_handle_dict = {}
+    for ed in edges_lst:
+        if ed['source'] not in source_handle_dict.keys():
+            source_handle_dict[ed['source']] = [ed['sourceHandle']]
+        else:
+            source_handle_dict[ed['source']].append(ed['sourceHandle'])
+    return source_handle_dict
+
+
+def _get_source(nodes_dict, delayed_object_dict, source, sourceHandle):
+    if source in delayed_object_dict.keys():
+        return delayed_object_dict[source].__getattr__("output").__getattr__(sourceHandle)
+    else:
+        return nodes_dict[source]
+
+
+def _get_delayed_object_dict(total_lst, nodes_dict, source_handle_dict, pyiron_project):
+    delayed_object_dict = {}
+    for item in total_lst:
+        key, input_dict = item
+        kwargs = {
+            k: _get_source(
+                nodes_dict=nodes_dict,
+                delayed_object_dict=delayed_object_dict,
+                source=v["source"],
+                sourceHandle=v["sourceHandle"],
+            )
+            for k, v in input_dict.items()
+        }
+        delayed_object_dict[key] = job(
+            funct=nodes_dict[key],
+            output_key_lst=source_handle_dict.get(key, []),
+        )(**kwargs, pyiron_project=pyiron_project)
+    return delayed_object_dict
+
+
+def execute_workflow_with_pyiron(nodes_dict, edges_lst, pyiron_project):
+    delayed_object_dict = _get_delayed_object_dict(
+        total_lst=_group_edges(edges_lst),
+        nodes_dict=nodes_dict,
+        source_handle_dict=_get_source_handles(edges_lst),
+        pyiron_project=pyiron_project,
+    )
+    return delayed_object_dict[list(delayed_object_dict.keys())[-1]].pull()
+
+
+def convert_workflow(nodes_dict, edges_lst):
+    nodes_dict, edges_lst = _remove_server_obj(
+        nodes_dict=nodes_dict,
+        edges_lst=edges_lst,
+    )
+    delayed_object_updated_dict, _match_dict = get_unique_objects(
+        nodes_dict=nodes_dict,
+        edges_lst=edges_lst,
+    )
+    connection_dict, lookup_dict = _get_connection_dict(
+        delayed_object_updated_dict=delayed_object_updated_dict,
+        match_dict=match_dict,
+    )
+    universal_nodes = _get_nodes(
+        connection_dict=connection_dict,
+        delayed_object_updated_dict=delayed_object_updated_dict,
+    )
+    universal_edges = _get_edges_dict(
+        edges_lst=edges_lst,
+        nodes_dict=nodes_dict,
+        connection_dict=connection_dict,
+        lookup_dict=lookup_dict,
+    )
+    return universal_nodes, universal_edges

--- a/pyiron_base/project/universal.py
+++ b/pyiron_base/project/universal.py
@@ -85,6 +85,10 @@ def _get_edges_dict(edges_lst, nodes_dict, connection_dict, lookup_dict):
     return edges_dict_lst
 
 
+def _get_kwargs(lst):
+    return {t['targetHandle']: {'source': t['source'], 'sourceHandle': t['sourceHandle']} for t in lst}
+
+
 def _group_edges(edges_lst):
     edges_sorted_lst = sorted(edges_lst, key=lambda x: x['target'], reverse=True)
     total_lst, tmp_lst = [], []
@@ -93,10 +97,10 @@ def _group_edges(edges_lst):
         if target_id == ed["target"]:
             tmp_lst.append(ed)
         else:
-            total_lst.append((target_id, get_kwargs(lst=tmp_lst)))
+            total_lst.append((target_id, _get_kwargs(lst=tmp_lst)))
             target_id = ed["target"]
             tmp_lst = [ed]
-    total_lst.append((target_id, get_kwargs(lst=tmp_lst)))
+    total_lst.append((target_id, _get_kwargs(lst=tmp_lst)))
     return total_lst
 
 
@@ -152,7 +156,7 @@ def convert_workflow(nodes_dict, edges_lst):
         nodes_dict=nodes_dict,
         edges_lst=edges_lst,
     )
-    delayed_object_updated_dict, _match_dict = get_unique_objects(
+    delayed_object_updated_dict, match_dict = _get_unique_objects(
         nodes_dict=nodes_dict,
         edges_lst=edges_lst,
     )


### PR DESCRIPTION
Based on the discussions we had as part of the core hackathon I tried to work on a way to exchange workflow graphs between `pyiron_base` and `pyiron_workflow` based on the dictionary representation `pyironflow` already uses to communicate the workflow graph between the visual programming interface. The two example notebooks for `pyiron_base` are available at:
* https://github.com/pyiron-dev/compare-workflow-graphs/blob/main/pyiron_base_to_universal.ipynb
* https://github.com/pyiron-dev/compare-workflow-graphs/blob/main/universal_to_pyiron_base.ipynb

The format is currently very simple, based on the `get_edges()` function in `pyironflow`: 
https://github.com/pyiron/pyironFlow/blob/main/pyironflow/reactflow.py#L178

```python
edges_lst = [
    {'target': 0, 'targetHandle': 'x', 'source': 1, 'sourceHandle': 'x'},
    {'target': 1, 'targetHandle': 'x', 'source': 2, 'sourceHandle': None},
    {'target': 1, 'targetHandle': 'y', 'source': 3, 'sourceHandle': None},
    {'target': 0, 'targetHandle': 'y', 'source': 1, 'sourceHandle': 'y'},
    {'target': 0, 'targetHandle': 'z', 'source': 1, 'sourceHandle': 'z'},
]
```

The nodes at the moment just use the function as Python objects and the same ids used in the `edges_lst` for `target` and `source`:
```python
nodes_dict = {
    0: add_x_and_y_and_z,
    1: add_x_and_y,
    2: 1,
    3: 2,
}
```

With the functions being simply:
```python
def add_x_and_y(x, y):
    z = x + y
    return {"x": x, "y": y, "z": z}

def add_x_and_y_and_z(x, y, z):
    w = x + y + z
    return w
```