### PR TITLE
Bump h5io-browser from 0.2.0 to 0.2.1 (#1898)

### DIFF
--- a/.ci_support/environment-docs.yml
+++ b/.ci_support/environment-docs.yml
@@ -10,7 +10,7 @@ dependencies:
 - cloudpickle =3.1.1
 - executorlib =1.7.1
 - gitpython =3.1.45
-- h5io_browser =0.2.0
+- h5io_browser =0.2.1
 - h5py =3.13.0
 - jinja2 =3.1.6
 - monty =2025.3.3

--- a/.ci_support/environment-mini.yml
+++ b/.ci_support/environment-mini.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - cloudpickle =3.1.1
 - executorlib =1.7.1
-- h5io_browser =0.2.0
+- h5io_browser =0.2.1
 - h5py =3.13.0
 - monty =2025.3.3
 - numpy =2.3.2

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - cloudpickle =3.1.1
 - executorlib =1.7.1
 - gitpython =3.1.45
-- h5io_browser =0.2.0
+- h5io_browser =0.2.1
 - h5py =3.13.0
 - jinja2 =3.1.6
 - monty =2025.3.3

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.1.1
 - executorlib =1.7.1
 - gitpython =3.1.45
-- h5io_browser =0.2.0
+- h5io_browser =0.2.1
 - h5py =3.13.0
 - jinja2 =3.1.6
 - monty =2025.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "cloudpickle==3.1.1",
     "executorlib==1.7.1",
-    "h5io_browser==0.2.0",
+    "h5io_browser==0.2.1",
     "h5py==3.13.0",
     "numpy==2.3.2",
     "monty==2025.3.3",


### PR DESCRIPTION
* Bump h5io-browser from 0.2.0 to 0.2.1

Bumps [h5io-browser](https://github.com/h5io/h5io_browser) from 0.2.0 to 0.2.1.
- [Release notes](https://github.com/h5io/h5io_browser/releases)
- [Commits](https://github.com/h5io/h5io_browser/compare/h5io_browser-0.2.0...h5io_browser-0.2.1)

---
updated-dependencies:
- dependency-name: h5io-browser dependency-version: 0.2.1 dependency-type: direct:production update-type: version-update:semver-patch ...



* Update environment.yml

* Update environment.yml

* Update environment-docs.yml

* Update environment-mini.yml

---------