### PR TITLE
Delayed Object raise error for failing jobs

### DIFF
--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -322,6 +322,8 @@ class DelayedObject:
                 self._job.run()
                 if self._job.status.finished:
                     self._result = self._job.output["result"]
+                elif self._job.status.aborted:
+                    raise self._job.output.error
                 else:
                     return JobFuture(job=self._job)
             else:

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -241,9 +241,8 @@ class TestPythonFunctionContainer(TestWithProject):
         delayed_obj = self.project.wrap_python_function(
             python_function=function_with_error, a=1, b=2, delayed=True
         )
-        future = delayed_obj.pull()
         with self.assertRaises(ValueError):
-            future.result()
+            delayed_obj.pull()
         self.assertTrue(delayed_obj._job.status.aborted)
 
     @unittest.skipIf(


### PR DESCRIPTION
Example:
```python
from pyiron_base import Project, job

@job
def return_dict(i):
    raise ValueError()

pr = Project("test")
j = return_dict(i=1, pyiron_project=pr)
result = j.pull()
result
```
Previously this example just returned a `JobFuture` object, now it raises the error as expected. 
