### PR TITLE
Github Action Push with repository permissions does not trigger continuous integration 

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,13 +8,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: (github.actor == 'dependabot[bot]')
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.ref }} # Check out the head of the actual branch, not the PR
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
       - name: UpdateEnvironmentFile
         shell: bash -l {0}
         run: |
@@ -33,4 +32,5 @@ jobs:
       - name: UpdateDependabotPR push
         uses: ad-m/github-push-action@master
         with:
+          github_token: ${{ secrets.DEPENDABOT_WORKFLOW_TOKEN }}
           branch: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
Reverts pyiron/pyiron_base#1760