### PR TITLE
Add non-modal execution of future objects

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -5,13 +5,13 @@ import cloudpickle
 import numpy as np
 
 from pyiron_base.jobs.job.template import PythonTemplateJob
-from pyiron_base.project.delayed import get_function_parameter_dict, get_hash, JobFuture
+from pyiron_base.project.delayed import JobFuture, get_function_parameter_dict, get_hash
 
 
 def check_for_future(input_dict):
     result_dict = {}
     found_future = False
-    for k,v in input_dict.items():
+    for k, v in input_dict.items():
         if isinstance(v, JobFuture):
             if v.done():
                 result_dict[k] = v.result()
@@ -19,7 +19,9 @@ def check_for_future(input_dict):
                 result_dict[k] = v
                 found_future = True
         elif isinstance(v, list):
-            v_lst_dict, status = check_for_future(input_dict={i: l for i, l in enumerate(v)})
+            v_lst_dict, status = check_for_future(
+                input_dict={i: l for i, l in enumerate(v)}
+            )
             if status:
                 found_future = True
             result_dict[k] = list(v_lst_dict.values())

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -11,25 +11,26 @@ from pyiron_base.project.delayed import get_function_parameter_dict, get_hash, J
 def check_for_future(input_dict):
     result_dict = {}
     found_future = False
-    for k,v in input_dict.items():
-        if isinstance(v, JobFuture):
-            if v.done():
-                result_dict[k] = v.result()
+    if len(input_dict) > 0:
+        for k,v in input_dict.items():
+            if isinstance(v, JobFuture):
+                if v.done():
+                    result_dict[k] = v.result()
+                else:
+                    result_dict[k] = v
+                    found_future = True
+            elif isinstance(v, list):
+                v_lst_dict, status = check_for_future(input_dict={i: l for i, l in enumerate(v)})
+                if status:
+                    found_future = True
+                result_dict[k] = list(v_lst_dict.values())
+            elif isinstance(v, dict):
+                v_dict, status = check_for_future(input_dict=v)
+                if status:
+                    found_future = True
+                result_dict[k] = v_dict
             else:
                 result_dict[k] = v
-                found_future = True
-        elif isinstance(v, list):
-            v_lst_dict, status = check_for_future(input_dict={i: l for i, l in enumerate(v)})
-            if status:
-                found_future = True
-            result_dict[k] = list(v_lst_dict.values())
-        elif isinstance(v, dict):
-            v_dict, status = check_for_future(input_dict=v)
-            if status:
-                found_future = True
-            result_dict[k] = v_dict
-        else:
-            result_dict[k] = v
     return result_dict, found_future
 
 

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -5,14 +5,14 @@ import cloudpickle
 import numpy as np
 
 from pyiron_base.jobs.job.template import PythonTemplateJob
-from pyiron_base.project.delayed import get_function_parameter_dict, get_hash, JobFuture
+from pyiron_base.project.delayed import JobFuture, get_function_parameter_dict, get_hash
 
 
 def check_for_future(input_dict):
     result_dict = {}
     found_future = False
     if len(input_dict) > 0:
-        for k,v in input_dict.items():
+        for k, v in input_dict.items():
             if isinstance(v, JobFuture):
                 if v.done():
                     result_dict[k] = v.result()
@@ -20,7 +20,9 @@ def check_for_future(input_dict):
                     result_dict[k] = v
                     found_future = True
             elif isinstance(v, list):
-                v_lst_dict, status = check_for_future(input_dict={i: l for i, l in enumerate(v)})
+                v_lst_dict, status = check_for_future(
+                    input_dict={i: l for i, l in enumerate(v)}
+                )
                 if status:
                     found_future = True
                 result_dict[k] = list(v_lst_dict.values())

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -26,6 +26,18 @@ class JobFuture(Future):
         self._job.storage.from_hdf(hdf=self._job.project_hdf5)
         return self._job.output["result"]
 
+    def __getstate__(self):
+        return {
+            "working_directory": self._job.working_directory,
+            "job_id": self._job.job_id,
+            "hdf5_file": self._job.project_hdf5.file_name,
+            "h5_path": self._job.project_hdf5.h5_path,
+        }
+
+    def __setstate__(self, state):
+        from pyiron_base.jobs.job.wrapper import JobWrapper
+        self._job = JobWrapper(**state).job
+
 
 def draw(node_dict: Dict[str, object], edge_lst: List[List[str]]) -> None:
     """

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -36,6 +36,7 @@ class JobFuture(Future):
 
     def __setstate__(self, state):
         from pyiron_base.jobs.job.wrapper import JobWrapper
+
         self._job = JobWrapper(**state).job
 
 


### PR DESCRIPTION
Example Workflow:
```python
from pyiron_base import job, Project

@job
def get_sum(x, y):
    return x + y

@job(output_key_lst=["prod", "div"])
def get_prod_and_div(x, y):
    return {"prod": x * y, "div": x / y}

@job
def get_square(x):
    return x ** 2

pr = Project("test")
prod_and_div = get_prod_and_div(x=1, y=2, pyiron_project=pr)
tmp_sum = get_sum(x=prod_and_div.output.prod, y=prod_and_div.output.div, pyiron_project=pr)
result = get_square(x=tmp_sum, pyiron_project=pr)
prod_and_div.server.run_mode.non_modal = True
tmp_sum.server.run_mode.non_modal = True
result.server.run_mode.non_modal = True
future = result.pull()

df = pr.job_table()
for job_name in df[df.status=="submitted"].job.values:
    pr.load(job_name).run()

pr.job_table()
```