### PR TITLE
Job Decorator: Add option to execute Python function in working directory

### DIFF
--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -1,8 +1,8 @@
-import os
 import inspect
-from typing import Optional
+import os
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Optional
 
 import cloudpickle
 import numpy as np
@@ -83,7 +83,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
     @property
     def execute_in_working_directory(self) -> bool:
         return self._execute_in_working_directory
-    
+
     @execute_in_working_directory.setter
     def execute_in_working_directory(self, val: bool) -> None:
         self._execute_in_working_directory = bool(val)

--- a/pyiron_base/jobs/flex/pythonfunctioncontainer.py
+++ b/pyiron_base/jobs/flex/pythonfunctioncontainer.py
@@ -116,7 +116,7 @@ class PythonFunctionContainerJob(PythonTemplateJob):
         """
         job_dict = super()._to_dict()
         job_dict["function"] = np.void(cloudpickle.dumps(self._function))
-        job_dict["exxcute_in_working_directory"] = self._execute_in_working_directory
+        job_dict["execute_in_working_directory"] = self._execute_in_working_directory
         job_dict["_automatically_rename_on_save_using_input"] = (
             self._automatically_rename_on_save_using_input
         )

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -290,7 +290,7 @@ class DelayedObject:
     @property
     def execute_in_working_directory(self) -> bool:
         return self._execute_in_working_directory
-    
+
     @execute_in_working_directory.setter
     def execute_in_working_directory(self, val: bool) -> None:
         self._execute_in_working_directory = bool(val)
@@ -329,7 +329,9 @@ class DelayedObject:
                 self._job = evaluate_function(
                     funct=self._function, input_dict=self._input
                 )
-                self._job.execute_in_working_directory = self._execute_in_working_directory
+                self._job.execute_in_working_directory = (
+                    self._execute_in_working_directory
+                )
                 self._job.run()
                 if self._job.status.finished:
                     self._result = self._job.output["result"]

--- a/pyiron_base/project/delayed.py
+++ b/pyiron_base/project/delayed.py
@@ -251,6 +251,7 @@ class DelayedObject:
         list_length: Optional[int] = None,
         list_index: Optional[int] = None,
         input_prefix_key: Optional[str] = None,
+        execute_in_working_directory: bool = False,
         **kwargs,
     ):
         self._input = {}
@@ -273,6 +274,7 @@ class DelayedObject:
         self._list_length = list_length
         self._list_index = list_index
         self._input_prefix_key = input_prefix_key
+        self._execute_in_working_directory = execute_in_working_directory
 
     @property
     def input(self):
@@ -284,6 +286,14 @@ class DelayedObject:
     @property
     def server(self):
         return self._server
+
+    @property
+    def execute_in_working_directory(self) -> bool:
+        return self._execute_in_working_directory
+    
+    @execute_in_working_directory.setter
+    def execute_in_working_directory(self, val: bool) -> None:
+        self._execute_in_working_directory = bool(val)
 
     def draw(self):
         node_dict, edge_lst = self.get_graph()
@@ -319,6 +329,7 @@ class DelayedObject:
                 self._job = evaluate_function(
                     funct=self._function, input_dict=self._input
                 )
+                self._job.execute_in_working_directory = self._execute_in_working_directory
                 self._job.run()
                 if self._job.status.finished:
                     self._result = self._job.output["result"]
@@ -359,6 +370,7 @@ class DelayedObject:
         obj_copy._python_function = self._python_function
         obj_copy._input = self._input
         obj_copy._result = self._result
+        obj_copy._execute_in_working_directory = self._execute_in_working_directory
         obj_copy._server.from_dict(self._server.to_dict())
         return obj_copy
 

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -264,13 +264,6 @@ class TestPythonFunctionContainer(TestWithProject):
             future.result()
         self.assertTrue(delayed_obj._job.status.aborted)
 
-    def test_get_working_dir_current_dir(self):
-        f1 = self.project.wrap_python_function(
-            python_function=get_working_directory, delayed=True
-        )
-        self.assertFalse(f1.execute_in_working_directory)
-        self.assertEqual(f1.pull(), os.getcwd())
-
     def test_get_working_dir(self):
         f1 = self.project.wrap_python_function(
             python_function=get_working_directory, delayed=True

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -271,7 +271,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertFalse(f1.execute_in_working_directory)
         f1.execute_in_working_directory = True
         self.assertTrue(f1.execute_in_working_directory)
-        self.assertEqual(f1.pull().replace("\\","/"), f1._job.working_directory)
+        self.assertEqual(f1.pull().replace("\\", "/"), f1._job.working_directory)
 
     def test_delayed(self):
         c = self.project.wrap_python_function(

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -264,19 +264,21 @@ class TestPythonFunctionContainer(TestWithProject):
             future.result()
         self.assertTrue(delayed_obj._job.status.aborted)
 
-    def test_get_working_dir(self):
+    def test_get_working_dir_current_dir(self):
         f1 = self.project.wrap_python_function(
             python_function=get_working_directory, delayed=True
         )
         self.assertFalse(f1.execute_in_working_directory)
         self.assertEqual(f1.pull(), os.getcwd())
-        f2 = self.project.wrap_python_function(
+
+    def test_get_working_dir(self):
+        f1 = self.project.wrap_python_function(
             python_function=get_working_directory, delayed=True
         )
-        self.assertFalse(f2.execute_in_working_directory)
-        f2.execute_in_working_directory = True
-        self.assertTrue(f2.execute_in_working_directory)
-        self.assertEqual(f2.pull(), f2._job.working_directory)
+        self.assertFalse(f1.execute_in_working_directory)
+        f1.execute_in_working_directory = True
+        self.assertTrue(f1.execute_in_working_directory)
+        self.assertEqual(f1.pull(), f1._job.working_directory)
 
     def test_delayed(self):
         c = self.project.wrap_python_function(

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -32,6 +32,10 @@ def function_with_error(a, b):
     raise ValueError()
 
 
+def get_working_directory():
+    return os.getcwd()
+
+
 class TestPythonFunctionContainer(TestWithProject):
     def test_as_job(self):
         job = self.project.wrap_python_function(my_function)
@@ -259,6 +263,17 @@ class TestPythonFunctionContainer(TestWithProject):
         with self.assertRaises(ValueError):
             future.result()
         self.assertTrue(delayed_obj._job.status.aborted)
+
+    def test_get_working_dir(self):
+        f1 = self.project.wrap_python_function(python_function=get_working_directory)
+        self.assertFalse(f1.execute_in_working_directory)
+        self.assertEqual(f1.pull(), os.getcwd())
+        f2 = self.project.wrap_python_function(python_function=get_working_directory)
+        self.assertFalse(f2.execute_in_working_directory)
+        f2.execute_in_working_directory = True
+        self.assertTrue(f2.execute_in_working_directory)
+        f2 = self.project.wrap_python_function(python_function=get_working_directory)
+        self.assertEqual(f2.pull(), f2._job.working_dir)
 
     def test_delayed(self):
         c = self.project.wrap_python_function(

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -265,10 +265,10 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertTrue(delayed_obj._job.status.aborted)
 
     def test_get_working_dir(self):
-        f1 = self.project.wrap_python_function(python_function=get_working_directory)
+        f1 = self.project.wrap_python_function(python_function=get_working_directory, delayed=True)
         self.assertFalse(f1.execute_in_working_directory)
         self.assertEqual(f1.pull(), os.getcwd())
-        f2 = self.project.wrap_python_function(python_function=get_working_directory)
+        f2 = self.project.wrap_python_function(python_function=get_working_directory, delayed=True)
         self.assertFalse(f2.execute_in_working_directory)
         f2.execute_in_working_directory = True
         self.assertTrue(f2.execute_in_working_directory)

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -271,7 +271,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertFalse(f1.execute_in_working_directory)
         f1.execute_in_working_directory = True
         self.assertTrue(f1.execute_in_working_directory)
-        self.assertEqual(f1.pull(), f1._job.working_directory)
+        self.assertEqual(f1.pull().replace("\\","/"), f1._job.working_directory)
 
     def test_delayed(self):
         c = self.project.wrap_python_function(

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -265,10 +265,14 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertTrue(delayed_obj._job.status.aborted)
 
     def test_get_working_dir(self):
-        f1 = self.project.wrap_python_function(python_function=get_working_directory, delayed=True)
+        f1 = self.project.wrap_python_function(
+            python_function=get_working_directory, delayed=True
+        )
         self.assertFalse(f1.execute_in_working_directory)
         self.assertEqual(f1.pull(), os.getcwd())
-        f2 = self.project.wrap_python_function(python_function=get_working_directory, delayed=True)
+        f2 = self.project.wrap_python_function(
+            python_function=get_working_directory, delayed=True
+        )
         self.assertFalse(f2.execute_in_working_directory)
         f2.execute_in_working_directory = True
         self.assertTrue(f2.execute_in_working_directory)

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -276,7 +276,6 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertFalse(f2.execute_in_working_directory)
         f2.execute_in_working_directory = True
         self.assertTrue(f2.execute_in_working_directory)
-        f2 = self.project.wrap_python_function(python_function=get_working_directory)
         self.assertEqual(f2.pull(), f2._job.working_dir)
 
     def test_delayed(self):

--- a/tests/unit/flex/test_pythonfunctioncontainer.py
+++ b/tests/unit/flex/test_pythonfunctioncontainer.py
@@ -276,7 +276,7 @@ class TestPythonFunctionContainer(TestWithProject):
         self.assertFalse(f2.execute_in_working_directory)
         f2.execute_in_working_directory = True
         self.assertTrue(f2.execute_in_working_directory)
-        self.assertEqual(f2.pull(), f2._job.working_dir)
+        self.assertEqual(f2.pull(), f2._job.working_directory)
 
     def test_delayed(self):
         c = self.project.wrap_python_function(


### PR DESCRIPTION
Example:
```python
import os
from pyiron_base import Project, job

@job
def return_dict(i):
    return {"a": i, "b": os.getcwd()}

pr = Project("test")
j = return_dict(i=1, pyiron_project=pr)
j.execute_in_working_directory = True
result = j.pull()
result
```