### PR TITLE
delayed: handling of lists as result

### DIFF
--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -260,7 +260,7 @@ class DelayedObject:
 
     def get_python_result(self):
         if isinstance(self._result, dict) and self._output_key is not None:
-            return self._result[self._output_key]
+            return self._result[str(self._output_key)]
         elif isinstance(self._result, list):
             if self._list_index is not None:
                 return self._result[self._list_index]

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -286,7 +286,9 @@ class DelayedObject:
             return self.get_python_result()
         elif self._output_file is not None:
             return self.get_file_result()
-        elif self._list_index is not None:
+        elif isinstance(self._result, list) and self._list_index is not None:
+            return self._result[self._list_index]
+        elif isinstance(self._result, dict) and self._list_index is not None:
             return self._result[str(self._list_index)]
         else:
             return self._result

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -261,6 +261,13 @@ class DelayedObject:
     def get_python_result(self):
         if isinstance(self._result, dict):
             return self._result[self._output_key]
+        elif isinstance(self._result, list):
+            if self._list_index is not None:
+                return self._result[self._list_index]
+            elif self._output_key is not None:
+                return self._result[int(self._output_key)]
+            else:
+                return self._result
         else:
             return getattr(self._result.output, self._output_key)
 

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -259,7 +259,7 @@ class DelayedObject:
         draw(node_dict=node_dict, edge_lst=edge_lst)
 
     def get_python_result(self):
-        if isinstance(self._result, dict):
+        if isinstance(self._result, dict) and self._output_key is not None:
             return self._result[self._output_key]
         elif isinstance(self._result, list):
             if self._list_index is not None:
@@ -268,8 +268,10 @@ class DelayedObject:
                 return self._result[int(self._output_key)]
             else:
                 return self._result
-        else:
+        elif self._output_key is not None:
             return getattr(self._result.output, self._output_key)
+        else:
+            return self._result
 
     def get_file_result(self):
         return getattr(self._result.files, self._output_file)
@@ -285,7 +287,7 @@ class DelayedObject:
         elif self._output_file is not None:
             return self.get_file_result()
         elif self._list_index is not None:
-            return self._result[self._list_index]
+            return self._result[str(self._list_index)]
         else:
             return self._result
 

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -42,19 +42,21 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.assertEqual(len(edges_lst), 6)
 
     def test_delayed_return_types(self):
-        @job(output_key_lst=["a"])
+        @job
         def my_function_a(a, b=8):
-            return {"a": a + b}
+            return [a + b]
 
         @job(cores=2, output_key_lst=["0"])
         def my_function_b(a, b=8):
             return [a + b]
 
-        c = my_function_a(a=1, b=2, pyiron_project=self.project)
-        d = my_function_b(a=c.output.a, b=3, pyiron_project=self.project)
+        c = my_function_a(a=1, b=2, pyiron_project=self.project, list_length=1)
+        for a in c:
+            d = my_function_b(a=a, b=3, pyiron_project=self.project)
         self.assertEqual(d.pull(), [6])
+        self.assertEqual(c.pull(), [3])
         nodes_dict, edges_lst = d.get_graph()
-        self.assertEqual(len(nodes_dict), 6)
+        self.assertEqual(len(nodes_dict), 7)
         self.assertEqual(len(edges_lst), 6)
 
 

--- a/tests/unit/flex/test_decorator.py
+++ b/tests/unit/flex/test_decorator.py
@@ -41,6 +41,22 @@ class TestPythonFunctionDecorator(TestWithProject):
         self.assertEqual(len(nodes_dict), 6)
         self.assertEqual(len(edges_lst), 6)
 
+    def test_delayed_return_types(self):
+        @job(output_key_lst=["a"])
+        def my_function_a(a, b=8):
+            return {"a": a + b}
+
+        @job(cores=2, output_key_lst=["0"])
+        def my_function_b(a, b=8):
+            return [a + b]
+
+        c = my_function_a(a=1, b=2, pyiron_project=self.project)
+        d = my_function_b(a=c.output.a, b=3, pyiron_project=self.project)
+        self.assertEqual(d.pull(), [6])
+        nodes_dict, edges_lst = d.get_graph()
+        self.assertEqual(len(nodes_dict), 6)
+        self.assertEqual(len(edges_lst), 6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This bug fix was necessary to enable the calculation of energy volume curves using delayed objects:
* [pyiron_base_qe_to_universal.ipynb ](https://github.com/pyiron-dev/compare-workflow-graphs/blob/main/pyiron_base_qe_to_universal.ipynb)
* [universal_qe_to_pyiron_base.ipynb](https://github.com/pyiron-dev/compare-workflow-graphs/blob/main/universal_qe_to_pyiron_base.ipynb)