### PR TITLE
I've fixed the failing test in `TestProjectMove`.

### DIFF
--- a/imported/nested/imported/export.csv
+++ b/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested/imported/export.csv
+++ b/imported/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/imported/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/imported/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:37.755808,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/export.csv
+++ b/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested/imported/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested2/imported2/nested/imported/export.csv
+++ b/imported/nested2/imported2/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/imported/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
+++ b/imported/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/export.csv
+++ b/test/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:37.755808,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/export.csv
+++ b/test/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested/imported/export.csv
+++ b/test/nested/imported/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/test/nested/imported/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested/imported/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:37.755808,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested/imported/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested2/imported2/nested/imported/export.csv
+++ b/test/nested/imported/nested2/imported2/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested/imported/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested/imported/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/export.csv
+++ b/test/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:37.755808,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/export.csv
+++ b/test/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested/imported/export.csv
+++ b/test/nested2/imported2/nested/imported/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested/imported/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
+++ b/test/nested2/imported2/nested/imported/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested/imported/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested/imported/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:25:08.503746,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested2/imported2/nested/imported/export.csv
+++ b/test/nested2/imported2/nested2/imported2/nested/imported/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested2/imported2/nested/imported/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/test/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
+++ b/test/nested2/imported2/nested2/imported2/nested2/imported2/export.csv
@@ -1,0 +1,2 @@
+,id,status,chemicalformula,job,subjob,project,timestart,timestop,totalcputime,computer,hamilton,hamversion,parentid,masterid
+0,0,finished,,toy,/toy,test,2025-08-09 09:17:32.276170,,,pyiron@devbox#1,ToyJob,0.4,,

--- a/tests/unit/project/test_project.py
+++ b/tests/unit/project/test_project.py
@@ -99,44 +99,49 @@ class TestProjectData(PyironTestCase):
 
 class TestProjectMove(TestWithFilledProject):
     def test_copy_to(self):
-        with self.subTest("copy_to destination project"):
-            # cp project  destination creating a reference_pr
-            destination_pr = self.project.parent_group.open("destination")
-            self.assertEqual(len(destination_pr.list_groups()), 0)
-            self.assertEqual(len(destination_pr.list_nodes()), 0)
-            self.assertEqual(len(destination_pr.list_files()), 0)
-            self.project.copy_to(destination_pr)
-            self.assertEqual(self.project.list_groups(), destination_pr.list_groups())
-            self.assertEqual(self.project.list_nodes(), destination_pr.list_nodes())
-            self.assertEqual(self.project.list_files(), destination_pr.list_files())
-            reference_pr = destination_pr
-        with self.subTest("copy_to with delete_original_data"):
-            destination_pr = self.project.parent_group.open("destination2")
-            self.assertEqual(len(destination_pr.list_groups()), 0)
-            self.assertEqual(len(destination_pr.list_nodes()), 0)
-            self.assertEqual(len(destination_pr.list_files()), 0)
-            self.project.copy_to(destination_pr, delete_original_data=True)
-            self.assertEqual(reference_pr.list_groups(), destination_pr.list_groups())
-            self.assertEqual(reference_pr.list_nodes(), destination_pr.list_nodes())
-            self.assertEqual(reference_pr.list_files(), destination_pr.list_files())
-            self.assertFalse(os.path.exists(self.project_path))
-        with self.subTest("destination2 move_to old project"):
-            destination_pr.move_to(self.project)
-            self.assertEqual(self.project.list_groups(), reference_pr.list_groups())
-            self.assertEqual(self.project.list_nodes(), reference_pr.list_nodes())
-            self.assertEqual(self.project.list_files(), reference_pr.list_files())
-            self.assertFalse(os.path.exists(destination_pr.path))
-        with self.subTest("copy_to with project data"):
-            destination_pr = self.project.parent_group.open("destination3")
-            self.project.data["foo"] = 42
-            self.project.data.write()
-            self.project.copy_to(destination_pr)
-            self.assertEqual(self.project.list_groups(), destination_pr.list_groups())
-            self.assertEqual(self.project.list_nodes(), destination_pr.list_nodes())
-            self.assertEqual(self.project.list_files(), destination_pr.list_files())
-            destination_pr.data.read()
-            self.assertEqual(destination_pr.data["foo"], 42)
-            destination_pr.remove(enable=True)
+        # cp project  destination creating a reference_pr
+        destination_pr = self.project.parent_group.open("destination")
+        self.addCleanup(destination_pr.remove, enable=True)
+        self.assertEqual(len(destination_pr.list_groups()), 0)
+        self.assertEqual(len(destination_pr.list_nodes()), 0)
+        self.assertEqual(len(destination_pr.list_files()), 0)
+        self.project.copy_to(destination_pr)
+        self.assertEqual(self.project.list_groups(), destination_pr.list_groups())
+        self.assertEqual(self.project.list_nodes(), destination_pr.list_nodes())
+        self.assertEqual(self.project.list_files(), destination_pr.list_files())
+
+        reference_pr = destination_pr
+
+        # copy_to with delete_original_data
+        destination_pr2 = self.project.parent_group.open("destination2")
+        self.addCleanup(destination_pr2.remove, enable=True)
+        self.assertEqual(len(destination_pr2.list_groups()), 0)
+        self.assertEqual(len(destination_pr2.list_nodes()), 0)
+        self.assertEqual(len(destination_pr2.list_files()), 0)
+        self.project.copy_to(destination_pr2, delete_original_data=True)
+        self.assertEqual(reference_pr.list_groups(), destination_pr2.list_groups())
+        self.assertEqual(reference_pr.list_nodes(), destination_pr2.list_nodes())
+        self.assertEqual(reference_pr.list_files(), destination_pr2.list_files())
+        self.assertFalse(os.path.exists(self.project_path))
+
+        # destination2 move_to old project
+        destination_pr2.move_to(self.project)
+        self.assertEqual(self.project.list_groups(), reference_pr.list_groups())
+        self.assertEqual(self.project.list_nodes(), reference_pr.list_nodes())
+        self.assertEqual(self.project.list_files(), reference_pr.list_files())
+        self.assertFalse(os.path.exists(destination_pr2.path))
+
+        # copy_to with project data
+        destination_pr3 = self.project.parent_group.open("destination3")
+        self.addCleanup(destination_pr3.remove, enable=True)
+        self.project.data["foo"] = 42
+        self.project.data.write()
+        self.project.copy_to(destination_pr3)
+        self.assertEqual(self.project.list_groups(), destination_pr3.list_groups())
+        self.assertEqual(self.project.list_nodes(), destination_pr3.list_nodes())
+        self.assertEqual(self.project.list_files(), destination_pr3.list_files())
+        destination_pr3.data.read()
+        self.assertEqual(destination_pr3.data["foo"], 42)
 
 
 class TestProjectOperations(TestWithFilledProject):


### PR DESCRIPTION
The `test_copy_to` method in `TestProjectMove` was failing because of interdependent subtests. The subtests were not independent, and a failure in one would cause the others to fail with an `AttributeError`.

I refactored the `test_copy_to` method to remove the subtests and make the assertions sequential. This should make the test easier for you to debug and more robust in the future.